### PR TITLE
LibreSSL 2.7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -765,11 +765,11 @@ if test "z$OPENSSL_FOUND" = "zyes" ; then
     if test "z$OPENSSL_VERSION" = "z" ; then
         AC_EGREP_CPP(greater-than-minvers, [
             #include <openssl/opensslv.h>
-            #if OPENSSL_VERSION_NUMBER == 0x20000000L && defined(LIBRESSL_VERSION_NUMBER)
+            #if OPENSSL_VERSION_NUMBER == 0x20000000L && (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
             greater-than-minvers
             #endif
         ],[
-            OPENSSL_VERSION="1.0.0 (libressl)"
+            OPENSSL_VERSION="1.0.0 (libressl < 2.7)"
         ],[
             OPENSSL_VERSION=""
         ])
@@ -778,7 +778,7 @@ if test "z$OPENSSL_FOUND" = "zyes" ; then
     if test "z$OPENSSL_VERSION" = "z" ; then
         AC_EGREP_CPP(greater-than-minvers, [
             #include <openssl/opensslv.h>
-            #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+            #if (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x20700000L) || OPENSSL_VERSION_NUMBER >= 0x10100000L
             greater-than-minvers
             #endif
         ],[

--- a/include/xmlsec/openssl/crypto.h
+++ b/include/xmlsec/openssl/crypto.h
@@ -43,12 +43,12 @@ XMLSEC_CRYPTO_EXPORT const xmlChar*     xmlSecOpenSSLGetDefaultTrustedCertsFolde
  * What version of the openssl API do we have? (also see configure.ac)
  *
  *******************************************************************/
-#if OPENSSL_VERSION_NUMBER == 0x20000000L && defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER == 0x20000000L && (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 /* Libressl decided to take over OpenSSL version 2.0.0, likely will create
  * issues down the road...
  */
 #define XMLSEC_OPENSSL_API_100      1
-#elif OPENSSL_VERSION_NUMBER >= 0x10100000L
+#elif (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x20700000L) || OPENSSL_VERSION_NUMBER >= 0x10100000L
 #define XMLSEC_OPENSSL_API_110      1
 #elif OPENSSL_VERSION_NUMBER >= 0x10000000L
 #define XMLSEC_OPENSSL_API_100      1

--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -16,6 +16,9 @@
  * OpenSSL 1.1.0 compatibility
  *
  *****************************************************************************/
+#if defined(XMLSEC_OPENSSL_API_110) && defined(LIBRESSL_VERSION_NUMBER) 
+#define EVP_CIPHER_CTX_encrypting(x)       ((x)->encrypt)
+#endif
 #if !defined(XMLSEC_OPENSSL_API_110)
 
 /* EVP_PKEY stuff */


### PR DESCRIPTION
LibreSSL 2.7 introduced compatibility with most OpenSSL 1.1 APIs. This corrects detection of LibreSSL versions, as well as include one missing OpenSSL 1.1 function from LibreSSL 2.7.

`openssl_compat.h` obtained from [OpenBSD Ports collection](https://github.com/openbsd/ports/blob/master/security/xmlsec/patches/patch-src_openssl_openssl_compat_h)

There is probably a better way to represent this detection logic.