### PR TITLE
MSCNG: verify signature

### DIFF
--- a/include/xmlsec/mscng/certkeys.h
+++ b/include/xmlsec/mscng/certkeys.h
@@ -21,6 +21,8 @@ extern "C" {
 
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataPtr   xmlSecMSCngCertAdopt         (PCCERT_CONTEXT pCert,
                                                                       xmlSecKeyDataType type);
+XMLSEC_CRYPTO_EXPORT BCRYPT_KEY_HANDLE  xmlSecMSCngKeyDataGetKey     (xmlSecKeyDataPtr data,
+                                                                      xmlSecKeyDataType type);
 
 #ifdef __cplusplus
 }

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -10,7 +10,10 @@
 
 #include <string.h>
 
+#define WIN32_NO_STATUS
 #include <windows.h>
+#undef WIN32_NO_STATUS
+#include <ntstatus.h>
 #include <bcrypt.h>
 
 #include <xmlsec/xmlsec.h>
@@ -190,6 +193,7 @@ xmlSecMSCngKeyDataInitialize(xmlSecKeyDataPtr data) {
 static void
 xmlSecMSCngKeyDataFinalize(xmlSecKeyDataPtr data) {
     xmlSecMSCngKeyDataCtxPtr ctx;
+    NTSTATUS status;
 
     xmlSecAssert(xmlSecKeyDataIsValid(data));
     xmlSecAssert(xmlSecKeyDataCheckSize(data, xmlSecMSCngKeyDataSize));
@@ -198,8 +202,9 @@ xmlSecMSCngKeyDataFinalize(xmlSecKeyDataPtr data) {
     xmlSecAssert(ctx != NULL);
 
     if (ctx->pubkey != 0) {
-        if(!BCryptDestroyKey(ctx->pubkey)) {
-            xmlSecMSCngLastError("BCryptDestroyKey", NULL);
+        status = BCryptDestroyKey(ctx->pubkey);
+        if(status != STATUS_SUCCESS) {
+            xmlSecMSCngNtError("BCryptDestroyKey", NULL, status);
         }
     }
 

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -144,6 +144,34 @@ xmlSecMSCngCertAdopt(PCCERT_CONTEXT pCert, xmlSecKeyDataType type) {
     return(data);
 }
 
+/**
+ * xmlSecMSCngKeyDataGetKey:
+ * @data: the key data to retrieve certificate from.
+ * @type: type of key requested (public/private)
+ *
+ * Native MSCng key retrieval from xmlsec keydata. The returned key must not be
+ * destroyed by the caller.
+ *
+ * Returns: key on success or 0 otherwise.
+ */
+BCRYPT_KEY_HANDLE
+xmlSecMSCngKeyDataGetKey(xmlSecKeyDataPtr data, xmlSecKeyDataType type) {
+    xmlSecMSCngKeyDataCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecKeyDataIsValid(data), 0);
+    xmlSecAssert2(xmlSecKeyDataCheckSize(data, xmlSecMSCngKeyDataSize), 0);
+
+    ctx = xmlSecMSCngKeyDataGetCtx(data);
+    xmlSecAssert2(ctx != NULL, 0);
+
+    if(type == xmlSecKeyDataTypePrivate) {
+        xmlSecNotImplementedError(NULL);
+        return(0);
+    }
+
+    return(ctx->pubkey);
+}
+
 static int
 xmlSecMSCngKeyDataInitialize(xmlSecKeyDataPtr data) {
     xmlSecMSCngKeyDataCtxPtr ctx;

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -205,9 +205,9 @@ static int xmlSecMSCngSignatureVerify(xmlSecTransformPtr transform,
                                       xmlSecSize dataSize,
                                       xmlSecTransformCtxPtr transformCtx) {
     xmlSecMSCngSignatureCtxPtr ctx;
-    int ret;
     BCRYPT_KEY_HANDLE pubkey;
     NTSTATUS status;
+    int ret;
 
     xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
     xmlSecAssert2(transform->operation == xmlSecTransformOperationVerify, -1);
@@ -240,6 +240,7 @@ static int xmlSecMSCngSignatureVerify(xmlSecTransformPtr transform,
             xmlSecOtherError(XMLSEC_ERRORS_R_DATA_NOT_MATCH,
                 xmlSecTransformGetName(transform),
                 "BCryptVerifySignature: the signature was not verified");
+            transform->status = xmlSecTransformStatusFail;
             return(-1);
         } else {
             xmlSecMSCngNtError("BCryptVerifySignature",

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -10,7 +10,11 @@
 
 #include <string.h>
 
+#define WIN32_NO_STATUS
 #include <windows.h>
+#undef WIN32_NO_STATUS
+#include <ntstatus.h>
+#include <bcrypt.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
@@ -30,6 +34,11 @@ struct _xmlSecMSCngSignatureCtx {
     xmlSecKeyDataPtr    data;
     xmlSecKeyDataId     keyId;
     LPCWSTR pszHashAlgId;
+    DWORD cbHash;
+    PBYTE pbHash;
+    BCRYPT_ALG_HANDLE hHashAlg;
+    PBYTE pbHashObject;
+    BCRYPT_HASH_HANDLE hHash;
 };
 
 /******************************************************************************
@@ -120,6 +129,22 @@ static void xmlSecMSCngSignatureFinalize(xmlSecTransformPtr transform) {
         xmlSecKeyDataDestroy(ctx->data);
     }
 
+    if (ctx->pbHash != NULL) {
+        xmlFree(ctx->pbHash);
+    }
+
+    if(ctx->hHashAlg != 0) {
+        BCryptCloseAlgorithmProvider(ctx->hHashAlg, 0);
+    }
+
+    if(ctx->pbHashObject != NULL) {
+        xmlFree(ctx->pbHashObject);
+    }
+
+    if(ctx->hHash != 0) {
+        BCryptDestroyHash(ctx->hHash);
+    }
+
     memset(ctx, 0, sizeof(xmlSecMSCngSignatureCtx));
 }
 
@@ -199,6 +224,12 @@ static int xmlSecMSCngSignatureVerify(xmlSecTransformPtr transform,
 static int
 xmlSecMSCngSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTransformCtxPtr transformCtx) {
     xmlSecMSCngSignatureCtxPtr ctx;
+    xmlSecSize inSize;
+    xmlSecSize outSize;
+    NTSTATUS status;
+    DWORD cbData = 0;
+    DWORD cbHashObject = 0;
+    int ret;
 
     xmlSecAssert2(xmlSecMSCngSignatureCheckId(transform), -1);
     xmlSecAssert2((transform->operation == xmlSecTransformOperationSign) || (transform->operation == xmlSecTransformOperationVerify), -1);
@@ -207,10 +238,128 @@ xmlSecMSCngSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTransf
 
     ctx = xmlSecMSCngSignatureGetCtx(transform);
     xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->pszHashAlgId != NULL, -1);
 
-    xmlSecNotImplementedError(NULL);
+    inSize = xmlSecBufferGetSize(&transform->inBuf);
+    outSize = xmlSecBufferGetSize(&transform->outBuf);
 
-    return(-1);
+    if(transform->status == xmlSecTransformStatusNone) {
+        xmlSecAssert2(outSize == 0, -1);
+
+        /* open an algorithm handle */
+        status = BCryptOpenAlgorithmProvider(
+            &ctx->hHashAlg,
+            ctx->pszHashAlgId,
+            NULL,
+            0);
+        if(status != STATUS_SUCCESS) {
+            xmlSecMSCngNtError("BCryptOpenAlgorithmProvider",
+                xmlSecTransformGetName(transform), status);
+            return(-1);
+        }
+
+        /* calculate the size of the buffer to hold the hash object */
+        status = BCryptGetProperty(
+            ctx->hHashAlg,
+            BCRYPT_OBJECT_LENGTH,
+            (PBYTE)&cbHashObject,
+            sizeof(DWORD),
+            &cbData,
+            0);
+        if(status != STATUS_SUCCESS) {
+            xmlSecMSCngNtError("BCryptGetProperty",
+                xmlSecTransformGetName(transform), status);
+            return(-1);
+        }
+
+        /* allocate the hash object on the heap */
+        ctx->pbHashObject = (PBYTE)xmlMalloc(cbHashObject);
+        if(ctx->pbHashObject == NULL) {
+            xmlSecMallocError(cbHashObject, NULL);
+            return(-1);
+        }
+
+        /* calculate the length of the hash */
+        status = BCryptGetProperty(
+            ctx->hHashAlg,
+            BCRYPT_HASH_LENGTH,
+            (PBYTE)&ctx->cbHash,
+            sizeof(DWORD),
+            &cbData,
+            0);
+        if(status != STATUS_SUCCESS) {
+            xmlSecMSCngNtError("BCryptGetProperty",
+                xmlSecTransformGetName(transform), status);
+            return(-1);
+        }
+
+        /* allocate the hash buffer on the heap */
+        ctx->pbHash = (PBYTE)xmlMalloc(ctx->cbHash);
+        if(ctx->pbHash == NULL) {
+            xmlSecMallocError(ctx->cbHash, NULL);
+            return(-1);
+        }
+
+        /* create the hash */
+        status = BCryptCreateHash(
+            ctx->hHashAlg,
+            &ctx->hHash,
+            ctx->pbHashObject,
+            cbHashObject,
+            NULL,
+            0,
+            0);
+        if(status != STATUS_SUCCESS) {
+            xmlSecMSCngNtError("BCryptCreateHash",
+                xmlSecTransformGetName(transform), status);
+            return(-1);
+        }
+
+        transform->status = xmlSecTransformStatusWorking;
+    }
+
+    if((transform->status == xmlSecTransformStatusWorking)) {
+        if(inSize > 0) {
+            xmlSecAssert2(outSize == 0, -1);
+
+            /* hash some data */
+            status = BCryptHashData(
+                ctx->hHash,
+                (PBYTE)xmlSecBufferGetData(&transform->inBuf),
+                inSize,
+                0);
+            if(status != STATUS_SUCCESS) {
+                xmlSecMSCngNtError("BCryptHashData",
+                    xmlSecTransformGetName(transform), status);
+                return(-1);
+            }
+
+            ret = xmlSecBufferRemoveHead(&transform->inBuf, inSize);
+            if(ret < 0) {
+                xmlSecInternalError("xmlSecBufferRemoveHead",
+                                     xmlSecTransformGetName(transform));
+                return(-1);
+            }
+        }
+
+        if(last != 0) {
+            if(transform->operation == xmlSecTransformOperationSign) {
+                xmlSecNotImplementedError(NULL);
+                return(-1);
+            }
+            transform->status = xmlSecTransformStatusFinished;
+        }
+    }
+
+    if((transform->status == xmlSecTransformStatusWorking) ||
+            (transform->status == xmlSecTransformStatusFinished)) {
+        xmlSecAssert2(xmlSecBufferGetSize(&transform->inBuf) == 0, -1);
+    } else {
+        xmlSecInvalidTransfromStatusError(transform);
+        return(-1);
+    }
+
+    return(0);
 }
 
 

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -84,7 +84,13 @@ xmlSecMSCngKeyDataX509Finalize(xmlSecKeyDataPtr data) {
     xmlSecAssert(ctx != NULL);
 
     if(ctx->cert != NULL) {
-        CertFreeCertificateContext(ctx->cert);
+        if(!CertDeleteCertificateFromStore(ctx->cert)) {
+            xmlSecMSCngLastError("CertDeleteCertificateFromStore", NULL);
+        }
+
+        if(!CertFreeCertificateContext(ctx->cert)) {
+            xmlSecMSCngLastError("CertFreeCertificateContext", NULL);
+        }
     }
 
     if(ctx->hMemStore != 0) {
@@ -353,7 +359,7 @@ xmlSecMSCngKeyDataX509VerifyAndExtractKey(xmlSecKeyDataPtr data,
         }
 
         /* verify that keyValue matches the key requirements */
-	if(xmlSecKeyReqMatchKeyValue(&(keyInfoCtx->keyReq), keyValue) != 1) {
+        if(xmlSecKeyReqMatchKeyValue(&(keyInfoCtx->keyReq), keyValue) != 1) {
             xmlSecInternalError("xmlSecKeyReqMatchKeyValue",
                 xmlSecKeyDataGetName(data));
             xmlSecKeyDataDestroy(keyValue);

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -278,6 +278,13 @@ xmlSecMSCngX509DataNodeRead(xmlSecKeyDataPtr data, xmlNodePtr node,
     return(0);
 }
 
+/**
+ * xmlSecMSCngX509CertGetTime:
+ *
+ * Converts FILETIME timestamp into time_t. See
+ * <https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx>
+ * for details.
+ */
 static int
 xmlSecMSCngX509CertGetTime(FILETIME in, time_t* out) {
     xmlSecAssert2(out != NULL, -1);
@@ -287,7 +294,7 @@ xmlSecMSCngX509CertGetTime(FILETIME in, time_t* out) {
     *out |= in.dwLowDateTime;
     /* 100 nanoseconds -> seconds */
     *out /= 10000;
-    /* WinAPI epoch -> Unix epoch */
+    /* 1601-01-01 epoch -> 1970-01-01 epoch */
     *out -= 11644473600000;
 
     return(0);


### PR DESCRIPTION
The

````
win32/binaries/xmlsec.exe verify --crypto mscng --crypto-config win32/tmp/xmlsec-crypto-config --trusted-der tests/keys/cacert.der --enabled-key-data x509 --insecure tests/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.xml
````

test now succeeds nicely, next TODO will be to not fail when --insecure is not used.