### PR TITLE
autotools: add switch to build with -Werror

### DIFF
--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -28,6 +28,7 @@
 #include <libexslt/exslt.h>
 #endif /* XMLSEC_NO_XSLT */
 
+#define XMLSEC_PRIVATE
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/xmltree.h>
 #include <xmlsec/keys.h>

--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -2400,7 +2400,6 @@ xmlSecAppXmlDataCreate(const char* filename, const xmlChar* defStartNodeName, co
         }
         cur = attr->parent;
     } else if(xmlSecAppCmdLineParamGetString(&nodeNameParam) != NULL) {
-        xmlChar* buf;
         xmlChar* name;
         xmlChar* ns;
         

--- a/configure.ac
+++ b/configure.ac
@@ -2125,6 +2125,18 @@ else
 fi
 
 dnl ==========================================================================
+dnl Warnings as errors
+dnl ==========================================================================
+AC_MSG_CHECKING(for warnings as errors)
+AC_ARG_ENABLE(werror,   [  --enable-werror      handle warnings as errors (no)])
+if test "z$enable_werror" = "zyes" ; then
+    CFLAGS="$CFLAGS -Werror"
+    AC_MSG_RESULT([yes])
+else
+    AC_MSG_RESULT([disabled])
+fi
+
+dnl ==========================================================================
 dnl Profiling
 dnl ==========================================================================
 AC_MSG_CHECKING(for profiling)


### PR DESCRIPTION
And fix the two warnings I found this way.

If this looks good, sooner or later the same would make sense for nmake as well.