### PR TITLE
configure: fix lost -lcrypt32 in mscrypto/mingw code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1554,7 +1554,7 @@ fi
 
 dnl Set CFLAGS/LIBS flags, do not change CFLAGS/LIBS if both are set
 if test "z$MSCRYPTO_FOUND" = "zyes" ; then
-    if test test "z$MSCRYPTO_CFLAGS" == "z" -o "z$MSCRYPTO_LIBS" = "z" ; then
+    if test "z$MSCRYPTO_CFLAGS" = "z" -o "z$MSCRYPTO_LIBS" = "z" ; then
         XMLSEC_DEFINES="$XMLSEC_DEFINES $MSCRYPTO_XMLSEC_DEFINES"
         MSCRYPTO_LIBS="$MSCRYPTO_LIBS $MSCRYPTO_LIBS_LIST"
     fi


### PR DESCRIPTION
Evaluating the condition resulted in a syntax errors, so it was always
false.

This fixes the `./configure --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --enable-mscrypto --without-openssl && make` build, which used to fail while linking.