### PR TITLE
Remove never read variable assignments

### DIFF
--- a/src/nss/x509.c
+++ b/src/nss/x509.c
@@ -900,7 +900,6 @@ xmlSecNssX509DataNodeRead(xmlSecKeyDataPtr data, xmlNodePtr node, xmlSecKeyInfoC
         cur != NULL;
         cur = xmlSecGetNextElementNode(cur->next)) {
 
-        ret = 0;
         if(xmlSecCheckNodeName(cur, xmlSecNodeX509Certificate, xmlSecDSigNs)) {
             ret = xmlSecNssX509CertificateNodeRead(data, cur, keyInfoCtx);
             if(ret < 0) {

--- a/src/transforms.c
+++ b/src/transforms.c
@@ -1915,8 +1915,6 @@ xmlSecTransformDefaultPushBin(xmlSecTransformPtr transform, const xmlSecByte* da
         }
 
         /* process data */
-        inSize = xmlSecBufferGetSize(&(transform->inBuf));
-        outSize = xmlSecBufferGetSize(&(transform->outBuf));
         finalData = (((dataSize == 0) && (final != 0)) ? 1 : 0);
         ret = xmlSecTransformExecute(transform, finalData, transformCtx);
         if(ret < 0) {


### PR DESCRIPTION
In all 3 cases the variables are written again a few lines later. The
only purpose could be if xmlSecBufferGetSize() would have a side effect,
which is not the case.

Found by the clang static analyzer.