### PR TITLE
nss: fix assert when building against debug nss

### DIFF
--- a/src/nss/signatures.c
+++ b/src/nss/signatures.c
@@ -379,6 +379,7 @@ xmlSecNssSignatureVerify(xmlSecTransformPtr transform,
         SECItem   signatureDer;
         SECStatus statusDer;
 
+        memset(&signatureDer, 0, sizeof(signatureDer));
         statusDer = DSAU_EncodeDerSigWithLen(&signatureDer, &signature, signature.len);
         if(statusDer != SECSuccess) {
             xmlSecNssError("DSAU_EncodeDerSigWithLen",


### PR DESCRIPTION
Due to reading uninitialized memory. gdb says:

    Assertion failure: dest == NULL || dest->data == NULL, at secasn1e.c:1483
    Program received signal SIGABRT, Aborted.
    0x00007ffff74748d7 in raise () from /lib64/libc.so.6
    (gdb) up
    #1  0x00007ffff7475caa in abort () from /lib64/libc.so.6
    (gdb)
    #2  0x00007fffe57f96ae in PR_Assert (s=0x7fffe1cbf298 "dest == NULL || dest->data == NULL", file=0x7fffe1cbef60 "secasn1e.c", ln=1483) at ../../../../pr/src/io/prlog.c:553
    553         abort();
    (gdb)
    #3  0x00007fffe1cb1941 in SEC_ASN1EncodeItem_Util (poolp=0x0, dest=0x7fffffff95f0, src=0x7fffffff9530, theTemplate=0x7fffe55ae180 <DSA_SignatureTemplate>) at secasn1e.c:1483
    1483        PORT_Assert(dest == NULL || dest->data == NULL);