### PR TITLE
mscrypto: work around persistence problem for the testsuite

### DIFF
--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -656,6 +656,17 @@ static xmlSecAppCmdLineParam pkcs12Param = {
     NULL
 };
 
+static xmlSecAppCmdLineParam pkcs12PersistParam = {
+    xmlSecAppCmdLineTopicKeysMngr,
+    "--pkcs12-persist",
+    NULL,
+    "--pkcs12-persist"
+    "\n\tpersist loaded private key",
+    xmlSecAppCmdLineParamTypeFlag,
+    xmlSecAppCmdLineParamFlagNone,
+    NULL
+};
+
 static xmlSecAppCmdLineParam pubkeyCertParam = { 
     xmlSecAppCmdLineTopicKeysMngr,
     "--pubkey-cert-pem",
@@ -819,6 +830,7 @@ static xmlSecAppCmdLineParamPtr parameters[] = {
     &pwdParam,
 #ifndef XMLSEC_NO_X509
     &pkcs12Param,
+    &pkcs12PersistParam,
     &pubkeyCertParam,
     &pubkeyCertDerParam,
     &trustedParam,
@@ -2086,6 +2098,9 @@ xmlSecAppLoadKeys(void) {
 
 #ifndef XMLSEC_NO_X509
     /* read all pkcs12 files */
+    if(xmlSecAppCmdLineParamIsSet(&pkcs12PersistParam)) {
+        xmlSecImportSetPersistKey();
+    }
     for(value = pkcs12Param.value; value != NULL; value = value->next) {
         if(value->strValue == NULL) {
             fprintf(stderr, "Error: invalid value for option \"%s\".\n", pkcs12Param.fullName);

--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -829,6 +829,10 @@ struct _xmlSecKeyDataStoreKlass {
 #define xmlSecKeyDataStorePtrListId     xmlSecKeyDataStorePtrListGetKlass()
 XMLSEC_EXPORT xmlSecPtrListId   xmlSecKeyDataStorePtrListGetKlass       (void);
 
+#ifdef XMLSEC_PRIVATE
+XMLSEC_EXPORT void xmlSecImportSetPersistKey                            (void);
+XMLSEC_EXPORT int xmlSecImportGetPersistKey                             (void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/keysdata.c
+++ b/src/keysdata.c
@@ -32,6 +32,7 @@
  *
  *************************************************************************/
 static xmlSecPtrList xmlSecAllKeyDataIds;
+static int xmlSecImportPersistKey = 0;
 
 /**
  * xmlSecKeyDataIdsGet:
@@ -1287,4 +1288,11 @@ xmlSecKeyDataStorePtrListGetKlass(void) {
     return(&xmlSecKeyDataStorePtrListKlass);
 }
 
+void xmlSecImportSetPersistKey(void) {
+    xmlSecImportPersistKey = 1;
+}
+
+int xmlSecImportGetPersistKey(void) {
+    return xmlSecImportPersistKey;
+}
 

--- a/src/mscrypto/app.c
+++ b/src/mscrypto/app.c
@@ -18,6 +18,7 @@
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/errors.h>
+#include <xmlsec/keysdata.h>
 
 #include <xmlsec/mscrypto/app.h>
 #include <xmlsec/mscrypto/crypto.h>
@@ -509,7 +510,11 @@ xmlSecMSCryptoAppPkcs12LoadMemory(const xmlSecByte* data,
         goto done;
     }
 
-    hCertStore = PFXImportCertStore(&pfx, wcPwd, CRYPT_EXPORTABLE | PKCS12_NO_PERSIST_KEY);
+    DWORD dwFlags = CRYPT_EXPORTABLE;
+    if (!xmlSecImportGetPersistKey()) {
+        dwFlags |= PKCS12_NO_PERSIST_KEY;
+    }
+    hCertStore = PFXImportCertStore(&pfx, wcPwd, dwFlags);
     if (NULL == hCertStore) {
         xmlSecMSCryptoError("PFXImportCertStore", NULL);
         goto done;

--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -75,6 +75,13 @@ else
     pub_key_format="der"
 fi
 
+#
+# Need to force persistence for mscrypto
+#
+if [ "z$crypto" = "zmscrypto" ] ; then
+    priv_key_option="--pkcs12-persist $priv_key_option"
+fi
+
 # On Windows, one needs to specify Crypto Service Provider (CSP)
 # in the pkcs12 file to ensure it is loaded correctly to be used
 # with SHA2 algorithms. Worse, the CSP is different for XP and older 


### PR DESCRIPTION
make check-crypto-mscrypto wants to have persistent private keys when
dealing with password-protected .p12 files, as discussed in the mailing
list thread at
<https://www.aleksey.com/pipermail/xmlsec/2017/010226.html>.

Enabling them by default would be problematic though, see commit
c098aed450a8ae272efad1fdeaa2450b67a2f46f (don't create files on
xmlsec-mscrypto when loading the key (bug #633924), 2014-05-23).

Try to please both use-cases by setting an environment variable as part
of 'make check-crypto-mscrypto', and then reacting to that in the
mscrypto backend.