### PR TITLE
tests: add support for reproducible output

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -1,3 +1,6 @@
+Running a specific test
+----------------------------------------------
+
 If a test fails, it's possible to re-run just that specific test for that
 specific backend using:
 
@@ -8,3 +11,13 @@ where $name is the key name for key tests, and a file name otherwise.
 Example:
 
 > make check-crypto-nss XMLSEC_TEST_NAME="enveloping-sha256-rsa-sha256-relationship"
+
+Reproducible output
+----------------------------------------------
+
+It is also possible to have reproducible output, filtering out timestamps. This
+is useful to see the output before and after a change to understand its impact.
+
+Example:
+
+> make check-crypto-nss XMLSEC_TEST_REPRODUCIBLE=y

--- a/tests/testDSig.sh
+++ b/tests/testDSig.sh
@@ -6,10 +6,14 @@
 ##########################################################################
 ##########################################################################
 ##########################################################################
-echo "--- testDSig started for xmlsec-$crypto library ($timestamp)"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- testDSig started for xmlsec-$crypto library ($timestamp)"
+fi
 echo "--- LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 echo "--- LTDL_LIBRARY_PATH=$LTDL_LIBRARY_PATH"
-echo "--- log file is $logfile"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- log file is $logfile"
+fi
 echo "--- testDSig started for xmlsec-$crypto library ($timestamp)" >> $logfile
 echo "--- LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $logfile
 echo "--- LTDL_LIBRARY_PATH=$LTDL_LIBRARY_PATH" >> $logfile
@@ -958,5 +962,7 @@ execDSigTest $res_success \
 ##########################################################################
 echo "--- testDSig finished" >> $logfile
 echo "--- testDSig finished"
-echo "--- detailed log is written to  $logfile"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- detailed log is written to  $logfile"
+fi
 

--- a/tests/testEnc.sh
+++ b/tests/testEnc.sh
@@ -6,10 +6,14 @@
 ##########################################################################
 ##########################################################################
 ##########################################################################
-echo "--- testEnc started for xmlsec-$crypto library ($timestamp)"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- testEnc started for xmlsec-$crypto library ($timestamp)"
+fi
 echo "--- LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 echo "--- LTDL_LIBRARY_PATH=$LTDL_LIBRARY_PATH"
-echo "--- log file is $logfile"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- log file is $logfile"
+fi
 echo "--- testEnc started for xmlsec-$crypto library ($timestamp)" >> $logfile
 echo "--- LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $logfile
 echo "--- LTDL_LIBRARY_PATH=$LTDL_LIBRARY_PATH" >> $logfile
@@ -385,7 +389,9 @@ fi
 ##########################################################################
 ##########################################################################
 echo "--------- Negative Testing: Following tests MUST FAIL ----------"
-echo "--- detailed log is written to  $logfile" 
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- detailed log is written to  $logfile"
+fi
 execEncTest $res_fail \
     "" \
     "01-phaos-xmlenc-3/bad-alg-enc-element-aes128-kw-3des" \
@@ -411,5 +417,7 @@ rm -rf $tmpfile
 ##########################################################################
 echo "--- testEnc finished" >> $logfile
 echo "--- testEnc finished"
-echo "--- detailed log is written to  $logfile"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- detailed log is written to  $logfile"
+fi
 

--- a/tests/testKeys.sh
+++ b/tests/testKeys.sh
@@ -6,10 +6,14 @@
 ##########################################################################
 ##########################################################################
 ##########################################################################
-echo "--- testKeys started for xmlsec-$crypto library ($timestamp) ---"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- testKeys started for xmlsec-$crypto library ($timestamp) ---"
+fi
 echo "--- LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 echo "--- LTDL_LIBRARY_PATH=$LTDL_LIBRARY_PATH"
-echo "--- log file is $logfile"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- log file is $logfile"
+fi
 echo "--- testKeys started for xmlsec-$crypto library ($timestamp) ---" >> $logfile
 echo "--- LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $logfile
 echo "--- LTDL_LIBRARY_PATH=$LTDL_LIBRARY_PATH" >> $logfile
@@ -68,4 +72,6 @@ execKeysTest $res_success \
 ##########################################################################
 echo "--- testKeys finished ---" >> $logfile
 echo "--- testKeys finished ---"
-echo "--- detailed log is written to  $logfile ---"
+if [ -z "$XMLSEC_TEST_REPRODUCIBLE" ]; then
+    echo "--- detailed log is written to  $logfile ---"
+fi


### PR DESCRIPTION
The motivation is that I've started adding support for RSA in the mscng
backend but I wanted to have an opt-in way to make sure I don't break
something in the existing ECDSA part.