### PR TITLE
Declare variables at the beginning of functions to fix compilation errors with MSVC

### DIFF
--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -1849,6 +1849,8 @@ static int
 xmlSecAppPrepareKeyInfoReadCtx(xmlSecKeyInfoCtxPtr keyInfoCtx) {
     xmlSecAppCmdLineValuePtr value;
     int ret;
+    xmlSecKeyDataId dataId;
+    const char* p;
     
     if(keyInfoCtx == NULL) {
         fprintf(stderr, "Error: key info context is null\n");
@@ -1877,8 +1879,6 @@ xmlSecAppPrepareKeyInfoReadCtx(xmlSecKeyInfoCtxPtr keyInfoCtx) {
                     enabledKeyDataParam.fullName);
             return(-1);
         }
-        xmlSecKeyDataId dataId;
-        const char* p;
 
         for(p = value->strListValue; (p != NULL) && ((*p) != '\0'); p += strlen(p)) {
             dataId = xmlSecKeyDataIdListFindByName(xmlSecKeyDataIdsGet(), BAD_CAST p, xmlSecKeyDataUsageAny);
@@ -2300,6 +2300,11 @@ xmlSecAppXmlDataCreate(const char* filename, const xmlChar* defStartNodeName, co
     xmlSecAppCmdLineValuePtr value;
     xmlSecAppXmlDataPtr data;
     xmlNodePtr cur = NULL;
+
+    xmlChar* attrName;
+    xmlChar* nodeName;
+    xmlChar* nsHref;
+    xmlChar* buf;
         
     if(filename == NULL) {
         fprintf(stderr, "Error: xml filename is null\n");
@@ -2348,10 +2353,7 @@ xmlSecAppXmlDataCreate(const char* filename, const xmlChar* defStartNodeName, co
             xmlSecAppXmlDataDestroy(data);
             return(NULL);
         }
-        xmlChar* attrName = (value->paramNameValue != NULL) ? BAD_CAST value->paramNameValue : BAD_CAST "id";
-        xmlChar* nodeName;
-        xmlChar* nsHref;
-        xmlChar* buf;
+        attrName = (value->paramNameValue != NULL) ? BAD_CAST value->paramNameValue : BAD_CAST "id";
 
         buf = xmlStrdup(BAD_CAST value->strValue);
         if(buf == NULL) {

--- a/src/mscrypto/app.c
+++ b/src/mscrypto/app.c
@@ -480,10 +480,13 @@ xmlSecMSCryptoAppPkcs12LoadMemory(const xmlSecByte* data,
     PCCERT_CONTEXT tmpcert = NULL;
     PCCERT_CONTEXT pCert = NULL;
     WCHAR* wcPwd = NULL;
+    DWORD dwFlags;
     xmlSecKeyDataPtr x509Data = NULL;
     xmlSecKeyDataPtr keyData = NULL;
     xmlSecKeyPtr key = NULL;
-        int ret;
+    int ret;
+    DWORD dwData = 0;
+    DWORD dwDataLen = sizeof(DWORD);
 
     xmlSecAssert2(data != NULL, NULL);
     xmlSecAssert2(dataSize > 1, NULL);
@@ -510,7 +513,7 @@ xmlSecMSCryptoAppPkcs12LoadMemory(const xmlSecByte* data,
         goto done;
     }
 
-    DWORD dwFlags = CRYPT_EXPORTABLE;
+    dwFlags = CRYPT_EXPORTABLE;
     if (!xmlSecImportGetPersistKey()) {
         dwFlags |= PKCS12_NO_PERSIST_KEY;
     }
@@ -531,9 +534,8 @@ xmlSecMSCryptoAppPkcs12LoadMemory(const xmlSecByte* data,
         if(pCert == NULL) {
             break;
         }
-        DWORD dwData = 0;
-        DWORD dwDataLen = sizeof(DWORD);
 
+        dwData = 0;
         /* Find the certificate that has the private key */
         if((TRUE == CertGetCertificateContextProperty(pCert, CERT_KEY_SPEC_PROP_ID, &dwData, &dwDataLen)) && (dwData > 0)) {
             tmpcert = CertDuplicateCertificateContext(pCert);


### PR DESCRIPTION
MSVC 2008 and 2010 both give compilation errors when trying to compile xmlsec with mscrypto.

Like this:

..\src\mscrypto\app.c(513) : error C2275: 'DWORD' : illegal use of this type as an expression
        C:\Program Files\Microsoft SDKs\Windows\v6.0A\include\windef.h(152) : see declaration of 'DWORD'
..\src\mscrypto\app.c(513) : error C2146: syntax error : missing ';' before identifier 'dwFlags'
..\src\mscrypto\app.c(513) : error C2065: 'dwFlags' : undeclared identifier
..\src\mscrypto\app.c(515) : error C2065: 'dwFlags' : undeclared identifier
..\src\mscrypto\app.c(517) : error C2065: 'dwFlags' : undeclared identifier
..\src\mscrypto\app.c(534) : error C2143: syntax error : missing ';' before 'type'
..\src\mscrypto\app.c(535) : error C2275: 'DWORD' : illegal use of this type as an expression
        C:\Program Files\Microsoft SDKs\Windows\v6.0A\include\windef.h(152) : see declaration of 'DWORD'
..\src\mscrypto\app.c(535) : error C2146: syntax error : missing ';' before identifier 'dwDataLen'
..\src\mscrypto\app.c(535) : error C2065: 'dwDataLen' : undeclared identifier
..\src\mscrypto\app.c(538) : error C2065: 'dwData' : undeclared identifier
..\src\mscrypto\app.c(538) : error C2065: 'dwDataLen' : undeclared identifier
..\src\mscrypto\app.c(538) : error C2065: 'dwData' : undeclared identifier