### PR TITLE
MSCNG: allow adding a HCERTSTORE to the list of certs stores

### DIFF
--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -59,6 +59,8 @@ XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptKeyStore    (xm
                                                                               HCERTSTORE keyStore);
 XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptTrustedStore(xmlSecKeyDataStorePtr store,
                                                                               HCERTSTORE trustedStore);
+XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptUntrustedStore(xmlSecKeyDataStorePtr store,
+                                                                                HCERTSTORE untrustedStore);
 XMLSEC_CRYPTO_EXPORT PCCERT_CONTEXT     xmlSecMSCngX509StoreVerify           (xmlSecKeyDataStorePtr store,
 									      HCERTSTORE certs,
 									      xmlSecKeyInfoCtx* keyInfoCtx);

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -57,6 +57,8 @@ XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptCert        (xm
                                                                               xmlSecKeyDataType type);
 XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptKeyStore    (xmlSecKeyDataStorePtr store,
                                                                               HCERTSTORE keyStore);
+XMLSEC_CRYPTO_EXPORT int                xmlSecMSCngX509StoreAdoptTrustedStore(xmlSecKeyDataStorePtr store,
+                                                                              HCERTSTORE trustedStore);
 XMLSEC_CRYPTO_EXPORT PCCERT_CONTEXT     xmlSecMSCngX509StoreVerify           (xmlSecKeyDataStorePtr store,
 									      HCERTSTORE certs,
 									      xmlSecKeyInfoCtx* keyInfoCtx);

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -113,6 +113,37 @@ xmlSecMSCngX509StoreAdoptKeyStore(xmlSecKeyDataStorePtr store, HCERTSTORE keySto
     return(0);
 }
 
+/**
+ * xmlSecMSCngX509StoreAdoptTrustedStore:
+ * @store:              the pointer to X509 key data store klass.
+ * @trustedStore:       the pointer to certs store.
+ *
+ * Adds @trustedStore to the list of trusted certs stores.
+ *
+ * Returns: 0 on success or a negative value if an error occurs.
+ */
+int
+xmlSecMSCngX509StoreAdoptTrustedStore(xmlSecKeyDataStorePtr store, HCERTSTORE trustedStore) {
+    xmlSecMSCngX509StoreCtxPtr ctx;
+    int ret;
+
+    xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), -1);
+    xmlSecAssert2( trustedStore != NULL, -1);
+
+    ctx = xmlSecMSCngX509StoreGetCtx(store);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->trusted != NULL, -1);
+
+    ret = CertAddStoreToCollection(ctx->trusted , trustedStore , CERT_PHYSICAL_STORE_ADD_ENABLE_FLAG , 3);
+    if(ret == FALSE) {
+        xmlSecMSCngLastError("CertAddStoreToCollection",
+            xmlSecKeyDataStoreGetName(store));
+        return(-1);
+    }
+
+    return(0);
+}
+
 static int
 xmlSecMSCngX509StoreInitialize(xmlSecKeyDataStorePtr store) {
     int ret;

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -144,6 +144,37 @@ xmlSecMSCngX509StoreAdoptTrustedStore(xmlSecKeyDataStorePtr store, HCERTSTORE tr
     return(0);
 }
 
+/**
+ * xmlSecMSCngX509StoreAdoptUntrustedStore:
+ * @store:              the pointer to X509 key data store klass.
+ * @untrustedStore:     the pointer to certs store.
+ *
+ * Adds @trustedStore to the list of untrusted certs stores.
+ *
+ * Returns: 0 on success or a negative value if an error occurs.
+ */
+int
+xmlSecMSCngX509StoreAdoptUntrustedStore(xmlSecKeyDataStorePtr store, HCERTSTORE untrustedStore) {
+    xmlSecMSCngX509StoreCtxPtr ctx;
+    int ret;
+
+    xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecMSCngX509StoreId), -1);
+    xmlSecAssert2(untrustedStore != NULL, -1);
+
+    ctx = xmlSecMSCngX509StoreGetCtx(store);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->untrusted != NULL, -1);
+
+    ret = CertAddStoreToCollection(ctx->untrusted, untrustedStore, CERT_PHYSICAL_STORE_ADD_ENABLE_FLAG , 2);
+    if(ret == FALSE) {
+        xmlSecMSCngLastError("CertAddStoreToCollection",
+            xmlSecKeyDataStoreGetName(store));
+        return(-1);
+    }
+
+    return(0);
+}
+
 static int
 xmlSecMSCngX509StoreInitialize(xmlSecKeyDataStorePtr store) {
     int ret;

--- a/src/transforms.c
+++ b/src/transforms.c
@@ -97,7 +97,7 @@ xmlSecTransformIdsInit(void) {
 
     ret = xmlSecPtrListInitialize(xmlSecTransformIdsGet(), xmlSecTransformIdListId);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecPtrListPtrInitialize(xmlSecTransformIdListId)", NULL);
+        xmlSecInternalError("xmlSecPtrListInitialize(xmlSecTransformIdListId)", NULL);
         return(-1);
     }
 
@@ -853,7 +853,7 @@ xmlSecTransformCtxPrepare(xmlSecTransformCtxPtr ctx, xmlSecTransformDataType inp
     /* add binary buffer to store result */
     transform = xmlSecTransformCtxCreateAndAppend(ctx, xmlSecTransformMemBufId);
     if(!xmlSecTransformIsValid(transform)) {
-        xmlSecInternalError("xmlSecTransformCreateAndAppend(xmlSecTransformMemBufId)", NULL);
+        xmlSecInternalError("xmlSecTransformCtxCreateAndAppend(xmlSecTransformMemBufId)", NULL);
         return(-1);
     }
     ctx->result = xmlSecTransformMemBufGetBuffer(transform);
@@ -930,7 +930,7 @@ xmlSecTransformCtxBinaryExecute(xmlSecTransformCtxPtr ctx,
 
     ret = xmlSecTransformPushBin(ctx->first, data, dataSize, 1, ctx);
     if(ret < 0) {
-        xmlSecInternalError2("xmlSecTransformCtxPushBin", NULL,
+        xmlSecInternalError2("xmlSecTransformPushBin", NULL,
                              "dataSize=%d", dataSize);
         return(-1);
     }
@@ -1952,7 +1952,7 @@ xmlSecTransformDefaultPushBin(xmlSecTransformPtr transform, const xmlSecByte* da
         if(outSize > 0) {
             ret = xmlSecBufferRemoveHead(&(transform->outBuf), outSize);
             if(ret < 0) {
-                xmlSecInternalError2("xmlSecBufferAppend",
+                xmlSecInternalError2("xmlSecBufferRemoveHead",
                                      xmlSecTransformGetName(transform),
                                      "size=%d", outSize);
                 return(-1);


### PR DESCRIPTION
There are a few functions which are part of the mscrypto public API (e.g.
xmlSecMSCryptoX509StoreAdoptKeyStore()) and there is no mscng equivalent yet.
Those are probably interesting as e.g. LibreOffice uses those functions.
Comparing what is used there and what is already provided, I found these two
missing.