### PR TITLE
Fix Visual Studio 2015 build

### DIFF
--- a/apps/cmdline.c
+++ b/apps/cmdline.c
@@ -7,7 +7,7 @@
  * 
  * Copyright (C) 2002-2016 Aleksey Sanin <aleksey@aleksey.com>. All Rights Reserved.
  */
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 

--- a/apps/crypto.c
+++ b/apps/crypto.c
@@ -7,7 +7,7 @@
  * 
  * Copyright (C) 2002-2016 Aleksey Sanin <aleksey@aleksey.com>. All Rights Reserved.
  */
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 

--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <time.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
The error is:

c:\Program Files\Windows Kits\10\Include\10.0.10150.0\ucrt\stdio.h(1925): warning C4005: 'snprintf': macro redefinition
..\apps\xmlsec.c(13): note: see previous definition of 'snprintf'
c:\Program Files\Windows Kits\10\Include\10.0.10150.0\ucrt\stdio.h(1927): fatal error C1189: #error:  Macro definition of snprintf conflicts with Standard Library function declaration

1900 is from
<http://stackoverflow.com/questions/70013/how-to-detect-if-im-compiling-code-with-visual-studio-2008>.