### PR TITLE
MSCNG: adopt key certificate

### DIFF
--- a/include/xmlsec/mscng/certkeys.h
+++ b/include/xmlsec/mscng/certkeys.h
@@ -21,8 +21,7 @@ extern "C" {
 
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataPtr   xmlSecMSCngCertAdopt         (PCCERT_CONTEXT pCert,
                                                                       xmlSecKeyDataType type);
-XMLSEC_CRYPTO_EXPORT BCRYPT_KEY_HANDLE  xmlSecMSCngKeyDataGetKey     (xmlSecKeyDataPtr data,
-                                                                      xmlSecKeyDataType type);
+XMLSEC_CRYPTO_EXPORT BCRYPT_KEY_HANDLE  xmlSecMSCngKeyDataGetPubKey  (xmlSecKeyDataPtr data);
 
 #ifdef __cplusplus
 }

--- a/include/xmlsec/mscng/crypto.h
+++ b/include/xmlsec/mscng/crypto.h
@@ -13,12 +13,15 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include <windows.h>
+
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_mscng(void);
+XMLSEC_CRYPTO_EXPORT LPWSTR xmlSecMSCngMultiByteToWideChar(const char* multiByte);
 
 /********************************************************************
  *

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -39,6 +39,8 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId    xmlSecMSCngKeyDataX509GetKlass(void);
         xmlSecMSCngX509StoreGetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataStoreId xmlSecMSCngX509StoreGetKlass(void);
 
+XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngKeyDataX509AdoptKeyCert   (xmlSecKeyDataPtr data,
+                                                                              PCCERT_CONTEXT cert);
 XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptCert        (xmlSecKeyDataStorePtr store,
                                                                               PCCERT_CONTEXT cert,
                                                                               xmlSecKeyDataType type);

--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -72,12 +72,28 @@ xmlSecMSCngAppKeyLoad(const char *filename, xmlSecKeyDataFormat format,
                       const char *pwd,
                       void* pwdCallback,
                       void* pwdCallbackCtx) {
+    xmlSecKeyPtr key = NULL;
+
     xmlSecAssert2(filename != NULL, NULL);
     xmlSecAssert2(format != xmlSecKeyDataFormatUnknown, NULL);
 
-    /* TODO: load key */
-    xmlSecNotImplementedError(NULL);
-    return(NULL);
+    switch(format) {
+    case xmlSecKeyDataFormatPkcs12:
+        key = xmlSecMSCngAppPkcs12Load(filename, pwd, pwdCallback,
+            pwdCallbackCtx);
+        if(key == NULL) {
+            xmlSecInternalError("xmlSecMSCngAppPkcs12Load", NULL);
+            return(NULL);
+        }
+        break;
+    default:
+        xmlSecOtherError2(XMLSEC_ERRORS_R_INVALID_FORMAT, NULL, "format=%d",
+            (int)format);
+        return(NULL);
+        break;
+    }
+
+    return(key);
 }
 
 /**

--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -185,14 +185,47 @@ xmlSecMSCngAppKeyCertLoadMemory(xmlSecKeyPtr key, const xmlSecByte* data, xmlSec
  */
 xmlSecKeyPtr
 xmlSecMSCngAppPkcs12Load(const char *filename,
-                         const char *pwd ATTRIBUTE_UNUSED,
-                         void* pwdCallback ATTRIBUTE_UNUSED,
-                         void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
-    xmlSecAssert2(filename != NULL, NULL);
+                         const char *pwd,
+                         void* pwdCallback,
+                         void* pwdCallbackCtx) {
+    xmlSecBuffer buffer;
+    xmlSecByte* data;
+    xmlSecKeyPtr key;
+    int ret;
 
-    /* TODO: load pkcs12 file */
-    xmlSecNotImplementedError(NULL);
-    return(NULL);
+    xmlSecAssert2(filename != NULL, NULL);
+    xmlSecAssert2(pwd != NULL, NULL);
+
+    ret = xmlSecBufferInitialize(&buffer, 0);
+    if(ret < 0) {
+        xmlSecInternalError("xmlSecBufferInitialize", NULL);
+        return(NULL);
+    }
+
+    ret = xmlSecBufferReadFile(&buffer, filename);
+    if(ret < 0) {
+        xmlSecInternalError2("xmlSecBufferReadFile", NULL, "filename=%s",
+            xmlSecErrorsSafeString(filename));
+        return(NULL);
+    }
+
+    data = xmlSecBufferGetData(&buffer);
+    if(data == NULL) {
+        xmlSecInvalidDataError("xmlSecBufferGetData", NULL);
+        xmlSecBufferFinalize(&buffer);
+        return(NULL);
+    }
+
+    key = xmlSecMSCngAppPkcs12LoadMemory(data, xmlSecBufferGetSize(&buffer),
+        pwd, pwdCallback, pwdCallbackCtx);
+    if(key == NULL) {
+        xmlSecInternalError("xmlSecMSCngAppPkcs12LoadMemory", NULL);
+        xmlSecBufferFinalize(&buffer);
+        return(NULL);
+    }
+
+    xmlSecBufferFinalize(&buffer);
+    return(key);
 }
 
 /**

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -276,8 +276,11 @@ xmlSecMSCngKeyDataDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
     }
 
     if(srcCtx->privkey != 0) {
-        xmlSecNotImplementedError(NULL);
-        return(-1);
+        ret = xmlSecMSCngKeyDataCertGetPrivkey(dstCtx->cert, &dstCtx->privkey);
+        if(ret < 0) {
+            xmlSecInternalError("xmlSecMSCngKeyDataCertGetPrivkey", NULL);
+            return(-1);
+        }
     }
 
     /* avoid BCryptDuplicateKey() here as that works for symmetric keys only */

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -15,6 +15,7 @@
 #undef WIN32_NO_STATUS
 #include <ntstatus.h>
 #include <bcrypt.h>
+#include <ncrypt.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/xmltree.h>
@@ -31,7 +32,7 @@ typedef struct _xmlSecMSCngKeyDataCtx xmlSecMSCngKeyDataCtx,
 
 struct _xmlSecMSCngKeyDataCtx {
     PCCERT_CONTEXT cert;
-    BCRYPT_KEY_HANDLE privkey;
+    NCRYPT_KEY_HANDLE privkey;
     BCRYPT_KEY_HANDLE pubkey;
 };
 
@@ -57,6 +58,31 @@ xmlSecMSCngKeyDataCertGetPubkey(PCCERT_CONTEXT cert, BCRYPT_KEY_HANDLE* key) {
     return(0);
 }
 
+static int
+xmlSecMSCngKeyDataCertGetPrivkey(PCCERT_CONTEXT cert, NCRYPT_KEY_HANDLE* key) {
+    int ret;
+
+    xmlSecAssert2(cert != NULL, -1);
+    xmlSecAssert2(key != NULL, -1);
+
+    DWORD keySpec = 0;
+    BOOL callerFree = FALSE;
+
+    ret = CryptAcquireCertificatePrivateKey(
+        cert,
+        CRYPT_ACQUIRE_COMPARE_KEY_FLAG | CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG,
+        NULL,
+        key,
+        &keySpec,
+        &callerFree);
+    if(ret == FALSE) {
+        xmlSecMSCngLastError("CryptAcquireCertificatePrivateKey", NULL);
+        return(-1);
+    }
+
+    return(0);
+}
+
 /**
  * xmlSecMSCngKeyDataAdoptCert:
  * @data:               the pointer to MSCng pccert data.
@@ -69,7 +95,7 @@ xmlSecMSCngKeyDataCertGetPubkey(PCCERT_CONTEXT cert, BCRYPT_KEY_HANDLE* key) {
 static int
 xmlSecMSCngKeyDataAdoptCert(xmlSecKeyDataPtr data, PCCERT_CONTEXT cert, xmlSecKeyDataType type) {
     xmlSecMSCngKeyDataCtxPtr ctx;
-    BCRYPT_KEY_HANDLE hKey;
+    BCRYPT_KEY_HANDLE hPubKey;
     int ret;
 
     xmlSecAssert2(xmlSecKeyDataIsValid(data), -1);
@@ -85,17 +111,24 @@ xmlSecMSCngKeyDataAdoptCert(xmlSecKeyDataPtr data, PCCERT_CONTEXT cert, xmlSecKe
 
     /* acquire the CNG key handle from the certificate */
     if((type & xmlSecKeyDataTypePrivate) != 0) {
-        xmlSecNotImplementedError(NULL);
+        NCRYPT_KEY_HANDLE hPrivKey;
 
-        return(-1);
+        ret = xmlSecMSCngKeyDataCertGetPrivkey(cert, &hPrivKey);
+        if(ret < 0) {
+            xmlSecInternalError("xmlSecMSCngKeyDataCertGetPrivkey", NULL);
+            return(-1);
+        }
+
+        ctx->privkey = hPrivKey;
     }
 
-    ret = xmlSecMSCngKeyDataCertGetPubkey(cert, &hKey);
+    ret = xmlSecMSCngKeyDataCertGetPubkey(cert, &hPubKey);
     if(ret < 0) {
         xmlSecInternalError("xmlSecMSCngKeyDataCertGetPubkey", NULL);
         return(-1);
     }
-    ctx->pubkey = hKey;
+
+    ctx->pubkey = hPubKey;
     ctx->cert = cert;
 
     return(0);
@@ -148,17 +181,16 @@ xmlSecMSCngCertAdopt(PCCERT_CONTEXT pCert, xmlSecKeyDataType type) {
 }
 
 /**
- * xmlSecMSCngKeyDataGetKey:
+ * xmlSecMSCngKeyDataGetPubKey:
  * @data: the key data to retrieve certificate from.
- * @type: type of key requested (public/private)
  *
- * Native MSCng key retrieval from xmlsec keydata. The returned key must not be
- * destroyed by the caller.
+ * Native MSCng public key retrieval from xmlsec keydata. The returned key must
+ * not be destroyed by the caller.
  *
  * Returns: key on success or 0 otherwise.
  */
 BCRYPT_KEY_HANDLE
-xmlSecMSCngKeyDataGetKey(xmlSecKeyDataPtr data, xmlSecKeyDataType type) {
+xmlSecMSCngKeyDataGetPubKey(xmlSecKeyDataPtr data) {
     xmlSecMSCngKeyDataCtxPtr ctx;
 
     xmlSecAssert2(xmlSecKeyDataIsValid(data), 0);
@@ -166,10 +198,6 @@ xmlSecMSCngKeyDataGetKey(xmlSecKeyDataPtr data, xmlSecKeyDataType type) {
 
     ctx = xmlSecMSCngKeyDataGetCtx(data);
     xmlSecAssert2(ctx != NULL, 0);
-
-    if(type == xmlSecKeyDataTypePrivate) {
-        return(ctx->privkey);
-    }
 
     return(ctx->pubkey);
 }
@@ -201,7 +229,7 @@ xmlSecMSCngKeyDataFinalize(xmlSecKeyDataPtr data) {
     xmlSecAssert(ctx != NULL);
 
     if(ctx->privkey != 0) {
-        status = BCryptDestroyKey(ctx->privkey);
+        status = NCryptFreeObject(ctx->privkey);
         if(status != STATUS_SUCCESS) {
             xmlSecMSCngNtError("BCryptDestroyKey", NULL, status);
         }
@@ -235,7 +263,7 @@ xmlSecMSCngKeyDataDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
     dstCtx = xmlSecMSCngKeyDataGetCtx(dst);
     xmlSecAssert2(dstCtx != NULL, -1);
     xmlSecAssert2(dstCtx->cert == NULL, -1);
-    xmlSecAssert2(dstCtx->privkey == NULL, -1);
+    xmlSecAssert2(dstCtx->privkey == 0, -1);
     xmlSecAssert2(dstCtx->pubkey == NULL, -1);
 
     srcCtx = xmlSecMSCngKeyDataGetCtx(src);

--- a/src/mscng/crypto.c
+++ b/src/mscng/crypto.c
@@ -314,3 +314,32 @@ xmlSecMSCngKeysMngrInit(xmlSecKeysMngrPtr mngr) {
 }
 
 
+LPWSTR
+xmlSecMSCngMultiByteToWideChar(const char* multiByte) {
+    LPWSTR wideChar = NULL;
+    int size;
+    int ret;
+
+    xmlSecAssert2(multiByte != NULL, NULL);
+
+    /* determinze size */
+    size = MultiByteToWideChar(CP_ACP, 0, multiByte, -1, NULL, 0);
+    if(size < 0) {
+        return(NULL);
+    }
+
+    wideChar = (LPWSTR)xmlMalloc(size * sizeof(WCHAR));
+    if(wideChar == NULL) {
+        xmlSecMallocError(size * sizeof(WCHAR), NULL);
+        return(NULL);
+    }
+
+    /* process the input string */
+    ret = MultiByteToWideChar(CP_ACP, 0, multiByte, -1, wideChar, size);
+    if(ret < 0) {
+        xmlFree(wideChar);
+        return(NULL);
+    }
+
+    return(wideChar);
+}

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -220,9 +220,9 @@ static int xmlSecMSCngSignatureVerify(xmlSecTransformPtr transform,
     ctx = xmlSecMSCngSignatureGetCtx(transform);
     xmlSecAssert2(ctx != NULL, -1);
 
-    pubkey = xmlSecMSCngKeyDataGetKey(ctx->data, xmlSecKeyDataTypePublic);
+    pubkey = xmlSecMSCngKeyDataGetPubKey(ctx->data);
     if(pubkey == 0) {
-        xmlSecInternalError("xmlSecMSCngKeyDataGetKey",
+        xmlSecInternalError("xmlSecMSCngKeyDataGetPubKey",
             xmlSecTransformGetName(transform));
         return(-1);
     }

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -66,12 +66,52 @@ xmlSecMSCngKeyDataX509Initialize(xmlSecKeyDataPtr data) {
 
 static int
 xmlSecMSCngKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
+    PCCERT_CONTEXT srcCert = NULL;
+    PCCERT_CONTEXT dstCert;
+    xmlSecMSCngX509DataCtxPtr srcCtx;
+    int ret;
+
     xmlSecAssert2(xmlSecKeyDataCheckId(dst, xmlSecMSCngKeyDataX509Id), -1);
     xmlSecAssert2(xmlSecKeyDataCheckId(src, xmlSecMSCngKeyDataX509Id), -1);
+    srcCtx = xmlSecMSCngX509DataGetCtx(src);
 
-    xmlSecNotImplementedError(NULL);
+    /* duplicate the certificate store */
+    while((srcCert = CertEnumCertificatesInStore(srcCtx->hMemStore, srcCert)) != NULL) {
+        dstCert = CertDuplicateCertificateContext(srcCert);
+        if(dstCert == NULL) {
+            xmlSecMSCngLastError("CertDuplicateCertificateContext",
+                xmlSecKeyDataGetName(dst));
+            return(-1);
+        }
 
-    return(-1);
+        ret = xmlSecMSCngKeyDataX509AdoptCert(dst, dstCert);
+        if(ret < 0) {
+            xmlSecInternalError("xmlSecMSCngKeyDataX509AdoptCert",
+                xmlSecKeyDataGetName(dst));
+            CertFreeCertificateContext(dstCert);
+            return(-1);
+        }
+    }
+
+    if(srcCtx->cert != NULL) {
+        /* have a key certificate, duplicate that */
+        dstCert = CertDuplicateCertificateContext(srcCtx->cert);
+        if(dstCert == NULL) {
+            xmlSecMSCngLastError("CertDuplicateCertificateContext",
+                xmlSecKeyDataGetName(dst));
+            return(-1);
+        }
+
+        ret = xmlSecMSCngKeyDataX509AdoptKeyCert(dst, dstCert);
+        if(ret < 0) {
+            xmlSecInternalError("xmlSecMSCngKeyDataX509AdoptKeyCert",
+                xmlSecKeyDataGetName(dst));
+            CertFreeCertificateContext(dstCert);
+            return(-1);
+        }
+    }
+
+    return(0);
 }
 
 static void

--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -158,6 +158,25 @@ xmlSecMSCngX509CertBase64DerRead(xmlChar* buf) {
     return(xmlSecMSCngX509CertDerRead((xmlSecByte*)buf, size));
 }
 
+
+int
+xmlSecMSCngKeyDataX509AdoptKeyCert(xmlSecKeyDataPtr data, PCCERT_CONTEXT cert) {
+    xmlSecMSCngX509DataCtxPtr ctx;
+
+    xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecMSCngKeyDataX509Id), -1);
+    xmlSecAssert2(cert != NULL, -1);
+
+    ctx = xmlSecMSCngX509DataGetCtx(data);
+    xmlSecAssert2(ctx != NULL, -1);
+
+    if(ctx->cert != NULL) {
+        CertFreeCertificateContext(ctx->cert);
+    }
+    ctx->cert = cert;
+
+    return(0);
+}
+
 static int
 xmlSecMSCngKeyDataX509AdoptCert(xmlSecKeyDataPtr data, PCCERT_CONTEXT cert) {
     xmlSecMSCngX509DataCtxPtr ctx;

--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -76,9 +76,9 @@ else
 fi
 
 #
-# Need to force persistence for mscrypto
+# Need to force persistence for mscrypto and mscng
 #
-if [ "z$crypto" = "zmscrypto" ] ; then
+if [ "z$crypto" = "zmscrypto" -o "z$crypto" = "zmscng" ] ; then
     priv_key_option="--pkcs12-persist $priv_key_option"
 fi
 

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -437,8 +437,8 @@ XMLSEC_NSS_ALIBS        = smime3.lib ssl3.lib nss3.lib libnspr4_s.lib libplds4_s
 XMLSEC_MSCRYPTO_SOLIBS  = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib
 XMLSEC_MSCRYPTO_ALIBS   = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib
 
-XMLSEC_MSCNG_SOLIBS  = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib Bcrypt.lib
-XMLSEC_MSCNG_ALIBS   = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib Bcrypt.lib
+XMLSEC_MSCNG_SOLIBS  = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib Bcrypt.lib Ncrypt.lib
+XMLSEC_MSCNG_ALIBS   = kernel32.lib user32.lib gdi32.lib Crypt32.lib Advapi32.lib Bcrypt.lib Ncrypt.lib
 
 
 # The archiver and its options.


### PR DESCRIPTION
This implements handling of private key / key certificate. Next TODO will be xmlSecMSCngKeyDataX509XmlWrite(), i.e. XML serialization of all this.