### PR TITLE
Revising build under MSYS2/MINGW64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,8 +73,10 @@ PRECHECK_COMMANDS = \
 else
 PRECHECK_COMMANDS= \
 	export LD_LIBRARY_PATH="$(ABS_BUILDDIR)/src/.libs:$$LD_LIBRARY_PATH" ; \
+	export PATH="$(ABS_BUILDDIR)/src/.libs:$$PATH" ; \
 	for i in $(XMLSEC_CRYPTO_LIST) ; do \
 	    export LD_LIBRARY_PATH="$(ABS_BUILDDIR)/src/$$i/.libs:$$LD_LIBRARY_PATH" ; \
+		export PATH="$(ABS_BUILDDIR)/src/$$i/.libs:$$PATH" ; \
 	done && \
 	cd $(ABS_SRCDIR) \
 	$(NULL)	

--- a/configure.ac
+++ b/configure.ac
@@ -153,13 +153,6 @@ case "${host}" in
 	XMLSEC_EXTRA_LDFLAGS="-no-undefined -avoid-version"
 	XMLSEC_CRYPTO_EXTRA_LDFLAGS="-no-undefined -avoid-version"
 	XMLSEC_SHLIBSFX=".dll.a"
-        # To avoid problem with loading of a shared library (dlopen or
-        # equivalent) at run time on some platforms we need to link
-        # everything statically (it works without hack on 9x and under
-        # emulation; on nt 5.x (w2k,xp) the error is 998: "Invalid
-        # access to memory location").
-        enable_static_linking="yes"
-        enable_crypto_dl="no"
 	;;
  *-*-cygwin*)
 	XMLSEC_EXTRA_LDFLAGS="-no-undefined"
@@ -1567,6 +1560,7 @@ AC_MSG_CHECKING(for static linking)
 AC_ARG_ENABLE(static_linking,   [  --enable-static-linking enable static linking (no)])
 if test "z$enable_static_linking" = "zyes" ; then
     XMLSEC_STATIC_BINARIES="-static"
+    XMLSEC_DEFINES="$XMLSEC_DEFINES -DXMLSEC_STATIC=1"
     AC_MSG_RESULT(yes)
 else
     AC_MSG_RESULT(no)

--- a/configure.ac
+++ b/configure.ac
@@ -975,15 +975,18 @@ if test "z$MSCRYPTO_ENABLE" = "zyes" ; then
     XMLSEC_NO_MSCRYPTO="0"
 
     MSCRYPTO_CFLAGS="$MSCRYPTO_CFLAGS -DXMLSEC_CRYPTO_MSCRYPTO=1"
-    case $host in
-	*-*-mingw*)
-		dnl since mingw crypt32 library is limited
-		dnl we use own def-file
-		MSCRYPTO_LIBS='-Wl,$(srcdir)/mingw-crypt32.def';;
-	*)
-		MSCRYPTO_LIBS="-lcrypt32";;
-    esac
-
+    if test "x$GCC" = "xyes"; then
+        MSCRYPTO_LIBS="-lcrypt32"
+    else
+        case $host in
+        *-*-mingw*)
+            dnl since mingw crypt32 library is limited
+            dnl we use own def-file
+            MSCRYPTO_LIBS='-Wl,$(srcdir)/mingw-crypt32.def';;
+        *)
+            MSCRYPTO_LIBS="-lcrypt32";;
+        esac
+    fi
     XMLSEC_CRYPTO_LIST="$XMLSEC_CRYPTO_LIST mscrypto"
 else
     XMLSEC_CRYPTO_DISABLED_LIST="$XMLSEC_CRYPTO_DISABLED_LIST mscrypto"

--- a/configure.ac
+++ b/configure.ac
@@ -1560,7 +1560,7 @@ AC_MSG_CHECKING(for static linking)
 AC_ARG_ENABLE(static_linking,   [  --enable-static-linking enable static linking (no)])
 if test "z$enable_static_linking" = "zyes" ; then
     XMLSEC_STATIC_BINARIES="-static"
-    XMLSEC_DEFINES="$XMLSEC_DEFINES -DXMLSEC_STATIC=1"
+    XMLSEC_APP_DEFINES="$XMLSEC_APP_DEFINES -DXMLSEC_STATIC -DLIBXSLT_STATIC -DLIBXML_STATIC"
     AC_MSG_RESULT(yes)
 else
     AC_MSG_RESULT(no)

--- a/include/xmlsec/exports.h
+++ b/include/xmlsec/exports.h
@@ -29,20 +29,11 @@ extern "C" {
 #      endif
      /* if a client program includes this file: */
 #    else
-#if 1
-       /* gcc fail by initialisation of global variable with error
-          (as example in .../openssl/ciphers.c):
-            "initializer element is not constant"
-          To avoid this we shouldn't use __declspec(dllimport).
-          This will enable auto-import feature. */
-#      define XMLSEC_EXPORT
-#else
-#      if !defined(XMLSEC_STATIC)
+#      if !defined(XMLSEC_STATIC) && defined(_MSC_VER)
 #        define XMLSEC_EXPORT __declspec(dllimport)
 #      else
 #        define XMLSEC_EXPORT
 #      endif
-#endif
 #    endif
    /* This holds on all other platforms/compilers, which are easier to
       handle in regard to this. */
@@ -62,7 +53,7 @@ extern "C" {
 #      endif
      /* if a client program includes this file: */
 #    else
-#      if !defined(XMLSEC_STATIC)
+#      if !defined(XMLSEC_STATIC) && defined(_MSC_VER)
 #        define XMLSEC_CRYPTO_EXPORT __declspec(dllimport)
 #      else
 #        define XMLSEC_CRYPTO_EXPORT
@@ -86,10 +77,14 @@ extern "C" {
 #      endif
      /* if we compile libxmlsec-crypto itself: */
 #    elif defined(IN_XMLSEC_CRYPTO)
+#      if !defined(XMLSEC_STATIC) && defined(_MSC_VER)
+#        define XMLSEC_EXPORT_VAR __declspec(dllexport) extern
+#      else
 #        define XMLSEC_EXPORT_VAR extern
+#      endif
      /* if a client program includes this file: */
 #    else
-#      if !defined(XMLSEC_STATIC)
+#      if !defined(XMLSEC_STATIC) && defined(_MSC_VER)
 #        define XMLSEC_EXPORT_VAR __declspec(dllimport) extern
 #      else
 #        define XMLSEC_EXPORT_VAR extern

--- a/src/gcrypt/app.c
+++ b/src/gcrypt/app.c
@@ -67,7 +67,7 @@ Noteworthy changes in version 1.4.3 (2008-09-18)
     /* NOTE configure.in defines GCRYPT_MIN_VERSION */
     if (!gcry_check_version (GCRYPT_MIN_VERSION)) {
         xmlSecGCryptError2("gcry_check_version", GPG_ERR_NO_ERROR, NULL,
-                           "min_version=%ld", (long)GCRYPT_MIN_VERSION);
+                           "min_version=%ld", (intptr_t)GCRYPT_MIN_VERSION);
         return(-1);
     }
 

--- a/src/mscrypto/private.h
+++ b/src/mscrypto/private.h
@@ -16,7 +16,7 @@
 #error "private.h file contains private xmlsec definitions and should not be used outside xmlsec or xmlsec-$crypto libraries"
 #endif /* XMLSEC_PRIVATE */
 
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && defined(_MSC_VER)
 #  include "xmlsec-mingw.h"
 #endif
 

--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -83,7 +83,10 @@ if test "z$OS_ARCH" = "zCygwin" || test "z$OS_ARCH" = "zMsys" ; then
     # Samples:
     #   Cygwin	: CYGWIN_NT-5.1
     #   Msys	: MINGW32_NT-5.1
-    if expr "$OS_KERNEL" : '.*_NT-5\.1' > /dev/null; then
+    if expr "$OS_KERNEL" : 'MINGW*' > /dev/null; then
+        # No special handling is needed on MINGW32/MINGW64
+        priv_key_suffix=""
+    elif expr "$OS_KERNEL" : '.*_NT-5\.1' > /dev/null; then
         priv_key_suffix="-winxp"
     else
         priv_key_suffix="-win"


### PR DESCRIPTION
* Udating configure.ac settings, enable dynamic linking by default
* Updating also the export section making it work both with MS VC compiler and also with gcc as well
* Correcting testrun script for tests under MSYS2/MINGW: no special handling / private key suffix is needed
* Fixing a compiler warning in gcrypt/app.c