### PR TITLE
Fix building against libxml2-2.7.8

### DIFF
--- a/src/xmlsec.c
+++ b/src/xmlsec.c
@@ -46,7 +46,10 @@ xmlSecNoXxeExternalEntityLoader(const char *URL, const char *ID,
     if (ctxt == NULL) {
         return(NULL);
     }
-    if (ctxt->input_id == 1) {
+#if LIBXML_VERSION >= 20800
+    if (ctxt->input_id == 1)
+#endif
+    {
         return xmlSecDefaultExternalEntityLoader((const char *) URL, ID, ctxt);
     }
     xmlSecXmlError2("xmlSecNoXxeExternalEntityLoader", NULL,


### PR DESCRIPTION
This fixes the build on OS X 10.8, which is still LibreOffice's baseline.

An alternative way would be that configure rejects 2.7.8 even in case it's passed in via LIBXML_CFLAGS/LIBXML_LIBS, where it currently still accepted 2.7.8 with the previous stable release (1.2.23).