### PR TITLE
MSCNG: verify certificate

### DIFF
--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -244,7 +244,7 @@ xmlSecMSCngAppKeysMngrCertLoad(xmlSecKeysMngrPtr mngr, const char *filename,
 
     ret = xmlSecMSCngAppKeysMngrCertLoadMemory(mngr, xmlSecBufferGetData(&buffer),
         xmlSecBufferGetSize(&buffer), format, type);
-    if (ret < 0) {
+    if(ret < 0) {
         xmlSecInternalError2("xmlSecMSCngAppKeysMngrCertLoadMemory", NULL,
                              "filename=%s", xmlSecErrorsSafeString(filename));
         xmlSecBufferFinalize(&buffer);
@@ -306,7 +306,7 @@ xmlSecMSCngAppKeysMngrCertLoadMemory(xmlSecKeysMngrPtr mngr, const xmlSecByte* d
 
     xmlSecAssert2(pCert != NULL, -1);
     ret = xmlSecMSCngX509StoreAdoptCert(x509Store, pCert, type);
-    if (ret < 0) {
+    if(ret < 0) {
         xmlSecInternalError("xmlSecMSCngX509StoreAdoptCert", NULL);
         CertFreeCertificateContext(pCert);
         return(-1);

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -235,6 +235,8 @@ xmlSecMSCngKeyDataDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
     dstCtx = xmlSecMSCngKeyDataGetCtx(dst);
     xmlSecAssert2(dstCtx != NULL, -1);
     xmlSecAssert2(dstCtx->cert == NULL, -1);
+    xmlSecAssert2(dstCtx->privkey == NULL, -1);
+    xmlSecAssert2(dstCtx->pubkey == NULL, -1);
 
     srcCtx = xmlSecMSCngKeyDataGetCtx(src);
     xmlSecAssert2(srcCtx != NULL, -1);

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -45,7 +45,7 @@ xmlSecMSCngKeyDataCertGetPubkey(PCCERT_CONTEXT cert, BCRYPT_KEY_HANDLE* key) {
     xmlSecAssert2(cert != NULL, -1);
     xmlSecAssert2(key != NULL, -1);
 
-    if (!CryptImportPublicKeyInfoEx2(X509_ASN_ENCODING,
+    if(!CryptImportPublicKeyInfoEx2(X509_ASN_ENCODING,
             &cert->pCertInfo->SubjectPublicKeyInfo,
             0,
             NULL,
@@ -200,21 +200,21 @@ xmlSecMSCngKeyDataFinalize(xmlSecKeyDataPtr data) {
     ctx = xmlSecMSCngKeyDataGetCtx(data);
     xmlSecAssert(ctx != NULL);
 
-    if (ctx->privkey != 0) {
+    if(ctx->privkey != 0) {
         status = BCryptDestroyKey(ctx->privkey);
         if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptDestroyKey", NULL, status);
         }
     }
 
-    if (ctx->pubkey != 0) {
+    if(ctx->pubkey != 0) {
         status = BCryptDestroyKey(ctx->pubkey);
         if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptDestroyKey", NULL, status);
         }
     }
 
-    if (ctx->cert != NULL) {
+    if(ctx->cert != NULL) {
         CertFreeCertificateContext(ctx->cert);
     }
 
@@ -280,7 +280,7 @@ xmlSecMSCngKeyDataEcdsaGetType(xmlSecKeyDataPtr data) {
     ctx = xmlSecMSCngKeyDataGetCtx(data);
     xmlSecAssert2(ctx != NULL, xmlSecKeyDataTypeUnknown);
 
-    if (ctx->privkey != 0) {
+    if(ctx->privkey != 0) {
         return(xmlSecKeyDataTypePrivate | xmlSecKeyDataTypePublic);
     }
 

--- a/src/mscng/digests.c
+++ b/src/mscng/digests.c
@@ -120,7 +120,7 @@ static void xmlSecMSCngDigestFinalize(xmlSecTransformPtr transform) {
         xmlFree(ctx->pbHashObject);
     }
 
-    if (ctx->pbHash != NULL) {
+    if(ctx->pbHash != NULL) {
         xmlFree(ctx->pbHash);
     }
 
@@ -257,7 +257,7 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
         transform->status = xmlSecTransformStatusWorking;
     }
 
-    if (transform->status == xmlSecTransformStatusWorking) {
+    if(transform->status == xmlSecTransformStatusWorking) {
         xmlSecSize inSize;
 
         inSize = xmlSecBufferGetSize(in);

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -130,7 +130,7 @@ static void xmlSecMSCngSignatureFinalize(xmlSecTransformPtr transform) {
         xmlSecKeyDataDestroy(ctx->data);
     }
 
-    if (ctx->pbHash != NULL) {
+    if(ctx->pbHash != NULL) {
         xmlFree(ctx->pbHash);
     }
 

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -193,6 +193,69 @@ xmlSecMSCngX509StoreAdoptCert(xmlSecKeyDataStorePtr store, PCCERT_CONTEXT pCert,
 }
 
 /**
+ * xmlSecMSCngX509StoreVerifyCertificateOwn:
+ * @cert: the certificate to verify.
+ * @trustedStore: trusted certificates added via xmlSecMSCngX509StoreAdoptCert().
+ * @certStore: the untrusted certificates stack.
+ * @store: key data store, name used for error reporting only.
+ *
+ * Verifies @cert based on trustedStore (ignoring system trusted certificates).
+ *
+ * Returns: 0 on success or a negative value if an error occurs.
+ */
+static int
+xmlSecMSCngX509StoreVerifyCertificateOwn(PCCERT_CONTEXT cert,
+        HCERTSTORE trustedStore, HCERTSTORE certStore,
+        xmlSecKeyDataStorePtr store) {
+        xmlSecNotImplementedError(NULL);
+        return(-1);
+}
+
+/**
+ * xmlSecMSCngX509StoreVerifyCertificate:
+ * @store: the pointer to X509 certificate context store klass.
+ * @cert: the certificate to verify.
+ * @certStore: the untrusted certificates stack.
+ * @keyInfoCtx: the pointer to <dsig:KeyInfo/> element processing context.
+ *
+ * Verifies @cert.
+ *
+ * Returns: 0 on success or a negative value if an error occurs.
+ */
+static int
+xmlSecMSCngX509StoreVerifyCertificate(xmlSecKeyDataStorePtr store,
+    PCCERT_CONTEXT cert, HCERTSTORE certStore, xmlSecKeyInfoCtx* keyInfoCtx) {
+    xmlSecMSCngX509StoreCtxPtr ctx;
+    int ret;
+
+    xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), -1);
+    xmlSecAssert2(cert != NULL, -1);
+    xmlSecAssert2(cert->pCertInfo != NULL, -1);
+    xmlSecAssert2(certStore != NULL, -1);
+    xmlSecAssert2(keyInfoCtx != NULL, -1);
+
+    ctx = xmlSecMSCngX509StoreGetCtx(store);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->hCertStoreCollection != NULL, -1);
+
+    if(keyInfoCtx->certsVerificationTime > 0) {
+        xmlSecNotImplementedError(NULL);
+        return(-1);
+    }
+
+    /* verify based on the own trusted certificates */
+    ret = xmlSecMSCngX509StoreVerifyCertificateOwn(cert,
+        ctx->hCertStoreCollection, certStore, store);
+    if(ret >= 0) {
+        return(0);
+    }
+
+    /* TODO the same based on system trusted certificates */
+    xmlSecNotImplementedError(NULL);
+    return(-1);
+}
+
+/**
  * xmlSecMSCngX509StoreVerify:
  * @store: the pointer to X509 certificate context store klass.
  * @certs: the untrusted certificates stack.
@@ -206,6 +269,7 @@ PCCERT_CONTEXT
 xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
         xmlSecKeyInfoCtx* keyInfoCtx) {
     PCCERT_CONTEXT cert = NULL;
+    int ret;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), NULL);
     xmlSecAssert2(certs != NULL, NULL);
@@ -241,7 +305,10 @@ xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
             }
 
             /* need to actually verify the certificate */
-            xmlSecNotImplementedError(NULL);
+            ret = xmlSecMSCngX509StoreVerifyCertificate(store, cert, certs, keyInfoCtx);
+            if (ret == 0) {
+                return(cert);
+            }
         }
     }
 

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -204,7 +204,7 @@ xmlSecMSCngX509StoreAdoptCert(xmlSecKeyDataStorePtr store, PCCERT_CONTEXT pCert,
  */
 PCCERT_CONTEXT
 xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
-	xmlSecKeyInfoCtx* keyInfoCtx) {
+        xmlSecKeyInfoCtx* keyInfoCtx) {
     PCCERT_CONTEXT cert = NULL;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), NULL);

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -49,14 +49,14 @@ xmlSecMSCngX509StoreFinalize(xmlSecKeyDataStorePtr store) {
     ctx = xmlSecMSCngX509StoreGetCtx(store);
     xmlSecAssert(ctx != NULL);
 
-    if (ctx->hCertStoreCollection != NULL) {
+    if(ctx->hCertStoreCollection != NULL) {
         ret = CertCloseStore(ctx->hCertStoreCollection, CERT_CLOSE_STORE_CHECK_FLAG);
         if(ret == FALSE) {
             xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
         }
     }
 
-    if (ctx->hCertStoreMemory != NULL) {
+    if(ctx->hCertStoreMemory != NULL) {
         ret = CertCloseStore(ctx->hCertStoreMemory, CERT_CLOSE_STORE_CHECK_FLAG);
         if(ret == FALSE) {
             xmlSecMSCngLastError("CertCloseStore", xmlSecKeyDataStoreGetName(store));
@@ -96,7 +96,7 @@ xmlSecMSCngX509StoreInitialize(xmlSecKeyDataStorePtr store) {
         0,
         CERT_STORE_CREATE_NEW_FLAG,
         NULL);
-    if (ctx->hCertStoreMemory == NULL) {
+    if(ctx->hCertStoreMemory == NULL) {
         xmlSecMSCngLastError("CertOpenStore", xmlSecKeyDataStoreGetName(store));
         xmlSecMSCngX509StoreFinalize(store);
         return(-1);
@@ -108,7 +108,7 @@ xmlSecMSCngX509StoreInitialize(xmlSecKeyDataStorePtr store) {
         ctx->hCertStoreMemory,
         CERT_PHYSICAL_STORE_ADD_ENABLE_FLAG,
         1);
-    if (ret == 0) {
+    if(ret == 0) {
         xmlSecMSCngLastError("CertAddStoreToCollection", xmlSecKeyDataStoreGetName(store));
         xmlSecMSCngX509StoreFinalize(store);
         return(-1);
@@ -216,10 +216,10 @@ xmlSecMSCngCheckRevocation(HCERTSTORE store, PCCERT_CONTEXT cert) {
             0,
             NULL,
             &crlEntry);
-        if (ret == 0) {
+        if(ret == 0) {
             continue;
         }
-        if (crlEntry == NULL) {
+        if(crlEntry == NULL) {
             continue;
         }
 
@@ -426,12 +426,12 @@ xmlSecMSCngX509StoreVerify(xmlSecKeyDataStorePtr store, HCERTSTORE certs,
 
             /* need to actually verify the certificate */
             ret = xmlSecMSCngX509StoreVerifyCertificate(store, cert, certs, keyInfoCtx);
-            if (ret == 0) {
+            if(ret == 0) {
                 return(cert);
             }
         }
     }
 
-    return (NULL);
+    return(NULL);
 }
 #endif /* XMLSEC_NO_X509 */


### PR DESCRIPTION
````
XMLSEC_TEST_NAME="aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256" nmake check-dsig
````

now passes up to the 'Verify existing signature' part (previously this was broken as the test doesn't use the `--insecure` flag). Next TODO will be signature creation.