### PR TITLE
Fixes to make libressl work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,6 +418,18 @@ elif test "z$with_openssl" != "z" ; then
     OPENSSL_FOUND="yes"
 elif test "z$PKGCONFIG_FOUND" = "zyes" ; then
     if test "z$OPENSSL_VERSION" = "z" ; then
+        AC_EGREP_CPP(yes,[
+            #include <openssl/opensslv.h>
+        #if defined(LIBRESSL_VERSION_NUMBER)
+        yes
+        #endif
+    ],[
+        OPENSSL_VERSION="1.0.0"
+    ],[
+        OPENSSL_VERSION=""
+    ])
+    fi
+    if test "z$OPENSSL_VERSION" = "z" ; then
         PKG_CHECK_MODULES(OPENSSL, openssl >= 1.1.0,
             [OPENSSL_VERSION="1.1.0"],
             [OPENSSL_VERSION=""])
@@ -488,6 +500,19 @@ if test "z$OPENSSL_FOUND" = "zyes" -a "z$OPENSSL_VERSION" = "z" ; then
     dnl Check the OpenSSL version    
     OLD_CPPFLAGS=$CPPFLAGS
     CPPFLAGS="$OPENSSL_CFLAGS"
+
+    if test "z$OPENSSL_VERSION" = "z" ; then
+        AC_EGREP_CPP(yes,[
+            #include <openssl/opensslv.h>
+        #if defined(LIBRESSL_VERSION_NUMBER)
+        yes
+        #endif
+    ],[
+        OPENSSL_VERSION="1.0.0"
+    ],[
+        OPENSSL_VERSION=""
+    ])
+    fi
 
     if test "z$OPENSSL_VERSION" = "z" ; then
         AC_EGREP_CPP(yes,[

--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -61,7 +61,7 @@ XMLSEC_PTR_TO_FUNC_IMPL(pem_password_cb)
 int
 xmlSecOpenSSLAppInit(const char* config) {
     
-#if (OPENSSL_VERSION_NUMBER < 0x10100000)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER))
     ERR_load_crypto_strings();
     OPENSSL_config(NULL);
     OpenSSL_add_all_algorithms();
@@ -119,7 +119,7 @@ int
 xmlSecOpenSSLAppShutdown(void) {
     xmlSecOpenSSLAppSaveRANDFile(NULL);
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000)
+#if ((OPENSSL_VERSION_NUMBER < 0x10100000) || defined(LIBRESSL_VERSION_NUMBER))
     RAND_cleanup();
     EVP_cleanup();
 

--- a/src/openssl/openssl11_wrapper.h
+++ b/src/openssl/openssl11_wrapper.h
@@ -9,7 +9,7 @@
  * same syntax. This file won't be required once OpenSSL 1.1.0 is the minimum
  * suported version.
  */
-#if (OPENSSL_VERSION_NUMBER < 0x10100000)
+#if ((OPENSSL_VERSION_NUMBER < 0x10100000) || defined(LIBRESSL_VERSION_NUMBER))
 
 #define EVP_PKEY_up_ref(pKey)  CRYPTO_add(&((pKey)->references), 1, CRYPTO_LOCK_EVP_PKEY)
 


### PR DESCRIPTION
First, I have no idea what I am doing.

These changes seem to make xmlsec compile against libressl, but I have no idea what this breaks for openssl, or even if this works. I just figured a pull request would make the problem points easiest to identify. I am also seeing some issues when i run make -k check, which i have not looked into yet.

Issue: https://github.com/lsh123/xmlsec/issues/48