### PR TITLE
configure: add option to disable documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,10 @@
 NULL =
 
 SAFE_VERSION	= @XMLSEC_VERSION_SAFE@
-SUBDIRS 	    = include src apps man docs
+SUBDIRS 	    = include src apps
+if XMLSEC_DOCS
+SUBDIRS += man docs
+endif
 TEST_APP 	    = apps/xmlsec1$(EXEEXT)
 DEFAULT_CRYPTO	= @XMLSEC_DEFAULT_CRYPTO@
 

--- a/configure.ac
+++ b/configure.ac
@@ -1411,6 +1411,21 @@ AM_CONDITIONAL(XMLSEC_NO_XMLENC, test "z$XMLSEC_NO_XMLENC" = "z1")
 AC_SUBST(XMLSEC_NO_XMLENC)
 
 dnl ==========================================================================
+dnl See do we need docs
+dnl ==========================================================================
+AC_MSG_CHECKING(for docs)
+AC_ARG_ENABLE(docs,   [  --enable-docs         enable documentation (yes)])
+if test "z$enable_docs" = "zno" ; then
+    XMLSEC_DOCS="0"
+    AC_MSG_RESULT(no)
+else
+    XMLSEC_DOCS="1"
+    AC_MSG_RESULT(yes)
+fi
+AM_CONDITIONAL(XMLSEC_DOCS, test "z$XMLSEC_DOCS" = "z1")
+AC_SUBST(XMLSEC_DOCS)
+
+dnl ==========================================================================
 dnl check if we need dynamic loading support
 dnl ==========================================================================
 XMLSEC_DL_INCLUDES=""


### PR DESCRIPTION
This is useful when xmlsec is bundled as a library in a project, and the
additional dependencies needed to build the documentation cause an
overhead, as only the library is used from the build result anyway.