### PR TITLE
mscrypto: fix selection CryptoPro CSP provider for GOST R 34.10-2001

### DIFF
--- a/src/mscrypto/csp_calg.h
+++ b/src/mscrypto/csp_calg.h
@@ -90,8 +90,8 @@
 #define PROV_CRYPTOPRO_GOST         75
 #define PROV_GOST_2012_256          80
 #define PROV_GOST_2012_512          81
-#define CRYPTOPRO_CSP_A             "CryptoPro CSP"
-#define CRYPTOPRO_CSP_W             L"CryptoPro CSP"
+#define CRYPTOPRO_CSP_A             "Crypto-Pro GOST R 34.10-2001 Cryptographic Service Provider"
+#define CRYPTOPRO_CSP_W             L"Crypto-Pro GOST R 34.10-2001 Cryptographic Service Provider"
 #define CRYPTOPRO_CSP_256_A             "Crypto-Pro GOST R 34.10-2012 Cryptographic Service Provider"
 #define CRYPTOPRO_CSP_256_W             L"Crypto-Pro GOST R 34.10-2012 Cryptographic Service Provider"
 #define CRYPTOPRO_CSP_512_A             "Crypto-Pro GOST R 34.10-2012 Strong Cryptographic Service Provider"


### PR DESCRIPTION
CryptAcquireContext() needs a proper crypto provider name, the one that can be found in the list of all CSPs in Windows registry: HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography\Defaults\Provider

CryptAcquireContext failed with the previously specified provider name "CryptoPro CSP". The name for GOST 2001 provider by CryptoPro is "Crypto-Pro GOST R 34.10-2001 Cryptographic Service Provider", not just "CryptoPro CSP".  