### PR TITLE
nmake: fix testsuite invocation for the mscrypto backend

### DIFF
--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -473,21 +473,21 @@ check-keys : $(BINDIR)\$(APP_NAME)
 	cd ..
 	if not exist win32\tmp mkdir win32\tmp
 	set TMPFOLDER=win32/tmp
-	sh ./tests/testrun.sh ./tests/testKeys.sh default ./tests win32/$(BINDIR)/$(APP_NAME) der
+	sh ./tests/testrun.sh ./tests/testKeys.sh "$(WITH_DEFAULT_CRYPTO)" ./tests win32/$(BINDIR)/$(APP_NAME) der
 	cd win32
 
 check-dsig : $(BINDIR)\$(APP_NAME)	
 	cd ..
 	if not exist win32\tmp mkdir win32\tmp
 	set TMPFOLDER=win32/tmp
-	sh ./tests/testrun.sh ./tests/testDSig.sh default ./tests win32/$(BINDIR)/$(APP_NAME) der
+	sh ./tests/testrun.sh ./tests/testDSig.sh "$(WITH_DEFAULT_CRYPTO)" ./tests win32/$(BINDIR)/$(APP_NAME) der
 	cd win32
 
 check-enc : $(BINDIR)\$(APP_NAME)
 	cd ..
 	if not exist win32\tmp mkdir win32\tmp
 	set TMPFOLDER=win32/tmp
-	sh ./tests/testrun.sh ./tests/testEnc.sh default ./tests win32/$(BINDIR)/$(APP_NAME) der
+	sh ./tests/testrun.sh ./tests/testEnc.sh "$(WITH_DEFAULT_CRYPTO)" ./tests win32/$(BINDIR)/$(APP_NAME) der
 	cd win32
 
 clean :


### PR DESCRIPTION
"default" does not apply the needed --pkcs12-persist flag, "mscrypto"
does, so resolve the default at an nmake level, not inside the xmlsec
app.

(This is the last bit to get testsuite working for MSVC-built binaries, I think -- previously I ran 'make check' in a mingw tree with manually copied in MSVC-built binaries.)