### PR TITLE
MSCNG: implement public key extraction from certificate

### DIFF
--- a/include/xmlsec/mscng/certkeys.h
+++ b/include/xmlsec/mscng/certkeys.h
@@ -1,0 +1,31 @@
+/*
+ * XML Security Library (http://www.aleksey.com/xmlsec).
+ *
+ * This is free software; see Copyright file in the source
+ * distribution for preciese wording.
+ *
+ * Copyright (C) 2018 Miklos Vajna <vmiklos@vmiklos.hu>. All Rights Reserved.
+ */
+#ifndef __XMLSEC_MSCNG_CERTKEYS_H__
+#define __XMLSEC_MSCNG_CERTKEYS_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <windows.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/transforms.h>
+
+XMLSEC_CRYPTO_EXPORT xmlSecKeyDataPtr   xmlSecMSCngCertAdopt         (PCCERT_CONTEXT pCert,
+                                                                      xmlSecKeyDataType type);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __XMLSEC_MSCNG_PCCERT_CONTEXT_H__ */
+
+

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -42,6 +42,9 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyDataStoreId xmlSecMSCngX509StoreGetKlass(void);
 XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptCert        (xmlSecKeyDataStorePtr store,
                                                                               PCCERT_CONTEXT cert,
                                                                               xmlSecKeyDataType type);
+XMLSEC_CRYPTO_EXPORT PCCERT_CONTEXT     xmlSecMSCngX509StoreVerify           (xmlSecKeyDataStorePtr store,
+									      HCERTSTORE certs,
+									      xmlSecKeyInfoCtx* keyInfoCtx);
 
 #endif /* XMLSEC_NO_X509 */
 

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -77,18 +77,48 @@ xmlSecMSCngCertAdopt(PCCERT_CONTEXT pCert, xmlSecKeyDataType type) {
     return(NULL);
 }
 
-#ifndef XMLSEC_NO_ECDSA
 static int
-xmlSecMSCngKeyDataEcdsaInitialize(xmlSecKeyDataPtr data) {
+xmlSecMSCngKeyDataInitialize(xmlSecKeyDataPtr data) {
     xmlSecMSCngKeyDataCtxPtr ctx;
 
-    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId), -1);
+    xmlSecAssert2(xmlSecKeyDataIsValid(data), -1);
+    xmlSecAssert2(xmlSecKeyDataCheckSize(data, xmlSecMSCngKeyDataSize), -1);
+
     ctx = xmlSecMSCngKeyDataGetCtx(data);
     xmlSecAssert2(ctx != NULL, -1);
 
-    xmlSecNotImplementedError(NULL);
+    memset(ctx, 0, sizeof(xmlSecMSCngKeyDataCtx));
 
-    return(-1);
+    return(0);
+}
+
+static void
+xmlSecMSCngKeyDataFinalize(xmlSecKeyDataPtr data) {
+    xmlSecMSCngKeyDataCtxPtr ctx;
+
+    xmlSecAssert(xmlSecKeyDataIsValid(data));
+    xmlSecAssert(xmlSecKeyDataCheckSize(data, xmlSecMSCngKeyDataSize));
+
+    ctx = xmlSecMSCngKeyDataGetCtx(data);
+    xmlSecAssert(ctx != NULL);
+
+    memset(ctx, 0, sizeof(xmlSecMSCngKeyDataCtx));
+}
+
+#ifndef XMLSEC_NO_ECDSA
+static int
+xmlSecMSCngKeyDataEcdsaInitialize(xmlSecKeyDataPtr data) {
+    int ret;
+
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId), xmlSecKeyDataTypeUnknown);
+
+    ret = xmlSecMSCngKeyDataInitialize(data);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecMSCngKeyDataInitialize", NULL);
+        return(-1);
+    }
+
+    return(0);
 }
 
 static int
@@ -104,6 +134,8 @@ xmlSecMSCngKeyDataEcdsaDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
 static void
 xmlSecMSCngKeyDataEcdsaFinalize(xmlSecKeyDataPtr data) {
     xmlSecAssert(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataEcdsaId));
+
+    xmlSecMSCngKeyDataFinalize(data);
 }
 
 static xmlSecKeyDataType

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -35,6 +35,48 @@ struct _xmlSecMSCngKeyDataCtx {
 #define xmlSecMSCngKeyDataGetCtx(data) \
     ((xmlSecMSCngKeyDataCtxPtr)(((xmlSecByte*)(data)) + sizeof(xmlSecKeyData)))
 
+/**
+ * xmlSecMSCngCertAdopt:
+ * @pCert:              the pointer to cert.
+ * @type:               the expected key type.
+ *
+ * Creates key data value from the cert.
+ *
+ * Returns: pointer to newly created xmlsec key or NULL if an error occurs.
+ */
+xmlSecKeyDataPtr
+xmlSecMSCngCertAdopt(PCCERT_CONTEXT pCert, xmlSecKeyDataType type) {
+    xmlSecKeyDataPtr data = NULL;
+    int ret;
+
+    xmlSecAssert2(pCert != NULL, NULL);
+    xmlSecAssert2(pCert->pCertInfo != NULL, NULL);
+    xmlSecAssert2(pCert->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId != NULL, NULL);
+
+#ifndef XMLSEC_NO_ECDSA
+    if (!strcmp(pCert->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId, szOID_ECC_PUBLIC_KEY)) {
+        data = xmlSecKeyDataCreate(xmlSecMSCngKeyDataEcdsaId);
+        if(data == NULL) {
+            xmlSecInternalError("xmlSecKeyDataCreate(KeyDataEcdsaId)", NULL);
+            return(NULL);
+        }
+    }
+#endif /* XMLSEC_NO_ECDSA */
+
+    if (data == NULL) {
+        xmlSecInvalidStringTypeError("PCCERT_CONTEXT key type",
+            pCert->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId,
+            "unsupported keytype",
+            NULL);
+        return(NULL);
+    }
+
+    /* TODO call xmlSecMSCngKeyDataAdoptCert() now */
+    xmlSecNotImplementedError(NULL);
+    xmlSecKeyDataDestroy(data);
+    return(NULL);
+}
+
 #ifndef XMLSEC_NO_ECDSA
 static int
 xmlSecMSCngKeyDataEcdsaInitialize(xmlSecKeyDataPtr data) {

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -32,7 +32,7 @@ typedef struct _xmlSecMSCngX509DataCtx xmlSecMSCngX509DataCtx,
                                        *xmlSecMSCngX509DataCtxPtr;
 
 struct _xmlSecMSCngX509DataCtx {
-    PCCERT_CONTEXT pCert;
+    HCERTSTORE hMemStore;
 };
 
 #define xmlSecMSCngX509DataSize      \
@@ -49,9 +49,17 @@ xmlSecMSCngKeyDataX509Initialize(xmlSecKeyDataPtr data) {
     xmlSecAssert2(ctx != NULL, -1);
     memset(ctx, 0, sizeof(xmlSecMSCngX509DataCtx));
 
-    xmlSecNotImplementedError(NULL);
+    ctx->hMemStore = CertOpenStore(CERT_STORE_PROV_MEMORY,
+        0,
+        0,
+        CERT_STORE_CREATE_NEW_FLAG,
+        NULL);
+    if(ctx->hMemStore == 0) {
+        xmlSecMSCngLastError("CertOpenStore", xmlSecKeyDataGetName(data));
+        return(-1);
+    }
 
-    return(-1);
+    return(0);
 }
 
 static int
@@ -73,7 +81,11 @@ xmlSecMSCngKeyDataX509Finalize(xmlSecKeyDataPtr data) {
     ctx = xmlSecMSCngX509DataGetCtx(data);
     xmlSecAssert(ctx != NULL);
 
-    xmlSecNotImplementedError(NULL);
+    if(ctx->hMemStore != 0) {
+        if(!CertCloseStore(ctx->hMemStore, CERT_CLOSE_STORE_CHECK_FLAG)) {
+            xmlSecMSCngLastError("CertCloseStore", NULL);
+        }
+    }
 
     memset(ctx, 0, sizeof(xmlSecMSCngX509DataCtx));
 }

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -201,7 +201,7 @@ xmlSecMSCngX509CertificateNodeRead(xmlSecKeyDataPtr data, xmlNodePtr node,
 
         if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_STOP_ON_EMPTY_NODE) != 0) {
             xmlSecInvalidNodeContentError(node, xmlSecKeyDataGetName(data),
-                "content is empty string");
+                "content is an empty string");
             return(-1);
         }
 

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -192,4 +192,25 @@ xmlSecMSCngX509StoreAdoptCert(xmlSecKeyDataStorePtr store, PCCERT_CONTEXT pCert,
     return(0);
 }
 
+/**
+ * xmlSecMSCngX509StoreVerify:
+ * @store: the pointer to X509 certificate context store klass.
+ * @certs: the untrusted certificates stack.
+ * @keyInfoCtx: the pointer to <dsig:KeyInfo/> element processing context.
+ *
+ * Verifies @certs list.
+ *
+ * Returns: pointer to the first verified certificate from @certs.
+ */
+PCCERT_CONTEXT
+xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
+	xmlSecKeyInfoCtx* keyInfoCtx) {
+    xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), NULL);
+    xmlSecAssert2(certs != NULL, NULL);
+    xmlSecAssert2(keyInfoCtx != NULL, NULL);
+
+    xmlSecNotImplementedError(NULL);
+
+    return (NULL);
+}
 #endif /* XMLSEC_NO_X509 */

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -205,11 +205,46 @@ xmlSecMSCngX509StoreAdoptCert(xmlSecKeyDataStorePtr store, PCCERT_CONTEXT pCert,
 PCCERT_CONTEXT
 xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
 	xmlSecKeyInfoCtx* keyInfoCtx) {
+    PCCERT_CONTEXT cert = NULL;
+
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), NULL);
     xmlSecAssert2(certs != NULL, NULL);
     xmlSecAssert2(keyInfoCtx != NULL, NULL);
 
-    xmlSecNotImplementedError(NULL);
+    while((cert = CertEnumCertificatesInStore(certs, cert)) != NULL) {
+        PCCERT_CONTEXT foundCert = NULL;
+        int skip = 0;
+        xmlSecAssert2(cert->pCertInfo != NULL, NULL);
+
+        /* is cert the issuer of a certificate in certs? if so, skip it */
+        do
+        {
+            foundCert = CertFindCertificateInStore(certs,
+                X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                0,
+                CERT_FIND_ISSUER_NAME,
+                &(cert->pCertInfo->Subject),
+                foundCert);
+            /* don't skip self-signed certificates */
+            if((foundCert != NULL) &&
+                    !CertCompareCertificateName(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                                                &(foundCert->pCertInfo->Subject),
+                                                &(foundCert->pCertInfo->Issuer))) {
+                skip = 1;
+            }
+        } while(skip == 0 && foundCert != NULL);
+        if(foundCert != NULL) {
+            CertFreeCertificateContext(foundCert);
+        }
+        if(skip == 0) {
+            if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_DONT_VERIFY_CERTS) != 0) {
+                return(cert);
+            }
+
+            /* need to actually verify the certificate */
+            xmlSecNotImplementedError(NULL);
+        }
+    }
 
     return (NULL);
 }

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -217,8 +217,7 @@ xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
         xmlSecAssert2(cert->pCertInfo != NULL, NULL);
 
         /* is cert the issuer of a certificate in certs? if so, skip it */
-        do
-        {
+        do {
             foundCert = CertFindCertificateInStore(certs,
                 X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
                 0,


### PR DESCRIPTION
The next TODO is to replace the stub at the end of xmlSecMSCngKeyDataX509VerifyAndExtractKey() with a real implementation (checks like not valid before/after, etc.)

One shortcut I did was to bypass certificate chain validation for now -- so I just report a not implemented error for that, which means that the test cmdline I use to get the above TODO is now:

````
win32/binaries/xmlsec.exe verify --crypto mscng --crypto-config win32/tmp/xmlsec-crypto-config --trusted-der tests/keys/cacert.der --enabled-key-data x509 --insecure tests/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.xml
````