### PR TITLE
MS CNG: adopt trusted certificate

### DIFF
--- a/include/xmlsec/mscng/crypto.h
+++ b/include/xmlsec/mscng/crypto.h
@@ -32,6 +32,35 @@ XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngKeysMngrInit      (xmlSecKeys
 
 /********************************************************************
  *
+ * ECDSA transforms
+ *
+ *******************************************************************/
+#ifndef XMLSEC_NO_ECDSA
+
+/**
+ * xmlSecMSCngKeyDataEcdsaId:
+ *
+ * The ECDSA key klass.
+ */
+#define xmlSecMSCngKeyDataEcdsaId \
+        xmlSecMSCngKeyDataEcdsaGetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId xmlSecMSCngKeyDataEcdsaGetKlass(void);
+
+#ifndef XMLSEC_NO_SHA256
+/**
+ * xmlSecMSCngTransformEcdsaSha256Id:
+ *
+ * The ECDSA-SHA256 signature transform klass.
+ */
+#define xmlSecMSCngTransformEcdsaSha256Id     \
+       xmlSecMSCngTransformEcdsaSha256GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformEcdsaSha256GetKlass(void);
+#endif /* XMLSEC_NO_SHA256 */
+
+#endif /* XMLSEC_NO_ECDSA */
+
+/********************************************************************
+ *
  * SHA256 transform
  *
  *******************************************************************/

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -28,6 +28,15 @@ extern "C" {
         xmlSecMSCngKeyDataX509GetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId    xmlSecMSCngKeyDataX509GetKlass(void);
 
+/**
+ * xmlSecMSCngX509StoreId:
+ *
+ * The MSCng X509 store klass.
+ */
+#define xmlSecMSCngX509StoreId \
+        xmlSecMSCngX509StoreGetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecKeyDataStoreId xmlSecMSCngX509StoreGetKlass(void);
+
 #endif /* XMLSEC_NO_X509 */
 
 #ifdef __cplusplus

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -19,6 +19,8 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 
+#include <windows.h>
+
 /**
  * xmlSecMSCngKeyDataX509Id:
  *
@@ -36,6 +38,10 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId    xmlSecMSCngKeyDataX509GetKlass(void);
 #define xmlSecMSCngX509StoreId \
         xmlSecMSCngX509StoreGetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataStoreId xmlSecMSCngX509StoreGetKlass(void);
+
+XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptCert        (xmlSecKeyDataStorePtr store,
+                                                                              PCCERT_CONTEXT cert,
+                                                                              xmlSecKeyDataType type);
 
 #endif /* XMLSEC_NO_X509 */
 

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -1,0 +1,37 @@
+/*
+ * XML Security Library (http://www.aleksey.com/xmlsec).
+ *
+ * This is free software; see Copyright file in the source
+ * distribution for preciese wording.
+ *
+ * Copyright (C) 2018 Miklos Vajna <vmiklos@vmiklos.hu>. All Rights Reserved.
+ */
+#ifndef __XMLSEC_MSCNG_X509_H__
+#define __XMLSEC_MSCNG_X509_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifndef XMLSEC_NO_X509
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/transforms.h>
+
+/**
+ * xmlSecMSCngKeyDataX509Id:
+ *
+ * The MSCng X509 data klass.
+ */
+#define xmlSecMSCngKeyDataX509Id \
+        xmlSecMSCngKeyDataX509GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId    xmlSecMSCngKeyDataX509GetKlass(void);
+
+#endif /* XMLSEC_NO_X509 */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __XMLSEC_MSCNG_X509_H__ */

--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -218,13 +218,38 @@ int
 xmlSecMSCngAppKeysMngrCertLoad(xmlSecKeysMngrPtr mngr, const char *filename,
                                xmlSecKeyDataFormat format,
                                xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+    xmlSecBuffer buffer;
+    int ret;
+
     xmlSecAssert2(mngr != NULL, -1);
     xmlSecAssert2(filename != NULL, -1);
     xmlSecAssert2(format != xmlSecKeyDataFormatUnknown, -1);
 
-    /* TODO: load cert and add to keys manager */
-    xmlSecNotImplementedError(NULL);
-    return(-1);
+    ret = xmlSecBufferInitialize(&buffer, 0);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecBufferInitialize", NULL);
+        return(-1);
+    }
+
+    ret = xmlSecBufferReadFile(&buffer, filename);
+    if(ret < 0) {
+        xmlSecInternalError2("xmlSecBufferReadFile", NULL,
+                             "filename=%s", xmlSecErrorsSafeString(filename));
+        xmlSecBufferFinalize(&buffer);
+        return(-1);
+    }
+
+    ret = xmlSecMSCngAppKeysMngrCertLoadMemory(mngr, xmlSecBufferGetData(&buffer),
+        xmlSecBufferGetSize(&buffer), format, type);
+    if (ret < 0) {
+        xmlSecInternalError2("xmlSecMSCngAppKeysMngrCertLoadMemory", NULL,
+                             "filename=%s", xmlSecErrorsSafeString(filename));
+        xmlSecBufferFinalize(&buffer);
+        return(-1);
+    }
+
+    xmlSecBufferFinalize(&buffer);
+    return(ret);
 }
 
 /**

--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -293,8 +293,7 @@ xmlSecMSCngAppKeysMngrCertLoadMemory(xmlSecKeysMngrPtr mngr, const xmlSecByte* d
                 data,
                 dataSize);
             if(pCert == NULL) {
-                /* TODO implement a xmlSecMSCngError() */
-                xmlSecInternalError("CertCreateCertificateContext", NULL);
+                xmlSecMSCngLastError("CertCreateCertificateContext", NULL)
                 return(-1);
             }
             break;

--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -16,9 +16,12 @@
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/errors.h>
+#include <xmlsec/keysmngr.h>
 
 #include <xmlsec/mscng/app.h>
 #include <xmlsec/mscng/crypto.h>
+#include <xmlsec/mscng/symbols.h>
+#include <xmlsec/mscng/x509.h>
 
 /**
  * xmlSecMSCngAppInit:
@@ -269,12 +272,21 @@ int
 xmlSecMSCngAppKeysMngrCertLoadMemory(xmlSecKeysMngrPtr mngr, const xmlSecByte* data,
                                      xmlSecSize dataSize, xmlSecKeyDataFormat format,
                                      xmlSecKeyDataType type) {
+    xmlSecKeyDataStorePtr x509Store;
+    int ret;
+
     xmlSecAssert2(mngr != NULL, -1);
     xmlSecAssert2(data != NULL, -1);
     xmlSecAssert2(format != xmlSecKeyDataFormatUnknown, -1);
 
-    /* TODO: load cert and add to keys manager */
+    x509Store = xmlSecKeysMngrGetDataStore(mngr, xmlSecMSCngX509StoreId);
+    if(x509Store == NULL) {
+        xmlSecInternalError("xmlSecKeysMngrGetDataStore(xmlSecMSCngX509StoreId)", NULL);
+        return(-1);
+    }
+
     xmlSecNotImplementedError(NULL);
+
     return(-1);
 }
 

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -1,0 +1,152 @@
+/*
+ * XML Security Library (http://www.aleksey.com/xmlsec).
+ *
+ * This is free software; see Copyright file in the source
+ * distribution for preciese wording.
+ *
+ * Copyright (C) 2018 Miklos Vajna <vmiklos@vmiklos.hu>. All Rights Reserved.
+ */
+#include "globals.h"
+
+#include <string.h>
+
+#include <windows.h>
+#include <ncrypt.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/xmltree.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/keyinfo.h>
+#include <xmlsec/transforms.h>
+#include <xmlsec/errors.h>
+#include <xmlsec/bn.h>
+
+#include <xmlsec/mscng/crypto.h>
+
+typedef struct _xmlSecMSCngKeyDataCtx xmlSecMSCngKeyDataCtx,
+                                      *xmlSecMSCngKeyDataCtxPtr;
+
+struct _xmlSecMSCngKeyDataCtx {
+    NCRYPT_KEY_HANDLE hKey;
+};
+
+#define xmlSecMSCngKeyDataSize       \
+    (sizeof(xmlSecKeyData) + sizeof(xmlSecMSCngKeyDataCtx))
+#define xmlSecMSCngKeyDataGetCtx(data) \
+    ((xmlSecMSCngKeyDataCtxPtr)(((xmlSecByte*)(data)) + sizeof(xmlSecKeyData)))
+
+#ifndef XMLSEC_NO_ECDSA
+static int
+xmlSecMSCngKeyDataEcdsaInitialize(xmlSecKeyDataPtr data) {
+    xmlSecMSCngKeyDataCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId), -1);
+    ctx = xmlSecMSCngKeyDataGetCtx(data);
+    xmlSecAssert2(ctx != NULL, -1);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static int
+xmlSecMSCngKeyDataEcdsaDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
+    xmlSecAssert2(xmlSecKeyDataCheckId(dst, xmlSecMSCngKeyDataEcdsaId), -1);
+    xmlSecAssert2(xmlSecKeyDataCheckId(src, xmlSecMSCngKeyDataEcdsaId), -1);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static void
+xmlSecMSCngKeyDataEcdsaFinalize(xmlSecKeyDataPtr data) {
+    xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId));
+}
+
+static xmlSecKeyDataType
+xmlSecMSCngKeyDataEcdsaGetType(xmlSecKeyDataPtr data) {
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId), 0);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(xmlSecKeyDataTypeUnknown);
+}
+
+static xmlSecSize
+xmlSecMSCngKeyDataEcdsaGetSize(xmlSecKeyDataPtr data) {
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId), 0);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(0);
+}
+
+
+static void
+xmlSecMSCngKeyDataEcdsaDebugDump(xmlSecKeyDataPtr data, FILE* output) {
+    xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId));
+    xmlSecAssert(output != NULL);
+
+    fprintf(output, "=== rsa key: size = %d\n",
+            xmlSecMSCngKeyDataEcdsaGetSize(data));
+}
+
+static void xmlSecMSCngKeyDataEcdsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* output) {
+    xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId));
+    xmlSecAssert(output != NULL);
+
+    fprintf(output, "<ECDSAKeyValue size=\"%d\" />\n",
+            xmlSecMSCngKeyDataEcdsaGetSize(data));
+}
+
+static xmlSecKeyDataKlass xmlSecMSCngKeyDataEcdsaKlass = {
+    sizeof(xmlSecKeyDataKlass),
+    xmlSecMSCngKeyDataSize,
+
+    /* data */
+    xmlSecNameECDSAKeyValue,
+    xmlSecKeyDataUsageKeyValueNode | xmlSecKeyDataUsageRetrievalMethodNodeXml,
+                                                /* xmlSecKeyDataUsage usage; */
+    xmlSecHrefECDSAKeyValue,                    /* const xmlChar* href; */
+    xmlSecNodeECDSAKeyValue,                    /* const xmlChar* dataNodeName; */
+    xmlSecDSigNs,                               /* const xmlChar* dataNodeNs; */
+
+    /* constructors/destructor */
+    xmlSecMSCngKeyDataEcdsaInitialize,          /* xmlSecKeyDataInitializeMethod initialize; */
+    xmlSecMSCngKeyDataEcdsaDuplicate,           /* xmlSecKeyDataDuplicateMethod duplicate; */
+    xmlSecMSCngKeyDataEcdsaFinalize,            /* xmlSecKeyDataFinalizeMethod finalize; */
+    NULL,                                       /* xmlSecKeyDataGenerateMethod generate; */
+
+    /* get info */
+    xmlSecMSCngKeyDataEcdsaGetType,             /* xmlSecKeyDataGetTypeMethod getType; */
+    xmlSecMSCngKeyDataEcdsaGetSize,             /* xmlSecKeyDataGetSizeMethod getSize; */
+    NULL,                                       /* xmlSecKeyDataGetIdentifier getIdentifier; */
+
+    /* read/write */
+    NULL,                                       /* xmlSecKeyDataXmlReadMethod xmlRead; */
+    NULL,                                       /* xmlSecKeyDataXmlWriteMethod xmlWrite; */
+    NULL,                                       /* xmlSecKeyDataBinReadMethod binRead; */
+    NULL,                                       /* xmlSecKeyDataBinWriteMethod binWrite; */
+
+    /* debug */
+    xmlSecMSCngKeyDataEcdsaDebugDump,           /* xmlSecKeyDataDebugDumpMethod debugDump; */
+    xmlSecMSCngKeyDataEcdsaDebugXmlDump,        /* xmlSecKeyDataDebugDumpMethod debugXmlDump; */
+
+    /* reserved for the future */
+    NULL,                                       /* void* reserved0; */
+    NULL,                                       /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngKeyDataEcdsaGetKlass:
+ *
+ * The MSCng ECDSA CertKey data klass.
+ *
+ * Returns: pointer to MSCng ECDSA key data klass.
+ */
+xmlSecKeyDataId
+xmlSecMSCngKeyDataEcdsaGetKlass(void) {
+    return(&xmlSecMSCngKeyDataEcdsaKlass);
+}
+#endif /* XMLSEC_NO_ECDSA */

--- a/src/mscng/crypto.c
+++ b/src/mscng/crypto.c
@@ -98,7 +98,7 @@ xmlSecCryptoGetFunctions_mscng(void) {
      * Key data store ids
      *
      ********************************************************************/
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_X509
     gXmlSecMSCngFunctions->x509StoreGetKlass                    = xmlSecMSCngX509StoreGetKlass;
 #endif /* XMLSEC_NO_X509 */
 
@@ -287,9 +287,29 @@ xmlSecMSCngShutdown(void) {
  */
 int
 xmlSecMSCngKeysMngrInit(xmlSecKeysMngrPtr mngr) {
+    int ret;
     xmlSecAssert2(mngr != NULL, -1);
 
-    /* TODO: add key data stores */
+#ifndef XMLSEC_NO_X509
+    /* create x509 store if needed */
+    if(xmlSecKeysMngrGetDataStore(mngr, xmlSecMSCngX509StoreId) == NULL) {
+        xmlSecKeyDataStorePtr x509Store;
+
+        x509Store = xmlSecKeyDataStoreCreate(xmlSecMSCngX509StoreId);
+        if(x509Store == NULL) {
+            xmlSecInternalError("xmlSecKeyDataStoreCreate(xmlSecMSCngX509StoreId)", NULL);
+            return(-1);
+        }
+
+        ret = xmlSecKeysMngrAdoptDataStore(mngr, x509Store);
+        if(ret < 0) {
+            xmlSecInternalError("xmlSecKeysMngrAdoptDataStore", NULL);
+            xmlSecKeyDataStoreDestroy(x509Store);
+            return(-1);
+        }
+    }
+#endif /* XMLSEC_NO_X509 */
+
     return(0);
 }
 

--- a/src/mscng/crypto.c
+++ b/src/mscng/crypto.c
@@ -21,6 +21,7 @@
 
 #include <xmlsec/mscng/app.h>
 #include <xmlsec/mscng/crypto.h>
+#include <xmlsec/mscng/x509.h>
 
 static xmlSecCryptoDLFunctionsPtr gXmlSecMSCngFunctions = NULL;
 
@@ -68,7 +69,7 @@ xmlSecCryptoGetFunctions_mscng(void) {
     gXmlSecMSCngFunctions->keyDataDsaGetKlass           = xmlSecMSCngKeyDataDsaGetKlass;
 #endif /* XMLSEC_NO_DSA */
 
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_ECDSA
     gXmlSecMSCngFunctions->keyDataEcdsaGetKlass         = xmlSecMSCngKeyDataEcdsaGetKlass;
 #endif /* XMLSEC_NO_ECDSA */
 
@@ -85,9 +86,11 @@ xmlSecCryptoGetFunctions_mscng(void) {
     gXmlSecMSCngFunctions->keyDataRsaGetKlass           = xmlSecMSCngKeyDataRsaGetKlass;
 #endif /* XMLSEC_NO_RSA */
 
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_X509
     gXmlSecMSCngFunctions->keyDataX509GetKlass                  = xmlSecMSCngKeyDataX509GetKlass;
+#ifdef XMLSEC_MSCNG_TODO
     gXmlSecMSCngFunctions->keyDataRawX509CertGetKlass           = xmlSecMSCngKeyDataRawX509CertGetKlass;
+#endif
 #endif /* XMLSEC_NO_X509 */
 
     /********************************************************************
@@ -145,7 +148,7 @@ xmlSecCryptoGetFunctions_mscng(void) {
     gXmlSecMSCngFunctions->transformEcdsaSha224GetKlass         = xmlSecMSCngTransformEcdsaSha224GetKlass;
 #endif /* XMLSEC_NO_SHA224 */
 
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_SHA256
     gXmlSecMSCngFunctions->transformEcdsaSha256GetKlass         = xmlSecMSCngTransformEcdsaSha256GetKlass;
 #endif /* XMLSEC_NO_SHA256 */
 

--- a/src/mscng/digests.c
+++ b/src/mscng/digests.c
@@ -10,7 +10,10 @@
 
 #include <string.h>
 
+#define WIN32_NO_STATUS
 #include <windows.h>
+#undef WIN32_NO_STATUS
+#include <ntstatus.h>
 #include <bcrypt.h>
 
 #include <xmlsec/xmlsec.h>
@@ -192,7 +195,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
             ctx->pszAlgId,
             NULL,
             0);
-        if(status != 0) {
+        if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptOpenAlgorithmProvider", xmlSecTransformGetName(transform), status);
             return(-1);
         }
@@ -205,7 +208,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
             sizeof(DWORD),
             &cbData,
             0);
-        if(status != 0) {
+        if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptGetProperty", xmlSecTransformGetName(transform), status);
             return(-1);
         }
@@ -225,7 +228,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
             sizeof(DWORD),
             &cbData,
             0);
-        if(status != 0) {
+        if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptGetProperty", xmlSecTransformGetName(transform), status);
             return(-1);
         }
@@ -246,7 +249,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
             NULL,
             0,
             0);
-        if(status != 0) {
+        if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptCreateHash", xmlSecTransformGetName(transform), status);
             return(-1);
         }
@@ -265,7 +268,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
                 (PBYTE)xmlSecBufferGetData(in),
                 inSize,
                 0);
-            if(status != 0) {
+            if(status != STATUS_SUCCESS) {
                 xmlSecMSCngNtError("BCryptHashData", xmlSecTransformGetName(transform), status);
                 return(-1);
             }
@@ -285,7 +288,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
                 ctx->pbHash,
                 ctx->cbHash,
                 0);
-            if(status < 0) {
+            if(status != STATUS_SUCCESS) {
                 xmlSecMSCngNtError("BCryptFinishHash", xmlSecTransformGetName(transform), status);
                 return(-1);
             }

--- a/src/mscng/globals.h
+++ b/src/mscng/globals.h
@@ -24,4 +24,41 @@
 /* Include common error helper macros. */
 #include "../errors_helpers.h"
 
+/**
+ * xmlSecMSCngLastError:
+ * @errorFunction:      the failed function name.
+ * @errorObject:        the error specific error object (e.g. transform, key data, etc).
+ *
+ * Macro. The XMLSec library macro for reporting crypro errors from GetLastError().
+ */
+#define xmlSecMSCngLastError(errorFunction, errorObject) \
+    {                                                    \
+        DWORD dwError = GetLastError();                  \
+        xmlSecError(XMLSEC_ERRORS_HERE,                  \
+                    (const char*)(errorObject),          \
+                    (errorFunction),                     \
+                    XMLSEC_ERRORS_R_CRYPTO_FAILED,       \
+                    "MSCng last error: 0x%08lx",         \
+                    (long int)dwError                    \
+        );                                               \
+    }
+
+/**
+ * xmlSecMSCngNtError:
+ * @errorFunction:      the failed function name.
+ * @errorObject:        the error specific error object (e.g. transform, key data, etc).
+ *
+ * Macro. The XMLSec library macro for reporting crypro errors from NTSTATUS.
+ */
+#define xmlSecMSCngNtError(errorFunction, errorObject, status) \
+    {                                                          \
+        xmlSecError(XMLSEC_ERRORS_HERE,                        \
+                    (const char*)(errorObject),                \
+                    (errorFunction),                           \
+                    XMLSEC_ERRORS_R_CRYPTO_FAILED,             \
+                    "MSCng NTSTATUS: 0x%08lx",                 \
+                    (long int)(status)                         \
+        );                                                     \
+    }
+
 #endif /* ! __XMLSEC_GLOBALS_H__ */

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -1,0 +1,265 @@
+/*
+ * XML Security Library (http://www.aleksey.com/xmlsec).
+ *
+ * This is free software; see Copyright file in the source
+ * distribution for preciese wording.
+ *
+ * Copyright (C) 2018 Miklos Vajna <vmiklos@vmiklos.hu>. All Rights Reserved.
+ */
+#include "globals.h"
+
+#include <string.h>
+
+#include <windows.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/transforms.h>
+#include <xmlsec/errors.h>
+
+#include <xmlsec/mscng/crypto.h>
+
+/**************************************************************************
+ *
+ * Internal MSCng signatures ctx
+ *
+ *****************************************************************************/
+typedef struct _xmlSecMSCngSignatureCtx      xmlSecMSCngSignatureCtx,
+                                             *xmlSecMSCngSignatureCtxPtr;
+struct _xmlSecMSCngSignatureCtx {
+    xmlSecKeyDataPtr    data;
+    xmlSecKeyDataId     keyId;
+    LPCWSTR pszHashAlgId;
+};
+
+/******************************************************************************
+ *
+ * Signature transforms
+ *
+ * xmlSecMSCngSignatureCtx is located after xmlSecTransform
+ *
+ *****************************************************************************/
+#define xmlSecMSCngSignatureSize     \
+    (sizeof(xmlSecTransform) + sizeof(xmlSecMSCngSignatureCtx))
+#define xmlSecMSCngSignatureGetCtx(transform) \
+    ((xmlSecMSCngSignatureCtxPtr)(((xmlSecByte*)(transform)) + sizeof(xmlSecTransform)))
+
+static int      xmlSecMSCngSignatureCheckId             (xmlSecTransformPtr transform);
+static int      xmlSecMSCngSignatureInitialize          (xmlSecTransformPtr transform);
+static void     xmlSecMSCngSignatureFinalize            (xmlSecTransformPtr transform);
+static int      xmlSecMSCngSignatureSetKeyReq           (xmlSecTransformPtr transform,
+                                                         xmlSecKeyReqPtr keyReq);
+static int      xmlSecMSCngSignatureSetKey              (xmlSecTransformPtr transform,
+                                                         xmlSecKeyPtr key);
+static int      xmlSecMSCngSignatureVerify              (xmlSecTransformPtr transform,
+                                                         const xmlSecByte* data,
+                                                         xmlSecSize dataSize,
+                                                         xmlSecTransformCtxPtr transformCtx);
+static int      xmlSecMSCngSignatureExecute             (xmlSecTransformPtr transform,
+                                                         int last,
+                                                         xmlSecTransformCtxPtr transformCtx);
+
+
+static int xmlSecMSCngSignatureCheckId(xmlSecTransformPtr transform) {
+
+#ifndef XMLSEC_NO_ECDSA
+
+#ifndef XMLSEC_NO_SHA256
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha256Id)) {
+       return(1);
+    } else
+#endif /* XMLSEC_NO_SHA256 */
+
+#endif /* XMLSEC_NO_ECDSA */
+
+    /* not found */
+    return(0);
+}
+
+static int xmlSecMSCngSignatureInitialize(xmlSecTransformPtr transform) {
+    xmlSecMSCngSignatureCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
+    xmlSecAssert2(xmlSecTransformCheckSize(transform, xmlSecMSCngSignatureSize), -1);
+
+    ctx = xmlSecMSCngSignatureGetCtx(transform);
+    xmlSecAssert2(ctx != NULL, -1);
+
+    memset(ctx, 0, sizeof(xmlSecMSCngSignatureCtx));
+
+#ifndef XMLSEC_NO_ECDSA
+
+#ifndef XMLSEC_NO_SHA256
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha256Id)) {
+        ctx->pszHashAlgId = BCRYPT_SHA256_ALGORITHM;
+        ctx->keyId = xmlSecMSCngKeyDataEcdsaId;
+    } else
+#endif /* XMLSEC_NO_SHA256 */
+
+#endif /* XMLSEC_NO_ECDSA */
+
+    /* not found */
+    {
+        xmlSecInvalidTransfromError(transform)
+        return(-1);
+    }
+
+    return(0);
+}
+
+static void xmlSecMSCngSignatureFinalize(xmlSecTransformPtr transform) {
+    xmlSecMSCngSignatureCtxPtr ctx;
+
+    xmlSecAssert(xmlSecMSCngSignatureCheckId(transform));
+    xmlSecAssert(xmlSecTransformCheckSize(transform, xmlSecMSCngSignatureSize));
+
+    ctx = xmlSecMSCngSignatureGetCtx(transform);
+    xmlSecAssert(ctx != NULL);
+
+    if(ctx->data != NULL)  {
+        xmlSecKeyDataDestroy(ctx->data);
+    }
+
+    memset(ctx, 0, sizeof(xmlSecMSCngSignatureCtx));
+}
+
+static int xmlSecMSCngSignatureSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
+    xmlSecMSCngSignatureCtxPtr ctx;
+    xmlSecKeyDataPtr value;
+
+    xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
+    xmlSecAssert2((transform->operation == xmlSecTransformOperationSign) || (transform->operation == xmlSecTransformOperationVerify), -1);
+    xmlSecAssert2(xmlSecTransformCheckSize(transform, xmlSecMSCngSignatureSize), -1);
+    xmlSecAssert2(key != NULL, -1);
+
+    ctx = xmlSecMSCngSignatureGetCtx(transform);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->keyId != NULL, -1);
+    xmlSecAssert2(ctx->pszHashAlgId != 0, -1);
+    xmlSecAssert2(xmlSecKeyCheckId(key, ctx->keyId), -1);
+
+    value = xmlSecKeyGetValue(key);
+    xmlSecAssert2(value != NULL, -1);
+
+    ctx->data = xmlSecKeyDataDuplicate(value);
+    if(ctx->data == NULL) {
+        xmlSecInternalError("xmlSecKeyDataDuplicate",
+                            xmlSecTransformGetName(transform));
+        return(-1);
+    }
+
+    return(0);
+}
+
+static int xmlSecMSCngSignatureSetKeyReq(xmlSecTransformPtr transform,  xmlSecKeyReqPtr keyReq) {
+    xmlSecMSCngSignatureCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
+    xmlSecAssert2((transform->operation == xmlSecTransformOperationSign) || (transform->operation == xmlSecTransformOperationVerify), -1);
+    xmlSecAssert2(xmlSecTransformCheckSize(transform, xmlSecMSCngSignatureSize), -1);
+    xmlSecAssert2(keyReq != NULL, -1);
+
+    ctx = xmlSecMSCngSignatureGetCtx(transform);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->keyId != NULL, -1);
+
+    keyReq->keyId        = ctx->keyId;
+    if(transform->operation == xmlSecTransformOperationSign) {
+        keyReq->keyType  = xmlSecKeyDataTypePrivate;
+        keyReq->keyUsage = xmlSecKeyUsageSign;
+    } else {
+        keyReq->keyType  = xmlSecKeyDataTypePublic;
+        keyReq->keyUsage = xmlSecKeyUsageVerify;
+    }
+    return(0);
+}
+
+static int xmlSecMSCngSignatureVerify(xmlSecTransformPtr transform,
+                                      const xmlSecByte* data,
+                                      xmlSecSize dataSize,
+                                      xmlSecTransformCtxPtr transformCtx) {
+    xmlSecMSCngSignatureCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
+    xmlSecAssert2(transform->operation == xmlSecTransformOperationVerify, -1);
+    xmlSecAssert2(xmlSecTransformCheckSize(transform, xmlSecMSCngSignatureSize), -1);
+    xmlSecAssert2(transform->status == xmlSecTransformStatusFinished, -1);
+    xmlSecAssert2(data != NULL, -1);
+    xmlSecAssert2(dataSize > 0, -1);
+    xmlSecAssert2(transformCtx != NULL, -1);
+
+    ctx = xmlSecMSCngSignatureGetCtx(transform);
+    xmlSecAssert2(ctx != NULL, -1);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static int
+xmlSecMSCngSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTransformCtxPtr transformCtx) {
+    xmlSecMSCngSignatureCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
+    xmlSecAssert2((transform->operation == xmlSecTransformOperationSign) || (transform->operation == xmlSecTransformOperationVerify), -1);
+    xmlSecAssert2(xmlSecTransformCheckSize(transform, xmlSecMSCngSignatureSize), -1);
+    xmlSecAssert2(transformCtx != NULL, -1);
+
+    ctx = xmlSecMSCngSignatureGetCtx(transform);
+    xmlSecAssert2(ctx != NULL, -1);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+
+#ifndef XMLSEC_NO_ECDSA
+
+#ifndef XMLSEC_NO_SHA256
+/****************************************************************************
+ *
+ * ECDSA-SHA256 signature transform
+ *
+ ***************************************************************************/
+static xmlSecTransformKlass xmlSecMSCngEcdsaSha256Klass = {
+    /* klass/object sizes */
+    sizeof(xmlSecTransformKlass),              /* xmlSecSize klassSize */
+    xmlSecMSCngSignatureSize,                  /* xmlSecSize objSize */
+
+    xmlSecNameEcdsaSha256,                     /* const xmlChar* name; */
+    xmlSecHrefEcdsaSha256,                     /* const xmlChar* href; */
+    xmlSecTransformUsageSignatureMethod,       /* xmlSecTransformUsage usage; */
+
+    xmlSecMSCngSignatureInitialize,            /* xmlSecTransformInitializeMethod initialize; */
+    xmlSecMSCngSignatureFinalize,              /* xmlSecTransformFinalizeMethod finalize; */
+    NULL,                                      /* xmlSecTransformNodeReadMethod readNode; */
+    NULL,                                      /* xmlSecTransformNodeWriteMethod writeNode; */
+    xmlSecMSCngSignatureSetKeyReq,             /* xmlSecTransformSetKeyReqMethod setKeyReq; */
+    xmlSecMSCngSignatureSetKey,                /* xmlSecTransformSetKeyMethod setKey; */
+    xmlSecMSCngSignatureVerify,                /* xmlSecTransformVerifyMethod verify; */
+    xmlSecTransformDefaultGetDataType,         /* xmlSecTransformGetDataTypeMethod getDataType; */
+    xmlSecTransformDefaultPushBin,             /* xmlSecTransformPushBinMethod pushBin; */
+    xmlSecTransformDefaultPopBin,              /* xmlSecTransformPopBinMethod popBin; */
+    NULL,                                      /* xmlSecTransformPushXmlMethod pushXml; */
+    NULL,                                      /* xmlSecTransformPopXmlMethod popXml; */
+    xmlSecMSCngSignatureExecute,               /* xmlSecTransformExecuteMethod execute; */
+
+    NULL,                                      /* void* reserved0; */
+    NULL,                                      /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngTransformEcdsaSha256GetKlass:
+ *
+ * The ECDSA-SHA256 signature transform klass.
+ *
+ * Returns: ECDSA-SHA256 signature transform klass.
+ */
+xmlSecTransformId
+xmlSecMSCngTransformEcdsaSha256GetKlass(void) {
+    return(&xmlSecMSCngEcdsaSha256Klass);
+}
+#endif /* XMLSEC_NO_SHA256 */
+
+#endif /* XMLSEC_NO_ECDSA */

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -1,0 +1,197 @@
+/*
+ * XML Security Library (http://www.aleksey.com/xmlsec).
+ *
+ * This is free software; see Copyright file in the source
+ * distribution for preciese wording.
+ *
+ * Copyright (C) 2018 Miklos Vajna <vmiklos@vmiklos.hu>. All Rights Reserved.
+ */
+
+#include "globals.h"
+
+#ifndef XMLSEC_NO_X509
+
+#include <string.h>
+
+#include <windows.h>
+#include <wincrypt.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/xmltree.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/keyinfo.h>
+#include <xmlsec/keysmngr.h>
+#include <xmlsec/x509.h>
+#include <xmlsec/base64.h>
+#include <xmlsec/bn.h>
+#include <xmlsec/errors.h>
+
+#include <xmlsec/mscng/crypto.h>
+#include <xmlsec/mscng/x509.h>
+
+typedef struct _xmlSecMSCngX509DataCtx xmlSecMSCngX509DataCtx,
+                                       *xmlSecMSCngX509DataCtxPtr;
+
+struct _xmlSecMSCngX509DataCtx {
+    PCCERT_CONTEXT pCert;
+};
+
+#define xmlSecMSCngX509DataSize      \
+    (sizeof(xmlSecKeyData) + sizeof(xmlSecMSCngX509DataCtx))
+#define xmlSecMSCngX509DataGetCtx(data) \
+    ((xmlSecMSCngX509DataCtxPtr)(((xmlSecByte*)(data)) + sizeof(xmlSecKeyData)))
+
+static int
+xmlSecMSCngKeyDataX509Initialize(xmlSecKeyDataPtr data) {
+    xmlSecMSCngX509DataCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id), -1);
+    ctx = xmlSecMSCngX509DataGetCtx(data);
+    xmlSecAssert2(ctx != NULL, -1);
+    memset(ctx, 0, sizeof(xmlSecMSCngX509DataCtx));
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static int
+xmlSecMSCngKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
+    xmlSecAssert2(xmlSecKeyDataCheckId(dst, xmlSecMSCngKeyDataX509Id), -1);
+    xmlSecAssert2(xmlSecKeyDataCheckId(src, xmlSecMSCngKeyDataX509Id), -1);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static void
+xmlSecMSCngKeyDataX509Finalize(xmlSecKeyDataPtr data) {
+    xmlSecMSCngX509DataCtxPtr ctx;
+
+    xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id));
+
+    ctx = xmlSecMSCngX509DataGetCtx(data);
+    xmlSecAssert(ctx != NULL);
+
+    xmlSecNotImplementedError(NULL);
+
+    memset(ctx, 0, sizeof(xmlSecMSCngX509DataCtx));
+}
+
+static xmlSecKeyDataType
+xmlSecMSCngKeyDataX509GetType(xmlSecKeyDataPtr data) {
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id), xmlSecKeyDataTypeUnknown);
+
+    return(xmlSecKeyDataTypeUnknown);
+}
+
+static const xmlChar*
+xmlSecMSCngKeyDataX509GetIdentifier(xmlSecKeyDataPtr data) {
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id), NULL);
+
+    return(NULL);
+}
+
+static int
+xmlSecMSCngKeyDataX509XmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key,
+                              xmlNodePtr node, xmlSecKeyInfoCtxPtr keyInfoCtx) {
+    xmlSecKeyDataPtr data;
+
+    xmlSecAssert2(id == xmlSecMSCngKeyDataX509Id, -1);
+    xmlSecAssert2(key != NULL, -1);
+    xmlSecAssert2(node != NULL, -1);
+    xmlSecAssert2(keyInfoCtx != NULL, -1);
+
+    data = xmlSecKeyEnsureData(key, id);
+    if(data == NULL) {
+        xmlSecInternalError("xmlSecKeyEnsureData",
+                            xmlSecKeyDataKlassGetName(id));
+        return(-1);
+    }
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static int
+xmlSecMSCngKeyDataX509XmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
+                               xmlNodePtr node, xmlSecKeyInfoCtxPtr keyInfoCtx) {
+    xmlSecAssert2(id == xmlSecMSCngKeyDataX509Id, -1);
+    xmlSecAssert2(key != NULL, -1);
+    xmlSecAssert2(node != NULL, -1);
+    xmlSecAssert2(keyInfoCtx != NULL, -1);
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static void
+xmlSecMSCngKeyDataX509DebugDump(xmlSecKeyDataPtr data, FILE* output) {
+    xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id));
+    xmlSecAssert(output != NULL);
+
+    xmlSecNotImplementedError(NULL);
+}
+
+static void
+xmlSecMSCngKeyDataX509DebugXmlDump(xmlSecKeyDataPtr data, FILE* output) {
+    xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id));
+    xmlSecAssert(output != NULL);
+
+    xmlSecNotImplementedError(NULL);
+}
+
+static xmlSecKeyDataKlass xmlSecMSCngKeyDataX509Klass = {
+    sizeof(xmlSecKeyDataKlass),
+    xmlSecMSCngX509DataSize,
+
+    /* data */
+    xmlSecNameX509Data,
+    xmlSecKeyDataUsageKeyInfoNode | xmlSecKeyDataUsageRetrievalMethodNodeXml,
+                                                /* xmlSecKeyDataUsage usage; */
+    xmlSecHrefX509Data,                         /* const xmlChar* href; */
+    xmlSecNodeX509Data,                         /* const xmlChar* dataNodeName; */
+    xmlSecDSigNs,                               /* const xmlChar* dataNodeNs; */
+
+    /* constructors/destructor */
+    xmlSecMSCngKeyDataX509Initialize,           /* xmlSecKeyDataInitializeMethod initialize; */
+    xmlSecMSCngKeyDataX509Duplicate,            /* xmlSecKeyDataDuplicateMethod duplicate; */
+    xmlSecMSCngKeyDataX509Finalize,             /* xmlSecKeyDataFinalizeMethod finalize; */
+    NULL,                                       /* xmlSecKeyDataGenerateMethod generate; */
+
+    /* get info */
+    xmlSecMSCngKeyDataX509GetType,              /* xmlSecKeyDataGetTypeMethod getType; */
+    NULL,                                       /* xmlSecKeyDataGetSizeMethod getSize; */
+    xmlSecMSCngKeyDataX509GetIdentifier,        /* xmlSecKeyDataGetIdentifier getIdentifier; */
+
+    /* read/write */
+    xmlSecMSCngKeyDataX509XmlRead,              /* xmlSecKeyDataXmlReadMethod xmlRead; */
+    xmlSecMSCngKeyDataX509XmlWrite,             /* xmlSecKeyDataXmlWriteMethod xmlWrite; */
+    NULL,                                       /* xmlSecKeyDataBinReadMethod binRead; */
+    NULL,                                       /* xmlSecKeyDataBinWriteMethod binWrite; */
+
+    /* debug */
+    xmlSecMSCngKeyDataX509DebugDump,            /* xmlSecKeyDataDebugDumpMethod debugDump; */
+    xmlSecMSCngKeyDataX509DebugXmlDump,         /* xmlSecKeyDataDebugDumpMethod debugXmlDump; */
+
+    /* reserved for the future */
+    NULL,                                       /* void* reserved0; */
+    NULL,                                       /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngKeyDataX509GetKlass:
+ *
+ * The MSCng X509 key data klass.
+ *
+ * Returns: the X509 data klass.
+ */
+xmlSecKeyDataId
+xmlSecMSCngKeyDataX509GetKlass(void) {
+    return(&xmlSecMSCngKeyDataX509Klass);
+}
+
+#endif /* XMLSEC_NO_X509 */

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -14,7 +14,6 @@
 #include <string.h>
 
 #include <windows.h>
-#include <wincrypt.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/xmltree.h>

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -36,7 +36,7 @@ struct _xmlSecMSCngX509StoreCtx {
 
 #define xmlSecMSCngX509StoreGetCtx(store) \
     ((xmlSecMSCngX509StoreCtxPtr)(((xmlSecByte*)(store)) + \
-    	sizeof(xmlSecKeyDataStoreKlass)))
+                 sizeof(xmlSecKeyDataStoreKlass)))
 #define xmlSecMSCngX509StoreSize \
     (sizeof(xmlSecKeyDataStoreKlass) + sizeof(xmlSecMSCngX509StoreCtx))
 
@@ -51,16 +51,16 @@ xmlSecMSCngX509StoreFinalize(xmlSecKeyDataStorePtr store) {
 
     if (ctx->hCertStoreCollection != NULL) {
         ret = CertCloseStore(ctx->hCertStoreCollection, CERT_CLOSE_STORE_CHECK_FLAG);
-	if(ret == FALSE) {
+        if(ret == FALSE) {
             xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
         }
     }
 
     if (ctx->hCertStoreMemory != NULL) {
         ret = CertCloseStore(ctx->hCertStoreMemory, CERT_CLOSE_STORE_CHECK_FLAG);
-	if(ret == FALSE) {
+        if(ret == FALSE) {
             xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
-	}
+        }
     }
 
     memset(ctx, 0, sizeof(xmlSecMSCngX509StoreCtx));
@@ -172,7 +172,7 @@ xmlSecMSCngX509StoreAdoptCert(xmlSecKeyDataStorePtr store, PCCERT_CONTEXT pCert,
         hCertStore = ctx->hCertStoreCollection;
     } else if(type == xmlSecKeyDataTypeNone) {
         xmlSecNotImplementedError(NULL);
-	return(-1);
+        return(-1);
     } else {
         xmlSecNotImplementedError(NULL);
         return(-1);

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -142,4 +142,52 @@ xmlSecMSCngX509StoreGetKlass(void) {
     return(&xmlSecMSCngX509StoreKlass);
 }
 
+/**
+ * xmlSecMSCngX509StoreAdoptCert:
+ * @store:              the pointer to X509 key data store klass.
+ * @cert:               the pointer to PCCERT_CONTEXT X509 certificate.
+ * @type:               the certificate type (trusted/untrusted).
+ *
+ * Adds trusted (root) or untrusted certificate to the store.
+ *
+ * Returns: 0 on success or a negative value if an error occurs.
+ */
+int
+xmlSecMSCngX509StoreAdoptCert(xmlSecKeyDataStorePtr store, PCCERT_CONTEXT pCert, xmlSecKeyDataType type) {
+    xmlSecMSCngX509StoreCtxPtr ctx;
+    HCERTSTORE hCertStore;
+    int ret;
+
+    xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), -1);
+    xmlSecAssert2(pCert != NULL, -1);
+
+    ctx = xmlSecMSCngX509StoreGetCtx(store);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->hCertStoreCollection != NULL, -1);
+
+    if(type == xmlSecKeyDataTypeTrusted) {
+        hCertStore = ctx->hCertStoreCollection;
+    } else if(type == xmlSecKeyDataTypeNone) {
+        xmlSecNotImplementedError(NULL);
+	return(-1);
+    } else {
+        xmlSecNotImplementedError(NULL);
+        return(-1);
+    }
+
+    xmlSecAssert2(hCertStore != NULL, -1);
+    ret = CertAddCertificateContextToStore(
+        hCertStore,
+        pCert,
+        CERT_STORE_ADD_ALWAYS,
+        NULL);
+    if(ret == FALSE) {
+        /* TODO implement a xmlSecMSCngError() */
+        xmlSecInternalError("CertAddCertificateContextToStore", xmlSecKeyDataStoreGetName(store));
+        return(-1);
+    }
+
+    return(0);
+}
+
 #endif /* XMLSEC_NO_X509 */

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -51,12 +51,16 @@ xmlSecMSCngX509StoreFinalize(xmlSecKeyDataStorePtr store) {
 
     if (ctx->hCertStoreCollection != NULL) {
         ret = CertCloseStore(ctx->hCertStoreCollection, CERT_CLOSE_STORE_CHECK_FLAG);
-        xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
+	if(ret == FALSE) {
+            xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
+        }
     }
 
     if (ctx->hCertStoreMemory != NULL) {
         ret = CertCloseStore(ctx->hCertStoreMemory, CERT_CLOSE_STORE_CHECK_FLAG);
-        xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
+	if(ret == FALSE) {
+            xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
+	}
     }
 
     memset(ctx, 0, sizeof(xmlSecMSCngX509StoreCtx));

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -52,13 +52,11 @@ xmlSecMSCngX509StoreFinalize(xmlSecKeyDataStorePtr store) {
     if (ctx->hCertStoreCollection != NULL) {
         ret = CertCloseStore(ctx->hCertStoreCollection, CERT_CLOSE_STORE_CHECK_FLAG);
         xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
-        return;
     }
 
     if (ctx->hCertStoreMemory != NULL) {
         ret = CertCloseStore(ctx->hCertStoreMemory, CERT_CLOSE_STORE_CHECK_FLAG);
         xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
-        return;
     }
 
     memset(ctx, 0, sizeof(xmlSecMSCngX509StoreCtx));

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -1,0 +1,98 @@
+/*
+ * XML Security Library (http://www.aleksey.com/xmlsec).
+ *
+ * This is free software; see Copyright file in the source
+ * distribution for preciese wording.
+ *
+ * Copyright (C) 2018 Miklos Vajna <vmiklos@vmiklos.hu>. All Rights Reserved.
+ */
+
+#include "globals.h"
+
+#ifndef XMLSEC_NO_X509
+
+#include <string.h>
+
+#include <windows.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/xmltree.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/keyinfo.h>
+#include <xmlsec/keysmngr.h>
+#include <xmlsec/base64.h>
+#include <xmlsec/bn.h>
+#include <xmlsec/errors.h>
+
+#include <xmlsec/mscng/crypto.h>
+#include <xmlsec/mscng/x509.h>
+
+typedef struct _xmlSecMSCngX509StoreCtx xmlSecMSCngX509StoreCtx,
+                                       *xmlSecMSCngX509StoreCtxPtr;
+struct _xmlSecMSCngX509StoreCtx {
+    HCERTSTORE hCertStore;
+};
+
+#define xmlSecMSCngX509StoreGetCtx(store) \
+    ((xmlSecMSCngX509StoreCtxPtr)(((xmlSecByte*)(store)) + \
+    	sizeof(xmlSecKeyDataStoreKlass)))
+#define xmlSecMSCngX509StoreSize \
+    (sizeof(xmlSecKeyDataStoreKlass) + sizeof(xmlSecMSCngX509StoreCtx))
+
+static int
+xmlSecMSCngX509StoreInitialize(xmlSecKeyDataStorePtr store) {
+    xmlSecMSCngX509StoreCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), -1);
+    ctx = xmlSecMSCngX509StoreGetCtx(store);
+    xmlSecAssert2(ctx != NULL, -1);
+
+    memset(ctx, 0, sizeof(xmlSecMSCngX509StoreCtx));
+
+    xmlSecNotImplementedError(NULL);
+
+    return(-1);
+}
+
+static void
+xmlSecMSCngX509StoreFinalize(xmlSecKeyDataStorePtr store) {
+    xmlSecMSCngX509StoreCtxPtr ctx;
+
+    xmlSecAssert(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId));
+    ctx = xmlSecMSCngX509StoreGetCtx(store);
+    xmlSecAssert(ctx != NULL);
+
+    xmlSecNotImplementedError(NULL);
+
+    memset(ctx, 0, sizeof(xmlSecMSCngX509StoreCtx));
+}
+
+static xmlSecKeyDataStoreKlass xmlSecMSCngX509StoreKlass = {
+    sizeof(xmlSecKeyDataStoreKlass),
+    xmlSecMSCngX509StoreSize,
+
+    /* data */
+    xmlSecNameX509Store,                    /* const xmlChar* name; */
+
+    /* constructors/destructor */
+    xmlSecMSCngX509StoreInitialize,         /* xmlSecKeyDataStoreInitializeMethod initialize; */
+    xmlSecMSCngX509StoreFinalize,           /* xmlSecKeyDataStoreFinalizeMethod finalize; */
+
+    /* reserved for the future */
+    NULL,                    /* void* reserved0; */
+    NULL,                    /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngX509StoreGetKlass:
+ *
+ * The MSCng X509 certificates key data store klass.
+ *
+ * Returns: pointer to MSCng X509 certificates key data store klass.
+ */
+xmlSecKeyDataStoreId
+xmlSecMSCngX509StoreGetKlass(void) {
+    return(&xmlSecMSCngX509StoreKlass);
+}
+
+#endif /* XMLSEC_NO_X509 */

--- a/tests/testDSig.sh
+++ b/tests/testDSig.sh
@@ -353,7 +353,7 @@ execDSigTest $res_success \
     "" \
     "aleksey-xmldsig-01/enveloping-sha1-ecdsa-sha1" \
     "sha1 ecdsa-sha1" \
-    "rsa x509" \
+    "ecdsa x509" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509" \
     "$priv_key_option $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509"
@@ -362,7 +362,7 @@ execDSigTest $res_success \
     "" \
     "aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256" \
     "sha256 ecdsa-sha256" \
-    "rsa x509" \
+    "ecdsa x509" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509" \
     "$priv_key_option $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509"
@@ -371,7 +371,7 @@ execDSigTest $res_success \
     "" \
     "aleksey-xmldsig-01/enveloping-sha512-ecdsa-sha512" \
     "sha512 ecdsa-sha512" \
-    "rsa x509" \
+    "ecdsa x509" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509" \
     "$priv_key_option $topfolder/keys/ecdsa-secp256r1-key.$priv_key_format --pwd secret123" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509"

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -307,14 +307,20 @@ XMLSEC_MSCRYPTO_OBJS_A = \
 
 XMLSEC_MSCNG_OBJS = \
 	$(XMLSEC_MSCNG_INTDIR)\app.obj\
+	$(XMLSEC_MSCNG_INTDIR)\certkeys.obj \
 	$(XMLSEC_MSCNG_INTDIR)\crypto.obj\
 	$(XMLSEC_MSCNG_INTDIR)\digests.obj\
-	$(XMLSEC_MSCNG_INTDIR)\strings.obj
+	$(XMLSEC_MSCNG_INTDIR)\strings.obj\
+	$(XMLSEC_MSCNG_INTDIR)\signatures.obj\
+	$(XMLSEC_MSCNG_INTDIR)\x509.obj
 XMLSEC_MSCNG_OBJS_A = \
 	$(XMLSEC_MSCNG_INTDIR_A)\app.obj\
+	$(XMLSEC_MSCNG_INTDIR_A)\certkeys.obj \
 	$(XMLSEC_MSCNG_INTDIR_A)\crypto.obj\
 	$(XMLSEC_MSCNG_INTDIR_A)\digests.obj\
-	$(XMLSEC_MSCNG_INTDIR_A)\strings.obj
+	$(XMLSEC_MSCNG_INTDIR_A)\strings.obj\
+	$(XMLSEC_MSCNG_INTDIR_A)\signatures.obj\
+	$(XMLSEC_MSCNG_INTDIR_A)\x509.obj
 
 #
 # The preprocessor and its options.

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -437,8 +437,8 @@ XMLSEC_NSS_ALIBS        = smime3.lib ssl3.lib nss3.lib libnspr4_s.lib libplds4_s
 XMLSEC_MSCRYPTO_SOLIBS  = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib
 XMLSEC_MSCRYPTO_ALIBS   = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib
 
-XMLSEC_MSCNG_SOLIBS  = kernel32.lib user32.lib gdi32.lib Advapi32.lib Bcrypt.lib
-XMLSEC_MSCNG_ALIBS   = kernel32.lib user32.lib gdi32.lib Advapi32.lib Bcrypt.lib
+XMLSEC_MSCNG_SOLIBS  = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib Bcrypt.lib
+XMLSEC_MSCNG_ALIBS   = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib Bcrypt.lib
 
 
 # The archiver and its options.

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -312,7 +312,8 @@ XMLSEC_MSCNG_OBJS = \
 	$(XMLSEC_MSCNG_INTDIR)\digests.obj\
 	$(XMLSEC_MSCNG_INTDIR)\strings.obj\
 	$(XMLSEC_MSCNG_INTDIR)\signatures.obj\
-	$(XMLSEC_MSCNG_INTDIR)\x509.obj
+	$(XMLSEC_MSCNG_INTDIR)\x509.obj\
+	$(XMLSEC_MSCNG_INTDIR)\x509vfy.obj
 XMLSEC_MSCNG_OBJS_A = \
 	$(XMLSEC_MSCNG_INTDIR_A)\app.obj\
 	$(XMLSEC_MSCNG_INTDIR_A)\certkeys.obj \
@@ -320,7 +321,8 @@ XMLSEC_MSCNG_OBJS_A = \
 	$(XMLSEC_MSCNG_INTDIR_A)\digests.obj\
 	$(XMLSEC_MSCNG_INTDIR_A)\strings.obj\
 	$(XMLSEC_MSCNG_INTDIR_A)\signatures.obj\
-	$(XMLSEC_MSCNG_INTDIR_A)\x509.obj
+	$(XMLSEC_MSCNG_INTDIR_A)\x509.obj\
+	$(XMLSEC_MSCNG_INTDIR_A)\x509vfy.obj
 
 #
 # The preprocessor and its options.


### PR DESCRIPTION
A number of commits, mostly split to allow easier reviewing. Lots of skeleton code to allow runtime testing of actual code instead of just a build test.

````
win32/binaries/xmlsec.exe check-transforms  --crypto mscng --crypto-config win32/tmp/xmlsec-crypto-config sha256 ecdsa-sha256
win32/binaries/xmlsec.exe check-key-data --crypto mscng --crypto-config win32/tmp/xmlsec-crypto-config ecdsa x509
````

Now finishes without errors, the next test is

````
win32/binaries/xmlsec.exe verify --crypto mscng --crypto-config win32/tmp/xmlsec-crypto-config --trusted-der tests/keys/cacert.der --enabled-key-data x509 tests/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.xml
````

that currently stops with a not-implemented-error when it comes to the cng x509 key data constructor.
Slowly getting somewhere. :-)