### PR TITLE
mscrypto: fix typo in xmlSecMSCryptoAppPkcs12LoadMemory()

### DIFF
--- a/src/mscrypto/app.c
+++ b/src/mscrypto/app.c
@@ -523,7 +523,7 @@ xmlSecMSCryptoAppPkcs12LoadMemory(const xmlSecByte* data,
 
     while (1) {
         pCert = CertEnumCertificatesInStore(hCertStore, pCert);
-        if(pCert != NULL) {
+        if(pCert == NULL) {
             break;
         }
         DWORD dwData = 0;


### PR DESCRIPTION
make check-crypto-mscrypto XMLSEC_TEST_NAME="enveloping-sha256-rsa-sha256-relationship"

when invoked from a mingw build fails here. Seems to be introduced with
the last hunk of `git show fd1807670 -- src/mscrypto/app.c`.