### PR TITLE
fix signing with RSA SHA2 via mscrypto

### DIFF
--- a/include/xmlsec/mscrypto/certkeys.h
+++ b/include/xmlsec/mscrypto/certkeys.h
@@ -31,6 +31,7 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyDataPtr   xmlSecMSCryptoCertAdopt         (PCCERT_
 
 XMLSEC_CRYPTO_EXPORT HCRYPTPROV         xmlSecMSCryptoKeyDataGetMSCryptoProvider(xmlSecKeyDataPtr data);
 XMLSEC_CRYPTO_EXPORT DWORD              xmlSecMSCryptoKeyDataGetMSCryptoKeySpec(xmlSecKeyDataPtr data);
+XMLSEC_CRYPTO_EXPORT PCRYPT_KEY_PROV_INFO xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo(xmlSecKeyDataPtr data);
 
 
 #ifdef __cplusplus

--- a/src/mscrypto/certkeys.c
+++ b/src/mscrypto/certkeys.c
@@ -2617,13 +2617,33 @@ PCRYPT_KEY_PROV_INFO xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo(xmlSecKeyDataP
     LPBYTE pInfoData = NULL;
     DWORD dwInfoDataLength = 0;
 
-    ctx = xmlSecMSCryptoKeyDataGetCtx(data);
-    CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, NULL, &dwInfoDataLength);
+    xmlSecAssert2(data != NULL, NULL);
 
-    if (dwInfoDataLength > 0)
-    {
+    ctx = xmlSecMSCryptoKeyDataGetCtx(data);
+    xmlSecAssert2(ctx != NULL, NULL);
+    xmlSecAssert2(ctx->pCert != NULL, NULL);
+
+    if (!CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, NULL, &dwInfoDataLength)) {
+        xmlSecError(XMLSEC_ERRORS_HERE,
+                    NULL,
+                    "CertGetCertificateContextProperty",
+                    XMLSEC_ERRORS_R_XMLSEC_FAILED,
+                    XMLSEC_ERRORS_NO_MESSAGE);
+        return NULL;
+    }
+
+    if (dwInfoDataLength > 0) {
         pInfoData = malloc(dwInfoDataLength * sizeof(BYTE));
-        CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, pInfoData, &dwInfoDataLength);
+
+        if (!CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, pInfoData, &dwInfoDataLength)) {
+            xmlSecError(XMLSEC_ERRORS_HERE,
+                        NULL,
+                        "CertGetCertificateContextProperty",
+                        XMLSEC_ERRORS_R_XMLSEC_FAILED,
+                        XMLSEC_ERRORS_NO_MESSAGE);
+            free(pInfoData);
+            return NULL;
+        }
     }
 
     return (PCRYPT_KEY_PROV_INFO)pInfoData;

--- a/src/mscrypto/certkeys.c
+++ b/src/mscrypto/certkeys.c
@@ -2623,23 +2623,23 @@ PCRYPT_KEY_PROV_INFO xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo(xmlSecKeyDataP
     xmlSecAssert2(ctx != NULL, NULL);
     xmlSecAssert2(ctx->pCert != NULL, NULL);
 
-    if (!CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, NULL, &dwInfoDataLength)) {
+    if(!CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, NULL, &dwInfoDataLength)) {
         xmlSecError(XMLSEC_ERRORS_HERE,
                     NULL,
                     "CertGetCertificateContextProperty",
-                    XMLSEC_ERRORS_R_XMLSEC_FAILED,
+                    XMLSEC_ERRORS_R_CRYPTO_FAILED,
                     XMLSEC_ERRORS_NO_MESSAGE);
         return NULL;
     }
 
-    if (dwInfoDataLength > 0) {
+    if(dwInfoDataLength > 0) {
         pInfoData = malloc(dwInfoDataLength * sizeof(BYTE));
 
-        if (!CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, pInfoData, &dwInfoDataLength)) {
+        if(!CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, pInfoData, &dwInfoDataLength)) {
             xmlSecError(XMLSEC_ERRORS_HERE,
                         NULL,
                         "CertGetCertificateContextProperty",
-                        XMLSEC_ERRORS_R_XMLSEC_FAILED,
+                        XMLSEC_ERRORS_R_CRYPTO_FAILED,
                         XMLSEC_ERRORS_NO_MESSAGE);
             free(pInfoData);
             return NULL;

--- a/src/mscrypto/certkeys.c
+++ b/src/mscrypto/certkeys.c
@@ -2612,4 +2612,21 @@ xmlSecMSCryptoKeyDataGost2001DebugXmlDump(xmlSecKeyDataPtr data, FILE* output) {
             xmlSecMSCryptoKeyDataGost2001GetSize(data));
 }
 
+PCRYPT_KEY_PROV_INFO xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo(xmlSecKeyDataPtr data) {
+    xmlSecMSCryptoKeyDataCtxPtr ctx;
+    LPBYTE pInfoData = NULL;
+    DWORD dwInfoDataLength = 0;
+
+    ctx = xmlSecMSCryptoKeyDataGetCtx(data);
+    CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, NULL, &dwInfoDataLength);
+
+    if (dwInfoDataLength > 0)
+    {
+        pInfoData = malloc(dwInfoDataLength * sizeof(BYTE));
+        CertGetCertificateContextProperty(ctx->pCert, CERT_KEY_PROV_INFO_PROP_ID, pInfoData, &dwInfoDataLength);
+    }
+
+    return (PCRYPT_KEY_PROV_INFO)pInfoData;
+}
+
 #endif /* XMLSEC_NO_GOST*/

--- a/src/mscrypto/signatures.c
+++ b/src/mscrypto/signatures.c
@@ -430,6 +430,11 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
     int ret;
     DWORD dwSigLen;
     BYTE *tmpBuf, *outBuf;
+    int bOk;
+    PCRYPT_KEY_PROV_INFO pProviderInfo = NULL;
+    char strContName[1000];
+    char strProvName[1000];
+    size_t size;
 
     xmlSecAssert2(xmlSecMSCryptoSignatureCheckId(transform), -1);
     xmlSecAssert2((transform->operation == xmlSecTransformOperationSign) || (transform->operation == xmlSecTransformOperationVerify), -1);
@@ -460,7 +465,56 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
             return (-1);
         }
 
-        if (!CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash))) {
+        //First try create hash with provider acquired in function xmlSecMSCryptoKeyDataAdoptCert.
+        bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
+
+        //Then try it with container name, provider name and type acquired from certificate context.
+        if (!bOk) {
+            pProviderInfo = xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo(ctx->data);
+
+            if (pProviderInfo == NULL) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo",
+                            XMLSEC_ERRORS_R_CRYPTO_FAILED,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
+
+            wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE);
+            wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE);
+
+            CryptReleaseContext(hProv, 0);
+            hProv = NULL;
+
+            CryptAcquireContext(&hProv,
+                strContName,
+                strProvName,
+                pProviderInfo->dwProvType,
+                0);
+
+            bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
+        }
+
+        //Last try it with PROV_RSA_AES provider type.
+        if (!bOk) {
+            CryptReleaseContext(hProv, 0);
+            hProv = NULL;
+
+            CryptAcquireContext(&hProv,
+                strContName,
+                NULL,
+                PROV_RSA_AES,
+                0);
+
+            bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
+        }
+
+        if (pProviderInfo != NULL) {
+            free(pProviderInfo);
+        }
+
+        if (!bOk) {
             xmlSecError(XMLSEC_ERRORS_HERE,
                         NULL,
                         "CryptCreateHash",

--- a/src/mscrypto/signatures.c
+++ b/src/mscrypto/signatures.c
@@ -469,22 +469,37 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
         bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
 
         //Then try it with container name, provider name and type acquired from certificate context.
-        if (!bOk) {
+        if(!bOk) {
             pProviderInfo = xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo(ctx->data);
 
-            if (pProviderInfo == NULL) {
+            if(pProviderInfo == NULL) {
                 xmlSecError(XMLSEC_ERRORS_HERE,
                             NULL,
                             "xmlSecMSCryptoKeyDataGetMSCryptoProviderInfo",
-                            XMLSEC_ERRORS_R_CRYPTO_FAILED,
+                            XMLSEC_ERRORS_R_XMLSEC_FAILED,
                             XMLSEC_ERRORS_NO_MESSAGE);
                 return(-1);
             }
 
-            xmlSecAssert2(wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE) == 0, -1);
-            xmlSecAssert2(wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE) == 0, -1);
+            if(wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE) != 0) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "wcstombs_s",
+                            XMLSEC_ERRORS_R_INVALID_DATA,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
 
-            if (!CryptReleaseContext(hProv, 0)) {
+            if(wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE) != 0) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "wcstombs_s",
+                            XMLSEC_ERRORS_R_INVALID_DATA,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
+
+            if(!CryptReleaseContext(hProv, 0)) {
                 xmlSecError(XMLSEC_ERRORS_HERE,
                             NULL,
                             "CryptReleaseContext",
@@ -494,7 +509,7 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
             }
             hProv = NULL;
 
-            if (!CryptAcquireContext(&hProv,
+            if(!CryptAcquireContext(&hProv,
                 strContName,
                 strProvName,
                 pProviderInfo->dwProvType,
@@ -511,7 +526,7 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
         }
 
         //Last try it with PROV_RSA_AES provider type.
-        if (!bOk) {
+        if(!bOk) {
             if (!CryptReleaseContext(hProv, 0)) {
                 xmlSecError(XMLSEC_ERRORS_HERE,
                             NULL,
@@ -522,7 +537,7 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
             }
             hProv = NULL;
 
-            if (!CryptAcquireContext(&hProv,
+            if(!CryptAcquireContext(&hProv,
                 strContName,
                 NULL,
                 PROV_RSA_AES,
@@ -538,11 +553,11 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
             bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
         }
 
-        if (pProviderInfo != NULL) {
+        if(pProviderInfo != NULL) {
             free(pProviderInfo);
         }
 
-        if (!bOk) {
+        if(!bOk) {
             xmlSecError(XMLSEC_ERRORS_HERE,
                         NULL,
                         "CryptCreateHash",

--- a/src/mscrypto/signatures.c
+++ b/src/mscrypto/signatures.c
@@ -481,21 +481,23 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
                 return(-1);
             }
 
-            if(wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE) != 0) {
+            ret = wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE);
+            if(ret != 0) {
                 xmlSecError(XMLSEC_ERRORS_HERE,
                             NULL,
                             "wcstombs_s",
                             XMLSEC_ERRORS_R_INVALID_DATA,
-                            XMLSEC_ERRORS_NO_MESSAGE);
+                            "ret=%d", ret);
                 return(-1);
             }
 
-            if(wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE) != 0) {
+            ret = wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE);
+            if(ret != 0) {
                 xmlSecError(XMLSEC_ERRORS_HERE,
                             NULL,
                             "wcstombs_s",
                             XMLSEC_ERRORS_R_INVALID_DATA,
-                            XMLSEC_ERRORS_NO_MESSAGE);
+                            "ret=%d", ret);
                 return(-1);
             }
 

--- a/src/mscrypto/signatures.c
+++ b/src/mscrypto/signatures.c
@@ -481,31 +481,59 @@ xmlSecMSCryptoSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTra
                 return(-1);
             }
 
-            wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE);
-            wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE);
+            xmlSecAssert2(wcstombs_s(&size, strContName, 1000, pProviderInfo->pwszContainerName, _TRUNCATE) == 0, -1);
+            xmlSecAssert2(wcstombs_s(&size, strProvName, 1000, pProviderInfo->pwszProvName, _TRUNCATE) == 0, -1);
 
-            CryptReleaseContext(hProv, 0);
+            if (!CryptReleaseContext(hProv, 0)) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "CryptReleaseContext",
+                            XMLSEC_ERRORS_R_CRYPTO_FAILED,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
             hProv = NULL;
 
-            CryptAcquireContext(&hProv,
+            if (!CryptAcquireContext(&hProv,
                 strContName,
                 strProvName,
                 pProviderInfo->dwProvType,
-                0);
+                0)) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "CryptAcquireContext",
+                            XMLSEC_ERRORS_R_CRYPTO_FAILED,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
 
             bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
         }
 
         //Last try it with PROV_RSA_AES provider type.
         if (!bOk) {
-            CryptReleaseContext(hProv, 0);
+            if (!CryptReleaseContext(hProv, 0)) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "CryptReleaseContext",
+                            XMLSEC_ERRORS_R_CRYPTO_FAILED,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
             hProv = NULL;
 
-            CryptAcquireContext(&hProv,
+            if (!CryptAcquireContext(&hProv,
                 strContName,
                 NULL,
                 PROV_RSA_AES,
-                0);
+                0)) {
+                xmlSecError(XMLSEC_ERRORS_HERE,
+                            NULL,
+                            "CryptAcquireContext",
+                            XMLSEC_ERRORS_R_CRYPTO_FAILED,
+                            XMLSEC_ERRORS_NO_MESSAGE);
+                return(-1);
+            }
 
             bOk = CryptCreateHash(hProv, ctx->digestAlgId, 0, 0, &(ctx->mscHash));
         }


### PR DESCRIPTION
I had problems with signing with RSA-SHA256 algorithm on Windows 7. Cryptographic provider acquired in xmlSecMSCryptoKeyDataAdoptCert function was not able to create hash in xmlSecMSCryptoSignatureExecute function. This commit fixes it for me.