### PR TITLE
Add Default linefeed for xmltree module

### DIFF
--- a/include/xmlsec/xmltree.h
+++ b/include/xmlsec/xmltree.h
@@ -30,13 +30,6 @@ extern "C" {
 #define xmlSecNodeGetName(node) \
     (((node)) ? ((const char*)((node)->name)) : NULL)
 
-/**
- * XMLSEC_XMLTREE_LINEFEED
- *
- * The default xmlnode linefeed
- */
-#define	XMLSEC_XMLTREE_LINEFEED			xmlSecStringCR
-
 XMLSEC_EXPORT const xmlChar*	xmlSecGetDefaultLineFeed(void);
 XMLSEC_EXPORT void		xmlSecSetDefaultLineFeed(const xmlChar *linefeed);
 

--- a/include/xmlsec/xmltree.h
+++ b/include/xmlsec/xmltree.h
@@ -30,6 +30,16 @@ extern "C" {
 #define xmlSecNodeGetName(node) \
     (((node)) ? ((const char*)((node)->name)) : NULL)
 
+/**
+ * XMLSEC_XMLTREE_LINEFEED
+ *
+ * The default xmlnode linefeed
+ */
+#define	XMLSEC_XMLTREE_LINEFEED			xmlSecStringCR
+
+XMLSEC_EXPORT const xmlChar*	xmlSecGetDefaultLineFeed(void);
+XMLSEC_EXPORT void		xmlSecSetDefaultLineFeed(const xmlChar *linefeed);
+
 XMLSEC_EXPORT const xmlChar*    xmlSecGetNodeNsHref     (const xmlNodePtr cur);
 XMLSEC_EXPORT int               xmlSecCheckNodeName     (const xmlNodePtr cur,
                                                          const xmlChar *name,

--- a/src/bn.c
+++ b/src/bn.c
@@ -845,7 +845,7 @@ xmlSecBnSetNodeValue(xmlSecBnPtr bn, xmlNodePtr cur, xmlSecBnFormat format, int 
     }
 
     if(addLineBreaks) {
-        xmlNodeAddContent(cur, xmlSecStringCR);
+        xmlNodeAddContent(cur, xmlSecGetDefaultLineFeed());
     }
 
     switch(format) {
@@ -879,7 +879,7 @@ xmlSecBnSetNodeValue(xmlSecBnPtr bn, xmlNodePtr cur, xmlSecBnFormat format, int 
     }
 
     if(addLineBreaks) {
-        xmlNodeAddContent(cur, xmlSecStringCR);
+        xmlNodeAddContent(cur, xmlSecGetDefaultLineFeed());
     }
 
     return(0);

--- a/src/gcrypt/asymkeys.c
+++ b/src/gcrypt/asymkeys.c
@@ -492,7 +492,7 @@ xmlSecGCryptNodeSetMpiValue(xmlNodePtr cur, const gcry_mpi_t a, int addLineBreak
     }
 
     if(addLineBreaks) {
-        xmlNodeSetContent(cur, xmlSecStringCR);
+        xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     } else {
         xmlNodeSetContent(cur, xmlSecStringEmpty);
     }
@@ -505,7 +505,7 @@ xmlSecGCryptNodeSetMpiValue(xmlNodePtr cur, const gcry_mpi_t a, int addLineBreak
     }
 
     if(addLineBreaks) {
-        xmlNodeAddContent(cur, xmlSecStringCR);
+        xmlNodeAddContent(cur, xmlSecGetDefaultLineFeed());
     }
 
     xmlSecBufferFinalize(&buf);

--- a/src/gnutls/x509.c
+++ b/src/gnutls/x509.c
@@ -948,7 +948,7 @@ xmlSecGnuTLSX509CertificateNodeWrite(gnutls_x509_crt_t cert, xmlNodePtr node, xm
 
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
     return(0);
@@ -1427,7 +1427,7 @@ xmlSecGnuTLSX509CRLNodeWrite(gnutls_x509_crl_t crl, xmlNodePtr node, xmlSecKeyIn
     }
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
 

--- a/src/mscrypto/x509.c
+++ b/src/mscrypto/x509.c
@@ -993,7 +993,7 @@ xmlSecMSCryptoX509CertificateNodeWrite(PCCERT_CONTEXT cert, xmlNodePtr node,
 
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
     return(0);
@@ -1396,7 +1396,7 @@ xmlSecMSCryptoX509CRLNodeWrite(PCCRL_CONTEXT crl, xmlNodePtr node, xmlSecKeyInfo
     }
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
 

--- a/src/nss/bignum.c
+++ b/src/nss/bignum.c
@@ -19,6 +19,7 @@
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
+#include <xmlsec/xmltree.h>
 #include <xmlsec/buffer.h>
 #include <xmlsec/base64.h>
 #include <xmlsec/errors.h>
@@ -121,7 +122,7 @@ xmlSecNssNodeSetBigNumValue(xmlNodePtr cur, const SECItem *a, int addLineBreaks)
     }
 
     if(addLineBreaks) {
-        xmlNodeSetContent(cur, xmlSecStringCR);
+        xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     } else {
         xmlNodeSetContent(cur, xmlSecStringEmpty);
     }
@@ -134,7 +135,7 @@ xmlSecNssNodeSetBigNumValue(xmlNodePtr cur, const SECItem *a, int addLineBreaks)
     }
 
     if(addLineBreaks) {
-        xmlNodeAddContent(cur, xmlSecStringCR);
+        xmlNodeAddContent(cur, xmlSecGetDefaultLineFeed());
     }
 
     xmlSecBufferFinalize(&buf);

--- a/src/nss/x509.c
+++ b/src/nss/x509.c
@@ -1012,7 +1012,7 @@ xmlSecNssX509CertificateNodeWrite(CERTCertificate* cert, xmlNodePtr node, xmlSec
 
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
     return(0);
@@ -1410,7 +1410,7 @@ xmlSecNssX509CRLNodeWrite(CERTSignedCrl* crl, xmlNodePtr node, xmlSecKeyInfoCtxP
     }
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
 

--- a/src/openssl/bn.c
+++ b/src/openssl/bn.c
@@ -16,6 +16,7 @@
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
+#include <xmlsec/xmltree.h>
 #include <xmlsec/buffer.h>
 #include <xmlsec/base64.h>
 #include <xmlsec/errors.h>
@@ -116,7 +117,7 @@ xmlSecOpenSSLNodeSetBNValue(xmlNodePtr cur, const BIGNUM *a, int addLineBreaks) 
     }
 
     if(addLineBreaks) {
-        xmlNodeSetContent(cur, xmlSecStringCR);
+        xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     } else {
         xmlNodeSetContent(cur, xmlSecStringEmpty);
     }
@@ -129,7 +130,7 @@ xmlSecOpenSSLNodeSetBNValue(xmlNodePtr cur, const BIGNUM *a, int addLineBreaks) 
     }
 
     if(addLineBreaks) {
-        xmlNodeAddContent(cur, xmlSecStringCR);
+        xmlNodeAddContent(cur, xmlSecGetDefaultLineFeed());
     }
 
     xmlSecBufferFinalize(&buf);

--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -976,7 +976,7 @@ xmlSecOpenSSLX509CertificateNodeWrite(X509* cert, xmlNodePtr node, xmlSecKeyInfo
 
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
     return(0);
@@ -1419,7 +1419,7 @@ xmlSecOpenSSLX509CRLNodeWrite(X509_CRL* crl, xmlNodePtr node, xmlSecKeyInfoCtxPt
     }
     /* todo: add \n around base64 data - from context */
     /* todo: add errors check */
-    xmlNodeSetContent(cur, xmlSecStringCR);
+    xmlNodeSetContent(cur, xmlSecGetDefaultLineFeed());
     xmlNodeSetContent(cur, buf);
     xmlFree(buf);
 

--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -26,7 +26,7 @@
 #include <xmlsec/base64.h>
 #include <xmlsec/errors.h>
 
-static const xmlChar*	g_xmlsec_xmltree_default_linefeed = XMLSEC_XMLTREE_LINEFEED;
+static const xmlChar*	g_xmlsec_xmltree_default_linefeed = xmlSecStringCR;
 
 /**
  * xmlSecGetDefaultLineFeed:

--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -26,6 +26,33 @@
 #include <xmlsec/base64.h>
 #include <xmlsec/errors.h>
 
+static const xmlChar*	g_xmlsec_xmltree_default_linefeed = XMLSEC_XMLTREE_LINEFEED;
+
+/**
+ * xmlSecGetDefaultLineFeed:
+ *
+ * Gets the current default linefeed.
+ *
+ * Returns: the current default linefeed.
+ */
+const xmlChar*
+xmlSecGetDefaultLineFeed(void)
+{
+    return g_xmlsec_xmltree_default_linefeed;
+}
+
+/**
+ * xmlSecSetDefaultLineFeed:
+ * @linefeed: default linefeed 
+ *
+ * Sets the current default linefeed.
+ */
+void
+xmlSecSetDefaultLineFeed(const xmlChar *linefeed)
+{
+    g_xmlsec_xmltree_default_linefeed = linefeed;
+}
+
 /**
  * xmlSecFindSibling:
  * @cur:                the pointer to XML node.
@@ -199,7 +226,7 @@ xmlSecAddChild(xmlNodePtr parent, const xmlChar *name, const xmlChar *ns) {
 
     if(parent->children == NULL) {
         /* TODO: add indents */
-        text = xmlNewText(xmlSecStringCR);
+        text = xmlNewText(xmlSecGetDefaultLineFeed());
         if(text == NULL) {
             xmlSecXmlError("xmlNewText", NULL);
             return(NULL);
@@ -230,7 +257,7 @@ xmlSecAddChild(xmlNodePtr parent, const xmlChar *name, const xmlChar *ns) {
     }
 
     /* TODO: add indents */
-    text = xmlNewText(xmlSecStringCR);
+    text = xmlNewText(xmlSecGetDefaultLineFeed());
     if(text == NULL) {
         xmlSecXmlError("xmlNewText", NULL);
         return(NULL);
@@ -258,7 +285,7 @@ xmlSecAddChildNode(xmlNodePtr parent, xmlNodePtr child) {
 
     if(parent->children == NULL) {
         /* TODO: add indents */
-        text = xmlNewText(xmlSecStringCR);
+        text = xmlNewText(xmlSecGetDefaultLineFeed());
         if(text == NULL) {
             xmlSecXmlError("xmlNewText", NULL);
             return(NULL);
@@ -269,7 +296,7 @@ xmlSecAddChildNode(xmlNodePtr parent, xmlNodePtr child) {
     xmlAddChild(parent, child);
 
     /* TODO: add indents */
-    text = xmlNewText(xmlSecStringCR);
+    text = xmlNewText(xmlSecGetDefaultLineFeed());
     if(text == NULL) {
         xmlSecXmlError("xmlNewText", NULL);
         return(NULL);
@@ -363,7 +390,7 @@ xmlSecAddNextSibling(xmlNodePtr node, const xmlChar *name, const xmlChar *ns) {
     }
 
     /* TODO: add indents */
-    text = xmlNewText(xmlSecStringCR);
+    text = xmlNewText(xmlSecGetDefaultLineFeed());
     if(text == NULL) {
         xmlSecXmlError("xmlNewText", NULL);
         return(NULL);
@@ -411,7 +438,7 @@ xmlSecAddPrevSibling(xmlNodePtr node, const xmlChar *name, const xmlChar *ns) {
     }
 
     /* TODO: add indents */
-    text = xmlNewText(xmlSecStringCR);
+    text = xmlNewText(xmlSecGetDefaultLineFeed());
     if(text == NULL) {
         xmlSecXmlError("xmlNewText", NULL);
         return(NULL);


### PR DESCRIPTION
When xmlsec creates XML nodes in the tree, it adds "\n" automatically. Functions `xmlSecSetDefaultLineFeed()` and `xmlSecGetDefaultLineFeed()` allow users to change this default functionality. I've use `xmlSecBase64GetDefaultLineSize()` and `xmlSecBase64SetDefaultLineSize()` as a template for this.

This may be necessary for some projects. For example the Brazillian government [NFE Project](https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=33ol5hhSYZk=) requires xml signatures and doesn't allow linebreaks between tags in messages. I think it would be helpful to have this function.

Please let me know if I should change something in this code to be accepted.