### PR TITLE
MSCNG: add SHA1 and SHA256 support for ECDSA

### DIFF
--- a/include/xmlsec/mscng/crypto.h
+++ b/include/xmlsec/mscng/crypto.h
@@ -49,6 +49,17 @@ XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngKeysMngrInit      (xmlSecKeys
         xmlSecMSCngKeyDataEcdsaGetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId xmlSecMSCngKeyDataEcdsaGetKlass(void);
 
+#ifndef XMLSEC_NO_SHA1
+/**
+ * xmlSecMSCngTransformEcdsaSha1Id:
+ *
+ * The ECDSA-SHA1 signature transform klass.
+ */
+#define xmlSecMSCngTransformEcdsaSha1Id     \
+       xmlSecMSCngTransformEcdsaSha1GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformEcdsaSha1GetKlass(void);
+#endif /* XMLSEC_NO_SHA1 */
+
 #ifndef XMLSEC_NO_SHA256
 /**
  * xmlSecMSCngTransformEcdsaSha256Id:
@@ -72,6 +83,22 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformEcdsaSha512GetKlass(v
 #endif /* XMLSEC_NO_SHA512 */
 
 #endif /* XMLSEC_NO_ECDSA */
+
+/********************************************************************
+ *
+ * SHA1 transform
+ *
+ *******************************************************************/
+#ifndef XMLSEC_NO_SHA1
+/**
+ * xmlSecMSCngTransformSha1Id:
+ *
+ * The SHA1 digest transform klass.
+ */
+#define xmlSecMSCngTransformSha1Id \
+       xmlSecMSCngTransformSha1GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformSha1GetKlass(void);
+#endif /* XMLSEC_NO_SHA1 */
 
 /********************************************************************
  *

--- a/include/xmlsec/mscng/crypto.h
+++ b/include/xmlsec/mscng/crypto.h
@@ -60,6 +60,17 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyDataId xmlSecMSCngKeyDataEcdsaGetKlass(void);
 XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformEcdsaSha256GetKlass(void);
 #endif /* XMLSEC_NO_SHA256 */
 
+#ifndef XMLSEC_NO_SHA512
+/**
+ * xmlSecMSCngTransformEcdsaSha512Id:
+ *
+ * The ECDSA-SHA512 signature transform klass.
+ */
+#define xmlSecMSCngTransformEcdsaSha512Id     \
+       xmlSecMSCngTransformEcdsaSha512GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformEcdsaSha512GetKlass(void);
+#endif /* XMLSEC_NO_SHA512 */
+
 #endif /* XMLSEC_NO_ECDSA */
 
 /********************************************************************
@@ -77,6 +88,22 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformEcdsaSha256GetKlass(v
        xmlSecMSCngTransformSha256GetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformSha256GetKlass(void);
 #endif /* XMLSEC_NO_SHA256 */
+
+/********************************************************************
+ *
+ * SHA512 transform
+ *
+ *******************************************************************/
+#ifndef XMLSEC_NO_SHA512
+/**
+ * xmlSecMSCngTransformSha512Id:
+ *
+ * The SHA512 digest transform klass.
+ */
+#define xmlSecMSCngTransformSha512Id \
+       xmlSecMSCngTransformSha512GetKlass()
+XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecMSCngTransformSha512GetKlass(void);
+#endif /* XMLSEC_NO_SHA512 */
 
 #ifdef __cplusplus
 }

--- a/src/mscng/crypto.c
+++ b/src/mscng/crypto.c
@@ -140,7 +140,7 @@ xmlSecCryptoGetFunctions_mscng(void) {
     /******************************* ECDSA ********************************/
 #ifndef XMLSEC_NO_ECDSA
 
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_SHA1
     gXmlSecMSCngFunctions->transformEcdsaSha1GetKlass           = xmlSecMSCngTransformEcdsaSha1GetKlass;
 #endif /* XMLSEC_NO_SHA1 */
 
@@ -205,7 +205,7 @@ xmlSecCryptoGetFunctions_mscng(void) {
 #endif /* XMLSEC_NO_RSA */
 
     /******************************* SHA1 ********************************/
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_SHA1
     gXmlSecMSCngFunctions->transformSha1GetKlass                = xmlSecMSCngTransformSha1GetKlass;
 #endif /* XMLSEC_NO_SHA1 */
 #ifndef XMLSEC_NO_SHA256

--- a/src/mscng/crypto.c
+++ b/src/mscng/crypto.c
@@ -156,7 +156,7 @@ xmlSecCryptoGetFunctions_mscng(void) {
     gXmlSecMSCngFunctions->transformEcdsaSha384GetKlass         = xmlSecMSCngTransformEcdsaSha384GetKlass;
 #endif /* XMLSEC_NO_SHA384 */
 
-#ifdef XMLSEC_MSCNG_TODO
+#ifndef XMLSEC_NO_SHA512
     gXmlSecMSCngFunctions->transformEcdsaSha512GetKlass         = xmlSecMSCngTransformEcdsaSha512GetKlass;
 #endif /* XMLSEC_NO_SHA512 */
 
@@ -211,6 +211,9 @@ xmlSecCryptoGetFunctions_mscng(void) {
 #ifndef XMLSEC_NO_SHA256
     gXmlSecMSCngFunctions->transformSha256GetKlass              = xmlSecMSCngTransformSha256GetKlass;
 #endif /* XMLSEC_NO_SHA256 */
+#ifndef XMLSEC_NO_SHA512
+    gXmlSecMSCngFunctions->transformSha512GetKlass              = xmlSecMSCngTransformSha512GetKlass;
+#endif /* XMLSEC_NO_SHA512 */
 
     /********************************************************************
      *

--- a/src/mscng/digests.c
+++ b/src/mscng/digests.c
@@ -62,6 +62,11 @@ static int      xmlSecMSCngDigestCheckId     (xmlSecTransformPtr transform);
 static int
 xmlSecMSCngDigestCheckId(xmlSecTransformPtr transform) {
 
+#ifndef XMLSEC_NO_SHA1
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha1Id)) {
+        return(1);
+    } else
+#endif /* XMLSEC_NO_SHA1 */
 #ifndef XMLSEC_NO_SHA256
     if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha256Id)) {
         return(1);
@@ -89,6 +94,12 @@ xmlSecMSCngDigestInitialize(xmlSecTransformPtr transform) {
 
     /* initialize context */
     memset(ctx, 0, sizeof(xmlSecMSCngDigestCtx));
+
+#ifndef XMLSEC_NO_SHA1
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha1Id)) {
+        ctx->pszAlgId = BCRYPT_SHA1_ALGORITHM;
+    } else
+#endif /* XMLSEC_NO_SHA1 */
 
 #ifndef XMLSEC_NO_SHA256
     if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha256Id)) {
@@ -326,6 +337,50 @@ xmlSecMSCngDigestExecute(xmlSecTransformPtr transform,
 
     return(0);
 }
+
+#ifndef XMLSEC_NO_SHA1
+/******************************************************************************
+ *
+ * SHA1
+ *
+ *****************************************************************************/
+static xmlSecTransformKlass xmlSecMSCngSha1Klass = {
+    /* klass/object sizes */
+    sizeof(xmlSecTransformKlass),              /* size_t klassSize */
+    xmlSecMSCngDigestSize,                  /* size_t objSize */
+
+    xmlSecNameSha1,                          /* const xmlChar* name; */
+    xmlSecHrefSha1,                          /* const xmlChar* href; */
+    xmlSecTransformUsageDigestMethod,          /* xmlSecTransformUsage usage; */
+    xmlSecMSCngDigestInitialize,               /* xmlSecTransformInitializeMethod initialize; */
+    xmlSecMSCngDigestFinalize,                 /* xmlSecTransformFinalizeMethod finalize; */
+    NULL,                                      /* xmlSecTransformNodeReadMethod readNode; */
+    NULL,                                      /* xmlSecTransformNodeWriteMethod writeNode; */
+    NULL,                                      /* xmlSecTransformSetKeyReqMethod setKeyReq; */
+    NULL,                                      /* xmlSecTransformSetKeyMethod setKey; */
+    xmlSecMSCngDigestVerify,                   /* xmlSecTransformVerifyMethod verify; */
+    xmlSecTransformDefaultGetDataType,         /* xmlSecTransformGetDataTypeMethod getDataType; */
+    xmlSecTransformDefaultPushBin,             /* xmlSecTransformPushBinMethod pushBin; */
+    xmlSecTransformDefaultPopBin,              /* xmlSecTransformPopBinMethod popBin; */
+    NULL,                                      /* xmlSecTransformPushXmlMethod pushXml; */
+    NULL,                                      /* xmlSecTransformPopXmlMethod popXml; */
+    xmlSecMSCngDigestExecute,                  /* xmlSecTransformExecuteMethod execute; */
+    NULL,                                      /* void* reserved0; */
+    NULL,                                      /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngTransformSha1GetKlass:
+ *
+ * SHA-1 digest transform klass.
+ *
+ * Returns: pointer to SHA-1 digest transform klass.
+ */
+xmlSecTransformId
+xmlSecMSCngTransformSha1GetKlass(void) {
+    return(&xmlSecMSCngSha1Klass);
+}
+#endif /* XMLSEC_NO_SHA1 */
 
 #ifndef XMLSEC_NO_SHA256
 /******************************************************************************

--- a/src/mscng/digests.c
+++ b/src/mscng/digests.c
@@ -65,8 +65,13 @@ xmlSecMSCngDigestCheckId(xmlSecTransformPtr transform) {
 #ifndef XMLSEC_NO_SHA256
     if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha256Id)) {
         return(1);
-    }
+    } else
 #endif /* XMLSEC_NO_SHA256 */
+#ifndef XMLSEC_NO_SHA512
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha512Id)) {
+        return(1);
+    } else
+#endif /* XMLSEC_NO_SHA512 */
 
     return(0);
 }
@@ -90,6 +95,12 @@ xmlSecMSCngDigestInitialize(xmlSecTransformPtr transform) {
         ctx->pszAlgId = BCRYPT_SHA256_ALGORITHM;
     } else
 #endif /* XMLSEC_NO_SHA256 */
+
+#ifndef XMLSEC_NO_SHA512
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformSha512Id)) {
+        ctx->pszAlgId = BCRYPT_SHA512_ALGORITHM;
+    } else
+#endif /* XMLSEC_NO_SHA512 */
 
     {
         xmlSecInvalidTransfromError(transform);
@@ -359,3 +370,47 @@ xmlSecMSCngTransformSha256GetKlass(void) {
     return(&xmlSecMSCngSha256Klass);
 }
 #endif /* XMLSEC_NO_SHA256 */
+
+#ifndef XMLSEC_NO_SHA512
+/******************************************************************************
+ *
+ * SHA512
+ *
+ *****************************************************************************/
+static xmlSecTransformKlass xmlSecMSCngSha512Klass = {
+    /* klass/object sizes */
+    sizeof(xmlSecTransformKlass),              /* size_t klassSize */
+    xmlSecMSCngDigestSize,                  /* size_t objSize */
+
+    xmlSecNameSha512,                          /* const xmlChar* name; */
+    xmlSecHrefSha512,                          /* const xmlChar* href; */
+    xmlSecTransformUsageDigestMethod,          /* xmlSecTransformUsage usage; */
+    xmlSecMSCngDigestInitialize,               /* xmlSecTransformInitializeMethod initialize; */
+    xmlSecMSCngDigestFinalize,                 /* xmlSecTransformFinalizeMethod finalize; */
+    NULL,                                      /* xmlSecTransformNodeReadMethod readNode; */
+    NULL,                                      /* xmlSecTransformNodeWriteMethod writeNode; */
+    NULL,                                      /* xmlSecTransformSetKeyReqMethod setKeyReq; */
+    NULL,                                      /* xmlSecTransformSetKeyMethod setKey; */
+    xmlSecMSCngDigestVerify,                   /* xmlSecTransformVerifyMethod verify; */
+    xmlSecTransformDefaultGetDataType,         /* xmlSecTransformGetDataTypeMethod getDataType; */
+    xmlSecTransformDefaultPushBin,             /* xmlSecTransformPushBinMethod pushBin; */
+    xmlSecTransformDefaultPopBin,              /* xmlSecTransformPopBinMethod popBin; */
+    NULL,                                      /* xmlSecTransformPushXmlMethod pushXml; */
+    NULL,                                      /* xmlSecTransformPopXmlMethod popXml; */
+    xmlSecMSCngDigestExecute,                  /* xmlSecTransformExecuteMethod execute; */
+    NULL,                                      /* void* reserved0; */
+    NULL,                                      /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngTransformSha512GetKlass:
+ *
+ * SHA-512 digest transform klass.
+ *
+ * Returns: pointer to SHA-512 digest transform klass.
+ */
+xmlSecTransformId
+xmlSecMSCngTransformSha512GetKlass(void) {
+    return(&xmlSecMSCngSha512Klass);
+}
+#endif /* XMLSEC_NO_SHA512 */

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -80,6 +80,12 @@ static int xmlSecMSCngSignatureCheckId(xmlSecTransformPtr transform) {
     } else
 #endif /* XMLSEC_NO_SHA256 */
 
+#ifndef XMLSEC_NO_SHA512
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha512Id)) {
+       return(1);
+    } else
+#endif /* XMLSEC_NO_SHA512 */
+
 #endif /* XMLSEC_NO_ECDSA */
 
     /* not found */
@@ -105,6 +111,13 @@ static int xmlSecMSCngSignatureInitialize(xmlSecTransformPtr transform) {
         ctx->keyId = xmlSecMSCngKeyDataEcdsaId;
     } else
 #endif /* XMLSEC_NO_SHA256 */
+
+#ifndef XMLSEC_NO_SHA512
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha512Id)) {
+        ctx->pszHashAlgId = BCRYPT_SHA512_ALGORITHM;
+        ctx->keyId = xmlSecMSCngKeyDataEcdsaId;
+    } else
+#endif /* XMLSEC_NO_SHA512 */
 
 #endif /* XMLSEC_NO_ECDSA */
 
@@ -503,5 +516,51 @@ xmlSecMSCngTransformEcdsaSha256GetKlass(void) {
     return(&xmlSecMSCngEcdsaSha256Klass);
 }
 #endif /* XMLSEC_NO_SHA256 */
+
+#ifndef XMLSEC_NO_SHA512
+/****************************************************************************
+ *
+ * ECDSA-SHA512 signature transform
+ *
+ ***************************************************************************/
+static xmlSecTransformKlass xmlSecMSCngEcdsaSha512Klass = {
+    /* klass/object sizes */
+    sizeof(xmlSecTransformKlass),              /* xmlSecSize klassSize */
+    xmlSecMSCngSignatureSize,                  /* xmlSecSize objSize */
+
+    xmlSecNameEcdsaSha512,                     /* const xmlChar* name; */
+    xmlSecHrefEcdsaSha512,                     /* const xmlChar* href; */
+    xmlSecTransformUsageSignatureMethod,       /* xmlSecTransformUsage usage; */
+
+    xmlSecMSCngSignatureInitialize,            /* xmlSecTransformInitializeMethod initialize; */
+    xmlSecMSCngSignatureFinalize,              /* xmlSecTransformFinalizeMethod finalize; */
+    NULL,                                      /* xmlSecTransformNodeReadMethod readNode; */
+    NULL,                                      /* xmlSecTransformNodeWriteMethod writeNode; */
+    xmlSecMSCngSignatureSetKeyReq,             /* xmlSecTransformSetKeyReqMethod setKeyReq; */
+    xmlSecMSCngSignatureSetKey,                /* xmlSecTransformSetKeyMethod setKey; */
+    xmlSecMSCngSignatureVerify,                /* xmlSecTransformVerifyMethod verify; */
+    xmlSecTransformDefaultGetDataType,         /* xmlSecTransformGetDataTypeMethod getDataType; */
+    xmlSecTransformDefaultPushBin,             /* xmlSecTransformPushBinMethod pushBin; */
+    xmlSecTransformDefaultPopBin,              /* xmlSecTransformPopBinMethod popBin; */
+    NULL,                                      /* xmlSecTransformPushXmlMethod pushXml; */
+    NULL,                                      /* xmlSecTransformPopXmlMethod popXml; */
+    xmlSecMSCngSignatureExecute,               /* xmlSecTransformExecuteMethod execute; */
+
+    NULL,                                      /* void* reserved0; */
+    NULL,                                      /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngTransformEcdsaSha512GetKlass:
+ *
+ * The ECDSA-SHA512 signature transform klass.
+ *
+ * Returns: ECDSA-SHA512 signature transform klass.
+ */
+xmlSecTransformId
+xmlSecMSCngTransformEcdsaSha512GetKlass(void) {
+    return(&xmlSecMSCngEcdsaSha512Klass);
+}
+#endif /* XMLSEC_NO_SHA512 */
 
 #endif /* XMLSEC_NO_ECDSA */

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -74,6 +74,12 @@ static int xmlSecMSCngSignatureCheckId(xmlSecTransformPtr transform) {
 
 #ifndef XMLSEC_NO_ECDSA
 
+#ifndef XMLSEC_NO_SHA1
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha1Id)) {
+       return(1);
+    } else
+#endif /* XMLSEC_NO_SHA1 */
+
 #ifndef XMLSEC_NO_SHA256
     if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha256Id)) {
        return(1);
@@ -104,6 +110,13 @@ static int xmlSecMSCngSignatureInitialize(xmlSecTransformPtr transform) {
     memset(ctx, 0, sizeof(xmlSecMSCngSignatureCtx));
 
 #ifndef XMLSEC_NO_ECDSA
+
+#ifndef XMLSEC_NO_SHA1
+    if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha1Id)) {
+        ctx->pszHashAlgId = BCRYPT_SHA1_ALGORITHM;
+        ctx->keyId = xmlSecMSCngKeyDataEcdsaId;
+    } else
+#endif /* XMLSEC_NO_SHA1 */
 
 #ifndef XMLSEC_NO_SHA256
     if(xmlSecTransformCheckId(transform, xmlSecMSCngTransformEcdsaSha256Id)) {
@@ -470,6 +483,52 @@ xmlSecMSCngSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTransf
 
 
 #ifndef XMLSEC_NO_ECDSA
+
+#ifndef XMLSEC_NO_SHA1
+/****************************************************************************
+ *
+ * ECDSA-SHA1 signature transform
+ *
+ ***************************************************************************/
+static xmlSecTransformKlass xmlSecMSCngEcdsaSha1Klass = {
+    /* klass/object sizes */
+    sizeof(xmlSecTransformKlass),              /* xmlSecSize klassSize */
+    xmlSecMSCngSignatureSize,                  /* xmlSecSize objSize */
+
+    xmlSecNameEcdsaSha1,                     /* const xmlChar* name; */
+    xmlSecHrefEcdsaSha1,                     /* const xmlChar* href; */
+    xmlSecTransformUsageSignatureMethod,       /* xmlSecTransformUsage usage; */
+
+    xmlSecMSCngSignatureInitialize,            /* xmlSecTransformInitializeMethod initialize; */
+    xmlSecMSCngSignatureFinalize,              /* xmlSecTransformFinalizeMethod finalize; */
+    NULL,                                      /* xmlSecTransformNodeReadMethod readNode; */
+    NULL,                                      /* xmlSecTransformNodeWriteMethod writeNode; */
+    xmlSecMSCngSignatureSetKeyReq,             /* xmlSecTransformSetKeyReqMethod setKeyReq; */
+    xmlSecMSCngSignatureSetKey,                /* xmlSecTransformSetKeyMethod setKey; */
+    xmlSecMSCngSignatureVerify,                /* xmlSecTransformVerifyMethod verify; */
+    xmlSecTransformDefaultGetDataType,         /* xmlSecTransformGetDataTypeMethod getDataType; */
+    xmlSecTransformDefaultPushBin,             /* xmlSecTransformPushBinMethod pushBin; */
+    xmlSecTransformDefaultPopBin,              /* xmlSecTransformPopBinMethod popBin; */
+    NULL,                                      /* xmlSecTransformPushXmlMethod pushXml; */
+    NULL,                                      /* xmlSecTransformPopXmlMethod popXml; */
+    xmlSecMSCngSignatureExecute,               /* xmlSecTransformExecuteMethod execute; */
+
+    NULL,                                      /* void* reserved0; */
+    NULL,                                      /* void* reserved1; */
+};
+
+/**
+ * xmlSecMSCngTransformEcdsaSha1GetKlass:
+ *
+ * The ECDSA-SHA1 signature transform klass.
+ *
+ * Returns: ECDSA-SHA1 signature transform klass.
+ */
+xmlSecTransformId
+xmlSecMSCngTransformEcdsaSha1GetKlass(void) {
+    return(&xmlSecMSCngEcdsaSha1Klass);
+}
+#endif /* XMLSEC_NO_SHA1 */
 
 #ifndef XMLSEC_NO_SHA256
 /****************************************************************************


### PR DESCRIPTION
````
XMLSEC_TEST_NAME="aleksey-xmldsig-01/enveloping-sha1-ecdsa-sha1" nmake check-dsig
XMLSEC_TEST_NAME="aleksey-xmldsig-01/enveloping-sha512-ecdsa-sha512" nmake check-dsig
````

These two testcases now pass with the changes.