### PR TITLE
nss, openssl: encode ECDSA signature value according to RFC 3279, 2.2.3

### DIFF
--- a/src/nss/signatures.c
+++ b/src/nss/signatures.c
@@ -344,9 +344,6 @@ static int
 xmlSecNssSignatureAlgorithmEncoded(SECOidTag alg) {
     switch(alg) {
     case SEC_OID_ANSIX9_DSA_SIGNATURE_WITH_SHA1_DIGEST:
-    case SEC_OID_ANSIX962_ECDSA_SHA1_SIGNATURE:
-    case SEC_OID_ANSIX962_ECDSA_SHA256_SIGNATURE:
-    case SEC_OID_ANSIX962_ECDSA_SHA512_SIGNATURE:
         return(1);
     }
 

--- a/src/openssl/signatures.c
+++ b/src/openssl/signatures.c
@@ -913,30 +913,8 @@ xmlSecOpenSSLSignatureEcdsaSign(xmlSecOpenSSLSignatureCtxPtr ctx, xmlSecBufferPt
         goto done;
     }
 
-    /* get signature components */
-    ECDSA_SIG_get0(sig, &rr, &ss);
-    if((rr == NULL) || (ss == NULL)) {
-        xmlSecOpenSSLError("ECDSA_SIG_get0", NULL);
-        goto done;
-    }
-
-    /* check sizes */
-    rSize = BN_num_bytes(rr);
-    if(rSize > signHalfSize) {
-        xmlSecInvalidSizeMoreThanError("ECDSA signatue r",
-                                       rSize, signHalfSize, NULL);
-        goto done;
-    }
-
-    sSize = BN_num_bytes(ss);
-    if(sSize > signHalfSize) {
-        xmlSecInvalidSizeMoreThanError("ECDSA signatue s",
-                                       sSize, signHalfSize, NULL);
-        goto done;
-    }
-
     /* allocate buffer */
-    ret = xmlSecBufferSetSize(out, 2 * signHalfSize);
+    ret = xmlSecBufferSetSize(out, ECDSA_size(ecKey));
     if(ret < 0) {
         xmlSecInternalError2("xmlSecBufferSetSize", NULL,
                              "size=%d", (int)(2 * signHalfSize));
@@ -945,11 +923,12 @@ xmlSecOpenSSLSignatureEcdsaSign(xmlSecOpenSSLSignatureCtxPtr ctx, xmlSecBufferPt
     outData = xmlSecBufferGetData(out);
     xmlSecAssert2(outData != NULL, -1);
 
-    /* write components */
-    xmlSecAssert2((rSize + sSize) <= 2 * signHalfSize, -1);
-    memset(outData, 0, 2 * signHalfSize);
-    BN_bn2bin(rr, outData + signHalfSize - rSize);
-    BN_bn2bin(ss, outData + 2 * signHalfSize - sSize);
+    /* write signature */
+    ret = i2d_ECDSA_SIG(sig, &outData);
+    if(ret < 0) {
+        xmlSecOpenSSLError("i2d_ECDSA_SIG", NULL);
+        goto done;
+    }
 
     /* success */
     res = 0;
@@ -996,38 +975,12 @@ xmlSecOpenSSLSignatureEcdsaVerify(xmlSecOpenSSLSignatureCtxPtr ctx, const xmlSec
         goto done;
     }
 
-    /* check size */
-    if(signSize != 2 * signHalfSize) {
-        xmlSecInvalidSizeError("ECDSA signature", signSize, 2 * signHalfSize,
-                               NULL);
-        goto done;
-    }
-
-    /* create/read signature */
-    sig = ECDSA_SIG_new();
+    /* read signature */
+    sig = d2i_ECDSA_SIG(NULL, &signData, signSize);
     if (sig == NULL) {
-        xmlSecOpenSSLError("DSA_SIG_new", NULL);
+        xmlSecOpenSSLError("d2i_ECDSA_SIG", NULL);
         goto done;
     }
-
-    rr = BN_bin2bn(signData, signHalfSize, NULL);
-    if(rr == NULL) {
-        xmlSecOpenSSLError("BN_bin2bn(sig->r)", NULL);
-        goto done;
-    }
-    ss = BN_bin2bn(signData + signHalfSize, signHalfSize, NULL);
-    if(ss == NULL) {
-        xmlSecOpenSSLError("BN_bin2bn(sig->s)", NULL);
-        goto done;
-    }
-
-    ret = ECDSA_SIG_set0(sig, rr, ss);
-    if(ret == 0) {
-        xmlSecOpenSSLError("ECDSA_SIG_set0()", NULL);
-        goto done;
-    }
-    rr = NULL;
-    ss = NULL;
 
     /* verify signature */
     ret = ECDSA_do_verify(ctx->dgst, ctx->dgstSize, sig, ecKey);

--- a/tests/aleksey-xmldsig-01/enveloping-sha1-ecdsa-sha1.xml
+++ b/tests/aleksey-xmldsig-01/enveloping-sha1-ecdsa-sha1.xml
@@ -8,8 +8,8 @@
       <DigestValue>7/XTsHaBSOnJ/jXD5v0zL6VKYsk=</DigestValue>
     </Reference>
   </SignedInfo>
-  <SignatureValue>1T18pVocVMRq1aJ6L+bpLOzNQtM5kqjXafgzlgaGxFQMM/K1oBzWE5vmlau8WYm+
-04elfDnQb9tf5w2dXGyQBQ==</SignatureValue>
+  <SignatureValue>MEUCIApM4cQgHaZoXgFgKwYrAktaIx/HcdE8rnlB2sNPO0w7AiEAp/0j68aKjRDb
+Mk5lrA3jiNU9ycMrN7ooc5MLS4I26gw=</SignatureValue>
   <KeyInfo>
     <X509Data>
 <X509Certificate>MIID9zCCA2CgAwIBAgIJAK+ii7kzrdqsMA0GCSqGSIb3DQEBBQUAMIGuMQswCQYD

--- a/tests/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.xml
+++ b/tests/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.xml
@@ -8,8 +8,8 @@
       <DigestValue>iDhYt78o294fA6pzQ7k44+eejrQMi+WX3l3UrUdtL1Q=</DigestValue>
     </Reference>
   </SignedInfo>
-  <SignatureValue>epctjDEaow8JdOu4/pCsV8WxYBtfeWGLYD51CRVeuUjjTaAodr+tXpdd1jvYoSxv
-YjhC4hmJTgH0tEmYWEPYZg==</SignatureValue>
+  <SignatureValue>MEUCIQD70FWastvMoUoWJJ1uisCuKZAwffgz5JbG2YGPL7ZIZQIgPSUen1IthHp3
+IEXEaVyjToYS+GCcMoEPglsbXkD4dno=</SignatureValue>
   <KeyInfo>
     <X509Data>
 <X509Certificate>MIID9zCCA2CgAwIBAgIJAK+ii7kzrdqsMA0GCSqGSIb3DQEBBQUAMIGuMQswCQYD

--- a/tests/aleksey-xmldsig-01/enveloping-sha512-ecdsa-sha512.xml
+++ b/tests/aleksey-xmldsig-01/enveloping-sha512-ecdsa-sha512.xml
@@ -9,8 +9,8 @@
 XDnbRaf22WqerzX1vL0QzA==</DigestValue>
     </Reference>
   </SignedInfo>
-  <SignatureValue>5vaWW6jmgfmhFcV65FrOsOicilCL4H53ZNZU5XCvYXQvfJmYsQZ4bhzg2KOV78ZO
-v05ijIzPhhvYF+eodPfCZQ==</SignatureValue>
+  <SignatureValue>MEUCIQCh4BCDyCLkQYUQarTOnTbPEH9t7jnnO5G61uVgHzpjCwIgI+f+2lML+N/C
+ihY5dFLVO7AyPm3iI3psAj2pvihInXs=</SignatureValue>
   <KeyInfo>
     <X509Data>
 <X509Certificate>MIID9zCCA2CgAwIBAgIJAK+ii7kzrdqsMA0GCSqGSIb3DQEBBQUAMIGuMQswCQYD


### PR DESCRIPTION
I'm new to the openssl part, but this post explains exactly this part of the openssl API in detail:

http://davidederosa.com/basic-blockchain-programming/elliptic-curve-digital-signatures/

It seems actually getting the correct encoded signature is much easier than the raw 2 numbers. :-)