### PR TITLE
configure: consider already set LIBXML_CFLAGS / LIBXML_LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,8 +226,6 @@ dnl find libxml
 dnl ==========================================================================
 LIBXML_MIN_VERSION="2.8.0"
 LIBXML_CONFIG="xml2-config"
-LIBXML_CFLAGS=""
-LIBXML_LIBS=""
 LIBXML_FOUND="no"
 AC_ARG_WITH(libxml, 
     [  --with-libxml=[PFX]       libxml2 location]
@@ -236,52 +234,64 @@ AC_ARG_WITH(libxml-src,
     [  --with-libxml-src=[PFX]   not installed yet libxml2 location]
 )
 
-if test "z$with_libxml" = "zno" -o "z$with_libxml_src" = "zno"; then 
-    AC_MSG_CHECKING(for libxml2 libraries >= $LIBXML_MIN_VERSION) 
-    AC_MSG_ERROR(libxml2 >= $LIBXML_MIN_VERSION is required for $XMLSEC_PACKAGE)
-elif test "z$with_libxml_src" != "z" ; then
-    AC_MSG_CHECKING(for libxml2 libraries >= $LIBXML_MIN_VERSION) 
-    CWD=`pwd`
-    if cd "$with_libxml_src" ; then 
-	SRC_DIR=`pwd`
-	LIBXML_CONFIG=${SRC_DIR}/xml2-config
-	LIBXML_LIBS="-L${SRC_DIR}/.libs -lxml2"
-	LIBXML_CFLAGS="-I${SRC_DIR}/include"
-	LIBXML_FOUND="yes"
-	cd $CWD
-	AC_MSG_RESULT([yes (source)])    
-    else 
-	AC_MSG_ERROR([libxml source dir not found (${with_libxml_src}), typo?])
-    fi 	
-elif test "z$with_libxml" = "z" -a "z$PKGCONFIG_FOUND" = "zyes" ; then
-    PKG_CHECK_MODULES(LIBXML, libxml-2.0 >= $LIBXML_MIN_VERSION,
-	[LIBXML_FOUND=yes],
-	[LIBXML_FOUND=no])
-fi
-if test "z$LIBXML_FOUND" = "zno" ; then
-    if test "z$with_libxml" != "zyes" ; then
-        if test "z$with_libxml" != "z" ; then
-	    AC_PATH_PROG([LIBXML_CONFIG], [$LIBXML_CONFIG], [],
-		     [$with_libxml/bin:$PATH])
-	else
-	    AC_PATH_PROG([LIBXML_CONFIG], [$LIBXML_CONFIG], [],
-		     [$PATH])
-	fi
+if test "z$LIBXML_CFLAGS" = "z" -o "z$LIBXML_LIBS" = "z"; then
+    if test "z$with_libxml" = "zno" -o "z$with_libxml_src" = "zno"; then 
+        AC_MSG_CHECKING(for libxml2 libraries >= $LIBXML_MIN_VERSION) 
+        AC_MSG_ERROR(libxml2 >= $LIBXML_MIN_VERSION is required for $XMLSEC_PACKAGE)
+    elif test "z$with_libxml_src" != "z" ; then
+        AC_MSG_CHECKING(for libxml2 libraries >= $LIBXML_MIN_VERSION) 
+        CWD=`pwd`
+        if cd "$with_libxml_src" ; then 
+            SRC_DIR=`pwd`
+            LIBXML_CONFIG=${SRC_DIR}/xml2-config
+            LIBXML_LIBS="-L${SRC_DIR}/.libs -lxml2"
+            LIBXML_CFLAGS="-I${SRC_DIR}/include"
+            LIBXML_FOUND="yes"
+            cd $CWD
+            AC_MSG_RESULT([yes (source)])    
+        else 
+            AC_MSG_ERROR([libxml source dir not found (${with_libxml_src}), typo?])
+        fi 	
+    elif test "z$with_libxml" = "z" -a "z$PKGCONFIG_FOUND" = "zyes" ; then
+        PKG_CHECK_MODULES(LIBXML, libxml-2.0 >= $LIBXML_MIN_VERSION,
+            [LIBXML_FOUND=yes],
+            [LIBXML_FOUND=no])
     fi
-    AC_MSG_CHECKING([libxml2 $LIBXML_CONFIG ])
-    if ! LIBXML_VERSION=`$LIBXML_CONFIG --version 2>/dev/null`; then
-	AC_MSG_ERROR(Could not find libxml2 anywhere.)
+    if test "z$LIBXML_FOUND" = "zno" ; then
+        if test "z$with_libxml" != "zyes" ; then
+            if test "z$with_libxml" != "z" ; then
+                AC_PATH_PROG([LIBXML_CONFIG], [$LIBXML_CONFIG], [],
+                         [$with_libxml/bin:$PATH])
+            else
+                AC_PATH_PROG([LIBXML_CONFIG], [$LIBXML_CONFIG], [],
+                         [$PATH])
+            fi
+        fi
+        AC_MSG_CHECKING([libxml2 $LIBXML_CONFIG ])
+        if ! LIBXML_VERSION=`$LIBXML_CONFIG --version 2>/dev/null`; then
+            AC_MSG_ERROR(Could not find libxml2 anywhere.)
+        fi
+        vers=`echo $LIBXML_VERSION | awk -F. '{ printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
+	minvers=`echo $LIBXML_MIN_VERSION | awk -F. '{ printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
+        if test "$vers" -ge "$minvers" ; then
+            LIBXML_LIBS="`$LIBXML_CONFIG --libs`"
+            LIBXML_CFLAGS="`$LIBXML_CONFIG --cflags`"
+            LIBXML_FOUND="yes"
+            AC_MSG_RESULT([yes ('$LIBXML_VERSION')])
+        else
+            AC_MSG_ERROR(You need at least libxml2 $LIBXML_MIN_VERSION for this version of $XMLSEC_PACKAGE)
+        fi
     fi
-    vers=`echo $LIBXML_VERSION | awk -F. '{ printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
-    minvers=`echo $LIBXML_MIN_VERSION | awk -F. '{ printf "%d", ($1 * 1000 + $2) * 1000 + $3;}'`
-    if test "$vers" -ge "$minvers" ; then
-        LIBXML_LIBS="`$LIBXML_CONFIG --libs`"
-        LIBXML_CFLAGS="`$LIBXML_CONFIG --cflags`"
-	LIBXML_FOUND="yes"
-        AC_MSG_RESULT([yes ('$LIBXML_VERSION')])
-    else
-        AC_MSG_ERROR(You need at least libxml2 $LIBXML_MIN_VERSION for this version of $XMLSEC_PACKAGE)
-    fi
+else
+    AC_MSG_CHECKING(for libxml2 libraries >= $LIBXML_MIN_VERSION)
+    minvers=`echo $LIBXML_MIN_VERSION | awk -F. '{ printf "%d", ($1 * 100 + $2) * 100 + $3;}'`
+    __save_CFLAGS="${CFLAGS}"
+    CFLAGS="${CFLAGS} ${LIBXML_CFLAGS}"
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <libxml/xmlversion.h>
+#if LIBXML_VERSION < $minvers
+#error "libxml2 is too old"
+#endif]])],AC_MSG_RESULT([OK]),AC_MSG_ERROR([You need at least libxml2 $LIBXML_MIN_VERSION for this version of $XMLSEC_PACKAGE]))
+    CFLAGS="${__save_CFLAGS}"
 fi
 
 AC_SUBST(LIBXML_CFLAGS)


### PR DESCRIPTION
If these are already set, then still check for the version, but no need
to invoke pkg-config or xml2-config.

This is an attempt to upstream the first 3 hunks of <https://github.com/LibreOffice/core/blob/master/external/libxmlsec/xmlsec1-configure.patch.1#L52>.