### PR TITLE
gnutls: fix XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS handling

### DIFF
--- a/src/gnutls/x509.c
+++ b/src/gnutls/x509.c
@@ -573,13 +573,11 @@ xmlSecGnuTLSKeyDataX509XmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key,
         return(-1);
     }
 
-    if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
-        ret = xmlSecGnuTLSKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
-        if(ret < 0) {
-            xmlSecInternalError("xmlSecGnuTLSKeyDataX509VerifyAndExtractKey",
-                                xmlSecKeyDataKlassGetName(id));
-            return(-1);
-        }
+    ret = xmlSecGnuTLSKeyDataX509VerifyAndExtractKey(data, key, keyInfoCtx);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecGnuTLSKeyDataX509VerifyAndExtractKey",
+                            xmlSecKeyDataKlassGetName(id));
+        return(-1);
     }
     return(0);
 }

--- a/src/gnutls/x509vfy.c
+++ b/src/gnutls/x509vfy.c
@@ -329,12 +329,16 @@ xmlSecGnuTLSX509StoreVerify(xmlSecKeyDataStorePtr store,
         }
 
         /* try to verify */
-        err = gnutls_x509_crt_list_verify(
-                cert_list, (int)cert_list_cur_length, /* certs chain */
-                ca_list, (int)ca_list_length, /* trusted cas */
-                crl_list, (int)crl_list_length, /* crls */
-                flags, /* flags */
-                &verify);
+	if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) == 0) {
+            err = gnutls_x509_crt_list_verify(
+                    cert_list, (int)cert_list_cur_length, /* certs chain */
+                    ca_list, (int)ca_list_length, /* trusted cas */
+                    crl_list, (int)crl_list_length, /* crls */
+                    flags, /* flags */
+                    &verify);
+        } else {
+            err = GNUTLS_E_SUCCESS;
+        }
         if(err != GNUTLS_E_SUCCESS) {
             xmlSecGnuTLSError("gnutls_x509_crt_list_verify", err, NULL);
             /* don't stop, continue! */


### PR DESCRIPTION
make check-crypto-gnutls XMLSEC_TEST_NAME="enveloping-sha256-rsa-sha256-verify"

passes with this. Now all backends handle this flag the same way.