### PR TITLE
nss: fix XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS handling

### DIFF
--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -742,6 +742,17 @@ static xmlSecAppCmdLineParam X509SkipStrictChecksParam = {
     xmlSecAppCmdLineParamFlagNone,
     NULL
 };
+
+static xmlSecAppCmdLineParam X509DontVerifyCerts = {
+    xmlSecAppCmdLineTopicDSigCommon,
+    "--insecure",
+    NULL,
+    "--insecure"
+    "\n\tdo not verify certificates",
+    xmlSecAppCmdLineParamTypeFlag,
+    xmlSecAppCmdLineParamFlagNone,
+    NULL
+};
 #endif /* XMLSEC_NO_X509 */    
 
 static xmlSecAppCmdLineParamPtr parameters[] = {
@@ -804,6 +815,7 @@ static xmlSecAppCmdLineParamPtr parameters[] = {
     &verificationTimeParam,
     &depthParam,    
     &X509SkipStrictChecksParam,    
+    &X509DontVerifyCerts,
 #endif /* XMLSEC_NO_X509 */    
     
     /* General configuration params */
@@ -1821,6 +1833,9 @@ xmlSecAppPrepareKeyInfoReadCtx(xmlSecKeyInfoCtxPtr keyInfoCtx) {
     }
     if(xmlSecAppCmdLineParamIsSet(&X509SkipStrictChecksParam)) {
         keyInfoCtx->flags |= XMLSEC_KEYINFO_FLAGS_X509DATA_SKIP_STRICT_CHECKS;
+    }
+    if(xmlSecAppCmdLineParamIsSet(&X509DontVerifyCerts)) {
+        keyInfoCtx->flags |= XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS;
     }
 #endif /* XMLSEC_NO_X509 */
 

--- a/src/nss/x509.c
+++ b/src/nss/x509.c
@@ -687,13 +687,11 @@ xmlSecNssKeyDataX509XmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key,
         return(-1);
     }
 
-    if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
-        ret = xmlSecNssKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
-        if(ret < 0) {
-            xmlSecInternalError("xmlSecNssKeyDataX509VerifyAndExtractKey",
-                                xmlSecKeyDataKlassGetName(id));
-            return(-1);
-        }
+    ret = xmlSecNssKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecNssKeyDataX509VerifyAndExtractKey",
+                            xmlSecKeyDataKlassGetName(id));
+        return(-1);
     }
     return(0);
 }

--- a/src/nss/x509vfy.c
+++ b/src/nss/x509vfy.c
@@ -213,13 +213,18 @@ xmlSecNssX509StoreVerify(xmlSecKeyDataStorePtr store, CERTCertList* certs,
             continue;
         }
 
-        /* it's important to set the usage here, otherwise no real verification
-         * is performed. */
-        status = CERT_VerifyCertificate(CERT_GetDefaultCertDB(),
-                                        cert, PR_FALSE,
-                                        certificateUsageEmailSigner, 
-                                        timeboundary , NULL, NULL, NULL);
-	    if (status == SECSuccess) {
+        if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
+            /* it's important to set the usage here, otherwise no real verification
+             * is performed. */
+            status = CERT_VerifyCertificate(CERT_GetDefaultCertDB(),
+                                            cert, PR_FALSE,
+                                            certificateUsageEmailSigner,
+                                            timeboundary , NULL, NULL, NULL);
+            if(status == SECSuccess) {
+                break;
+            }
+        } else {
+            status = SECSuccess;
             break;
         }
     }

--- a/tests/testDSig.sh
+++ b/tests/testDSig.sh
@@ -941,6 +941,16 @@ execDSigTest $res_fail \
     "rsa x509" \
     "--enabled-key-data x509"
 
+# This is the same, but due to --insecure it must pass.
+# If this fails, that means avoiding the certificate verification doesn't
+# happen correctly.
+execDSigTest $res_success \
+    "aleksey-xmldsig-01" \
+    "enveloping-sha256-rsa-sha256-verify" \
+    "sha256 rsa-sha256" \
+    "rsa x509" \
+    "--enabled-key-data x509 --insecure"
+
 ##########################################################################
 ##########################################################################
 ##########################################################################


### PR DESCRIPTION
Always extract it, just don't verify if the flag is used.