### PR TITLE
nss: add ECDSA-SHA512 supports

### DIFF
--- a/include/xmlsec/nss/crypto.h
+++ b/include/xmlsec/nss/crypto.h
@@ -226,6 +226,18 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecNssTransformEcdsaSha256GetKlass(voi
 
 #endif /* XMLSEC_NO_SHA256 */
 
+#ifndef XMLSEC_NO_SHA512
+
+/**
+ * xmlSecNssTransformEcdsaSha512Id:
+ *
+ * The ECDSA SHA512 signature transform klass.
+ */
+#define xmlSecNssTransformEcdsaSha512Id xmlSecNssTransformEcdsaSha512GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecNssTransformEcdsaSha512GetKlass(void);
+
+#endif /* XMLSEC_NO_SHA512 */
+
 #endif /* XMLSEC_NO_ECDSA */
 
 

--- a/include/xmlsec/nss/symbols.h
+++ b/include/xmlsec/nss/symbols.h
@@ -67,6 +67,7 @@ extern "C" {
 #define xmlSecTransformDsaSha1Id                xmlSecNssTransformDsaSha1Id
 #define xmlSecTransformEcdsaSha1Id              xmlSecNssTransformEcdsaSha1Id
 #define xmlSecTransformEcdsaSha256Id            xmlSecNssTransformEcdsaSha256Id
+#define xmlSecTransformEcdsaSha512Id            xmlSecNssTransformEcdsaSha512Id
 #define xmlSecTransformHmacMd5Id                xmlSecNssTransformHmacMd5Id
 #define xmlSecTransformHmacRipemd160Id          xmlSecNssTransformHmacRipemd160Id
 #define xmlSecTransformHmacSha1Id               xmlSecNssTransformHmacSha1Id

--- a/src/nss/crypto.c
+++ b/src/nss/crypto.c
@@ -132,6 +132,9 @@ xmlSecCryptoGetFunctions_nss(void) {
 #ifndef XMLSEC_NO_SHA256
     gXmlSecNssFunctions->transformEcdsaSha256GetKlass = xmlSecNssTransformEcdsaSha256GetKlass;
 #endif /* XMLSEC_NO_SHA256 */
+#ifndef XMLSEC_NO_SHA512
+    gXmlSecNssFunctions->transformEcdsaSha512GetKlass = xmlSecNssTransformEcdsaSha512GetKlass;
+#endif /* XMLSEC_NO_SHA512 */
 #endif /* XMLSEC_NO_ECDSA */
 
     /******************************* HMAC ********************************/

--- a/src/nss/signatures.c
+++ b/src/nss/signatures.c
@@ -94,6 +94,11 @@ xmlSecNssSignatureCheckId(xmlSecTransformPtr transform) {
         return(1);
     }
 #endif /* XMLSEC_NO_SHA256 */
+#ifndef XMLSEC_NO_SHA512
+    if(xmlSecTransformCheckId(transform, xmlSecNssTransformEcdsaSha512Id)) {
+        return(1);
+    }
+#endif /* XMLSEC_NO_SHA512 */
 #endif /* XMLSEC_NO_ECDSA */
 
 #ifndef XMLSEC_NO_RSA
@@ -167,6 +172,13 @@ xmlSecNssSignatureInitialize(xmlSecTransformPtr transform) {
         ctx->alg = SEC_OID_ANSIX962_ECDSA_SHA256_SIGNATURE;
     } else
 #endif /* XMLSEC_NO_SHA256 */
+#ifndef XMLSEC_NO_SHA512
+    if(xmlSecTransformCheckId(transform, xmlSecNssTransformEcdsaSha512Id)) {
+        ctx->keyId = xmlSecNssKeyDataEcdsaId;
+        /* This creates a signature which is ASN1 encoded */
+        ctx->alg = SEC_OID_ANSIX962_ECDSA_SHA512_SIGNATURE;
+    } else
+#endif /* XMLSEC_NO_SHA512 */
 #endif /* XMLSEC_NO_ECDSA */
 
 #ifndef XMLSEC_NO_RSA
@@ -334,6 +346,7 @@ xmlSecNssSignatureAlgorithmEncoded(SECOidTag alg) {
     case SEC_OID_ANSIX9_DSA_SIGNATURE_WITH_SHA1_DIGEST:
     case SEC_OID_ANSIX962_ECDSA_SHA1_SIGNATURE:
     case SEC_OID_ANSIX962_ECDSA_SHA256_SIGNATURE:
+    case SEC_OID_ANSIX962_ECDSA_SHA512_SIGNATURE:
         return(1);
     }
 
@@ -701,6 +714,53 @@ xmlSecNssTransformEcdsaSha256GetKlass(void) {
 }
 
 #endif /* XMLSEC_NO_SHA256 */
+#ifndef XMLSEC_NO_SHA512
+/****************************************************************************
+ *
+ * ECDSA-SHA512 signature transform
+ *
+ ***************************************************************************/
+
+static xmlSecTransformKlass xmlSecNssEcdsaSha512Klass = {
+    /* klass/object sizes */
+    sizeof(xmlSecTransformKlass),               /* xmlSecSize klassSize */
+    xmlSecNssSignatureSize,                     /* xmlSecSize objSize */
+
+    xmlSecNameEcdsaSha512,                      /* const xmlChar* name; */
+    xmlSecHrefEcdsaSha512,                      /* const xmlChar* href; */
+    xmlSecTransformUsageSignatureMethod,        /* xmlSecTransformUsage usage; */
+
+    xmlSecNssSignatureInitialize,               /* xmlSecTransformInitializeMethod initialize; */
+    xmlSecNssSignatureFinalize,                 /* xmlSecTransformFinalizeMethod finalize; */
+    NULL,                                       /* xmlSecTransformNodeReadMethod readNode; */
+    NULL,                                       /* xmlSecTransformNodeWriteMethod writeNode; */
+    xmlSecNssSignatureSetKeyReq,                /* xmlSecTransformSetKeyReqMethod setKeyReq; */
+    xmlSecNssSignatureSetKey,                   /* xmlSecTransformSetKeyMethod setKey; */
+    xmlSecNssSignatureVerify,                   /* xmlSecTransformVerifyMethod verify; */
+    xmlSecTransformDefaultGetDataType,          /* xmlSecTransformGetDataTypeMethod getDataType; */
+    xmlSecTransformDefaultPushBin,              /* xmlSecTransformPushBinMethod pushBin; */
+    xmlSecTransformDefaultPopBin,               /* xmlSecTransformPopBinMethod popBin; */
+    NULL,                                       /* xmlSecTransformPushXmlMethod pushXml; */
+    NULL,                                       /* xmlSecTransformPopXmlMethod popXml; */
+    xmlSecNssSignatureExecute,                  /* xmlSecTransformExecuteMethod execute; */
+
+    NULL,                                       /* void* reserved0; */
+    NULL,                                       /* void* reserved1; */
+};
+
+/**
+ * xmlSecNssTransformEcdsaSha512GetKlass:
+ *
+ * The ECDSA-SHA512 signature transform klass.
+ *
+ * Returns: ECDSA-SHA512 signature transform klass.
+ */
+xmlSecTransformId
+xmlSecNssTransformEcdsaSha512GetKlass(void) {
+    return(&xmlSecNssEcdsaSha512Klass);
+}
+
+#endif /* XMLSEC_NO_SHA512 */
 #endif /* XMLSEC_NO_ECDSA */
 
 #ifndef XMLSEC_NO_RSA


### PR DESCRIPTION
make check-crypto-nss XMLSEC_TEST_NAME="aleksey-xmldsig-01/enveloping-sha512-ecdsa-sha512"

passes with these changes. Also, I think with this finally the nss backend is on par with the openssl one regarding ECDSA support.