### PR TITLE
win32 configure: adapt to renamed autoconf configure

### DIFF
--- a/win32/configure.js
+++ b/win32/configure.js
@@ -21,7 +21,7 @@ var baseName = "libxmlsec";
 
 /* Configure file which contains the version and the output file where
    we can store our build configuration. */
-var configFile = baseDir + "\\configure.in";
+var configFile = baseDir + "\\configure.ac";
 var versionFile = ".\\configure.txt";
 
 /* Input and output files regarding the lib(e)xml features. The second


### PR DESCRIPTION
configure.in was renamed to configure.in in commit
ba55ea006f1bd8e28a7d8fe9da6b4a64ba00befb (rename configure.in,
2016-02-05) but win32's configure.js was not adapted.