### PR TITLE
nss: add ECDSA-SHA1 support

### DIFF
--- a/include/xmlsec/nss/crypto.h
+++ b/include/xmlsec/nss/crypto.h
@@ -202,6 +202,18 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecNssTransformDsaSha1GetKlass(void);
 #define xmlSecNssKeyDataEcdsaId xmlSecNssKeyDataEcdsaGetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId xmlSecNssKeyDataEcdsaGetKlass(void);
 
+#ifndef XMLSEC_NO_SHA1
+
+/**
+ * xmlSecNssTransformEcdsaSha1Id:
+ *
+ * The ECDSA SHA1 signature transform klass.
+ */
+#define xmlSecNssTransformEcdsaSha1Id xmlSecNssTransformEcdsaSha1GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecNssTransformEcdsaSha1GetKlass(void);
+
+#endif /* XMLSEC_NO_SHA1 */
+
 #ifndef XMLSEC_NO_SHA256
 
 /**

--- a/include/xmlsec/nss/symbols.h
+++ b/include/xmlsec/nss/symbols.h
@@ -65,6 +65,7 @@ extern "C" {
 #define xmlSecTransformDes3CbcId                xmlSecNssTransformDes3CbcId
 #define xmlSecTransformKWDes3Id                 xmlSecNssTransformKWDes3Id
 #define xmlSecTransformDsaSha1Id                xmlSecNssTransformDsaSha1Id
+#define xmlSecTransformEcdsaSha1Id              xmlSecNssTransformEcdsaSha1Id
 #define xmlSecTransformEcdsaSha256Id            xmlSecNssTransformEcdsaSha256Id
 #define xmlSecTransformHmacMd5Id                xmlSecNssTransformHmacMd5Id
 #define xmlSecTransformHmacRipemd160Id          xmlSecNssTransformHmacRipemd160Id

--- a/src/nss/crypto.c
+++ b/src/nss/crypto.c
@@ -126,6 +126,9 @@ xmlSecCryptoGetFunctions_nss(void) {
 
     /******************************* ECDSA ******************************/
 #ifndef XMLSEC_NO_ECDSA
+#ifndef XMLSEC_NO_SHA1
+    gXmlSecNssFunctions->transformEcdsaSha1GetKlass = xmlSecNssTransformEcdsaSha1GetKlass;
+#endif /* XMLSEC_NO_SHA1 */
 #ifndef XMLSEC_NO_SHA256
     gXmlSecNssFunctions->transformEcdsaSha256GetKlass = xmlSecNssTransformEcdsaSha256GetKlass;
 #endif /* XMLSEC_NO_SHA256 */


### PR DESCRIPTION
make check-crypto-nss XMLSEC_TEST_NAME="aleksey-xmldsig-01/enveloping-sha1-ecdsa-sha1"

passes with this. The only (perhaps) non-trivial part is that I pulled a duplicated list of conditions to a separate function.