### PR TITLE
fix build module openssl for vs2008

### DIFF
--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -303,7 +303,7 @@ CPPFLAGS 		= /nologo
 # The compiler and its options.
 #
 CC 				= cl.exe
-CFLAGS 			= /nologo /D "WIN32" /D "_WINDOWS" 
+CFLAGS 			= /nologo /D "WIN32" /D "_WINDOWS" /D inline=__inline
 CFLAGS 			= $(CFLAGS) /D "_MBCS" /D "_REENTRANT"  /W1  
 CFLAGS 			= $(CFLAGS) /I$(BASEDIR) /I$(BASEDIR)\include
 CFLAGS 			= $(CFLAGS) /I$(INCPREFIX)


### PR DESCRIPTION
The c compiler in vs2008 does not support inline directive.
There is no other places where this directive is used, so I just remove it instead of adding macros.
