### PR TITLE
tests: add support for running a single test using XMLSEC_TEST_NAME

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,10 @@
+If a test fails, it's possible to re-run just that specific test for that
+specific backend using:
+
+> make check-crypto-$backend XMLSEC_TEST_NAME="$name"
+
+where $name is the key name for key tests, and a file name otherwise.
+
+Example:
+
+> make check-crypto-nss XMLSEC_TEST_NAME="enveloping-sha256-rsa-sha256-relationship"

--- a/tests/testDSig.sh
+++ b/tests/testDSig.sh
@@ -842,6 +842,7 @@ execDSigTest $res_success \
 # test dynamic signature
 #
 ##########################################################################
+if [ -n "$XMLSEC_TEST_NAME" -a "$XMLSEC_TEST_NAME" = "dsig-dynamic" ]; then
 echo "Dynamic signature template"
 printf "    Create new signature                                 "
 echo "$VALGRIND $xmlsec_app sign-tmpl $xmlsec_params --keys-file $keysfile --output $tmpfile" >> $logfile
@@ -851,6 +852,7 @@ printf "    Verify new signature                                 "
 echo "$VALGRIND $xmlsec_app verify --keys-file $keysfile $tmpfile" >> $logfile
 $VALGRIND $xmlsec_app verify $xmlsec_params --keys-file $keysfile $tmpfile >> $logfile 2>> $logfile
 printRes $res_success $?
+fi
 
 
 ##########################################################################

--- a/tests/testEnc.sh
+++ b/tests/testEnc.sh
@@ -366,6 +366,7 @@ execEncTest $res_success \
 # test dynamicencryption
 #
 ##########################################################################
+if [ -n "$XMLSEC_TEST_NAME" -a "$XMLSEC_TEST_NAME" = "enc-dynamic" ]; then
 echo "Dynamic encryption template"
 printf "    Encrypt template                                     "
 echo "$VALGRIND $xmlsec_app encrypt-tmpl $xmlsec_params --keys-file $keysfile --output $tmpfile" >> $logfile
@@ -375,6 +376,7 @@ printf "    Decrypt document                                     "
 echo "$VALGRIND $xmlsec_app decrypt $xmlsec_params $keysfile $tmpfile" >> $logfile
 $VALGRIND $xmlsec_app decrypt $xmlsec_params --keys-file $keysfile $tmpfile >> $logfile 2>> $logfile
 printRes $res_success $?
+fi
 
 
 ##########################################################################

--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -144,6 +144,10 @@ execKeysTest() {
     key_name="$3"
     alg_name="$4"
 
+    if [ -n "$XMLSEC_TEST_NAME" -a "$XMLSEC_TEST_NAME" != "$key_name" ]; then
+        return
+    fi
+
     # prepare
     rm -f $tmpfile
     old_pwd=`pwd`
@@ -197,6 +201,10 @@ execDSigTest() {
     params1="$6"
     params2="$7"
     params3="$8"
+
+    if [ -n "$XMLSEC_TEST_NAME" -a "$XMLSEC_TEST_NAME" != "$filename" ]; then
+        return
+    fi
 
     # prepare
     rm -f $tmpfile
@@ -286,6 +294,10 @@ execEncTest() {
     params1="$5"
     params2="$6"
     params3="$7"
+
+    if [ -n "$XMLSEC_TEST_NAME" -a "$XMLSEC_TEST_NAME" != "$filename" ]; then
+        return
+    fi
 
     # prepare
     rm -f $tmpfile $tmpfile.2


### PR DESCRIPTION
I used this local patch when testing the relationship testcase, so I could quickly get feedback if my changes are OK or not OK. Does it make sense to have this upstream?