### PR TITLE
configure: Fix LibreSSL version detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -495,7 +495,7 @@ if test "z$OPENSSL_FOUND" = "zyes" -a "z$OPENSSL_VERSION" = "z" ; then
     if test "z$OPENSSL_VERSION" = "z" ; then
         AC_EGREP_CPP(yes,[
             #include <openssl/opensslv.h>
-        #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+        #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
         yes
         #endif
     ],[


### PR DESCRIPTION
  - LibreSSL:
    * defines OPENSSL_VERSION_NUMBER as 0x20000000L
    * deFines LIBRESS_VERSION_NUMBER in opensslv.h
    * was forked from 1.0.1f / 0x1000107fL

PR:		https://bugs.freebsd.org/213301
Reported by:	Michael Gmelin <grembo@freebsd.org>