### PR TITLE
Eliminate unnecessary else branches after return statements

### DIFF
--- a/src/bn.c
+++ b/src/bn.c
@@ -230,15 +230,14 @@ xmlSecBnFromString(xmlSecBnPtr bn, const xmlChar* str, xmlSecSize base) {
             positive = 1;
             --i; /* make sure that we will look at this character in next loop */
             break;
-        } else {
-            xmlSecError(XMLSEC_ERRORS_HERE,
-                    NULL,
-                    NULL,
-                    XMLSEC_ERRORS_R_INVALID_DATA,
-                    "char=%c;base=%d",
-                    ch, base);
-            return (-1);
         }
+        xmlSecError(XMLSEC_ERRORS_HERE,
+                NULL,
+                NULL,
+                XMLSEC_ERRORS_R_INVALID_DATA,
+                "char=%c;base=%d",
+                ch, base);
+        return (-1);
     }
 
     /* now parse the number itself */


### PR DESCRIPTION
This allows less indentation, so makes the code more readable.

(OTOH this is a bit of a cosmetic change, if you don't like it, no hard feelings. :-) )