### PR TITLE
mscrypto: fix XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS handling

### DIFF
--- a/src/mscrypto/x509.c
+++ b/src/mscrypto/x509.c
@@ -666,13 +666,11 @@ xmlSecMSCryptoKeyDataX509XmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key,
         return(-1);
     }
 
-    if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
-        ret = xmlSecMSCryptoKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
-        if(ret < 0) {
-            xmlSecInternalError("xmlSecMSCryptoKeyDataX509VerifyAndExtractKey",
-                                xmlSecKeyDataKlassGetName(id));
-            return(-1);
-        }
+    ret = xmlSecMSCryptoKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecMSCryptoKeyDataX509VerifyAndExtractKey",
+                            xmlSecKeyDataKlassGetName(id));
+        return(-1);
     }
     return(0);
 }

--- a/src/mscrypto/x509vfy.c
+++ b/src/mscrypto/x509vfy.c
@@ -524,8 +524,11 @@ xmlSecMSCryptoX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
             CertFreeCertificateContext(nextCert);
         }
 
-        if((selected == 1) && xmlSecMSCryptoX509StoreConstructCertsChain(store, cert, certs, keyInfoCtx)) {
-            return(cert);
+        if(selected == 1) {
+	    if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) != 0
+               || xmlSecMSCryptoX509StoreConstructCertsChain(store, cert, certs, keyInfoCtx)) {
+                return(cert);
+            }
         }
     }
 


### PR DESCRIPTION
Always extract it, just don't construct the certificate chain if the
flag is used.

With this, the recently added two new testcases in commits
7f6f993c32916cc73f8103ceac928609c0bd9fa0 (nss: fix
XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS handling (#78),
2017-01-22) and 1533729d17da5d35b9d014f85091ad80d54db265 (nss adopt cert
type (#73), 2016-12-15) also pass for mscrypto.