### PR TITLE
NSS: fix configure tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1091,7 +1091,7 @@ if test "z$NSPR_FOUND" = "zyes" ; then
     OLD_CPPFLAGS=$CPPFLAGS
     CPPFLAGS="$CPPFLAGS $NSPR_CFLAGS"
     AC_EGREP_CPP(greater-than-minvers, [
-        #include <nspr/prinit.h>
+        #include <prinit.h>
         #if ((PR_VMAJOR * 100 + PR_VMINOR) * 100 + PR_VPATCH) >= $minvers
         greater-than-minvers
         #endif
@@ -1110,7 +1110,7 @@ if test "z$NSS_FOUND" = "zyes" ; then
     OLD_CPPFLAGS=$CPPFLAGS
     CPPFLAGS="$CPPFLAGS $NSPR_CFLAGS $NSS_CFLAGS"
     AC_EGREP_CPP(greater-than-minvers, [
-        #include <nss/nss.h>
+        #include <nss.h>
         #if ((NSS_VMAJOR * 100 + NSS_VMINOR) * 100 + NSS_VPATCH) >= $minvers
         greater-than-minvers
         #endif


### PR DESCRIPTION
The code uses #include <prinit.h> and #include <nss.h>, so test that in
configure as well.

I build with

```./configure --with-pic --disable-shared --disable-crypto-dl --without-libxslt --without-gnutls --enable-silent-rules --without-openssl --without-gcrypt --enable-debugging```

on Linux, which implicitly enables only NSS, and without this patch the tip of master failed for me with

```At least one crypto library should exist ...```