### PR TITLE
Fix libressl and openssl>=1.1.0 (#48)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -417,32 +417,14 @@ elif test "z$with_openssl" != "z" ; then
     fi
     OPENSSL_FOUND="yes"
 elif test "z$PKGCONFIG_FOUND" = "zyes" ; then
-    if test "z$OPENSSL_VERSION" = "z" ; then
-        PKG_CHECK_MODULES(OPENSSL, openssl >= 1.1.0,
-            [OPENSSL_VERSION="1.1.0"],
-            [OPENSSL_VERSION=""])
-    fi
-
-    if test "z$OPENSSL_VERSION" = "z" ; then
-        PKG_CHECK_MODULES(OPENSSL, openssl >= 1.0.0,
-            [OPENSSL_VERSION="1.0.0"],
-            [OPENSSL_VERSION=""])
-    fi
-
-    if test "z$OPENSSL_VERSION" = "z" ; then
-        PKG_CHECK_MODULES(OPENSSL, openssl >= 0.9.8,
-    	    [OPENSSL_VERSION="0.9.8"],
-	    [OPENSSL_VERSION=""])
-    fi
+    dnl we cannot use pkg-config to detect >= 1.1.0 due to libressl reports
+    dnl version 2.x. So we need to rely on the compile tests below to detect
+    dnl the exact version number
 
     if test "z$OPENSSL_VERSION" = "z" ; then
         PKG_CHECK_MODULES(OPENSSL, openssl >= $OPENSSL_MIN_VERSION,
-	    [OPENSSL_VERSION="$OPENSSL_MIN_VERSION"],
-	    [OPENSSL_VERSION=""])
-    fi
-
-    if test "z$OPENSSL_VERSION" != "z" ; then
-        OPENSSL_FOUND="yes"
+	    [OPENSSL_FOUND="yes"],
+	    [OPENSSL_FOUND="no"])
     fi
 fi
 
@@ -482,7 +464,7 @@ if test "z$OPENSSL_FOUND" = "zno" ; then
     fi
 fi
 
-if test "z$OPENSSL_FOUND" = "zyes" -a "z$OPENSSL_VERSION" = "z" ; then
+if test "z$OPENSSL_FOUND" = "zyes" ; then
     AC_MSG_CHECKING(for openssl libraries >= $OPENSSL_MIN_VERSION) 
 
     dnl Check the OpenSSL version    

--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -61,7 +61,7 @@ XMLSEC_PTR_TO_FUNC_IMPL(pem_password_cb)
 int
 xmlSecOpenSSLAppInit(const char* config) {
     
-#if (OPENSSL_VERSION_NUMBER < 0x10100000)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000 || defined(LIBRESSL_VERSION_NUMBER))
     ERR_load_crypto_strings();
     OPENSSL_config(NULL);
     OpenSSL_add_all_algorithms();

--- a/src/openssl/openssl11_wrapper.h
+++ b/src/openssl/openssl11_wrapper.h
@@ -9,7 +9,7 @@
  * same syntax. This file won't be required once OpenSSL 1.1.0 is the minimum
  * suported version.
  */
-#if (OPENSSL_VERSION_NUMBER < 0x10100000)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000) || defined(LIBRESSL_VERSION_NUMBER)
 
 #define EVP_PKEY_up_ref(pKey)  CRYPTO_add(&((pKey)->references), 1, CRYPTO_LOCK_EVP_PKEY)
 


### PR DESCRIPTION
We cannot use pkg-config to detect libressl vs openssl>=1.1.0 since
libressl's pkg-config reports version 2.x. So we simply remove the
pkg-config based version detection and use the fallback compile test.

We also fix a couple of related preprocessor tests to use the correct
code with libressl.
