### PR TITLE
openssl: fix XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS handling

### DIFF
--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -640,13 +640,11 @@ xmlSecOpenSSLKeyDataX509XmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key,
         return(-1);
     }
 
-    if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
-        ret = xmlSecOpenSSLKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
-        if(ret < 0) {
-            xmlSecInternalError("xmlSecOpenSSLKeyDataX509VerifyAndExtractKey",
-                                xmlSecKeyDataKlassGetName(id));
-            return(-1);
-        }
+    ret = xmlSecOpenSSLKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecOpenSSLKeyDataX509VerifyAndExtractKey",
+                            xmlSecKeyDataKlassGetName(id));
+        return(-1);
     }
     return(0);
 }

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -310,7 +310,11 @@ xmlSecOpenSSLX509StoreVerify(xmlSecKeyDataStorePtr store, XMLSEC_STACK_OF_X509* 
             }
 
 
-            ret         = X509_verify_cert(xsc);
+            if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
+                ret         = X509_verify_cert(xsc);
+            } else {
+                ret = 1;
+            }
             err_cert    = X509_STORE_CTX_get_current_cert(xsc);
             err         = X509_STORE_CTX_get_error(xsc);
 


### PR DESCRIPTION
make check-crypto-openssl XMLSEC_TEST_NAME="enveloping-sha256-rsa-sha256-verify"

passes with this, similary to nss and mscrypto.