### PR TITLE
nmake: allow building with a custom C compiler

### DIFF
--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -908,7 +908,7 @@ xmlSecMSCngKeyDataDsaDebugDump(xmlSecKeyDataPtr data, FILE* output) {
     xmlSecAssert(output != NULL);
 
     fprintf(output, "=== rsa key: size = %d\n",
-            xmlSecMSCngKeyDataDsaGetSize(data));
+            (int)xmlSecMSCngKeyDataDsaGetSize(data));
 }
 
 static void xmlSecMSCngKeyDataDsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* output) {
@@ -916,7 +916,7 @@ static void xmlSecMSCngKeyDataDsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* outpu
     xmlSecAssert(output != NULL);
 
     fprintf(output, "<DSAKeyValue size=\"%d\" />\n",
-            xmlSecMSCngKeyDataDsaGetSize(data));
+            (int)xmlSecMSCngKeyDataDsaGetSize(data));
 }
 
 static int
@@ -1120,7 +1120,7 @@ xmlSecMSCngKeyDataRsaDebugDump(xmlSecKeyDataPtr data, FILE* output) {
     xmlSecAssert(output != NULL);
 
     fprintf(output, "=== rsa key: size = %d\n",
-            xmlSecMSCngKeyDataRsaGetSize(data));
+            (int)xmlSecMSCngKeyDataRsaGetSize(data));
 }
 
 static void xmlSecMSCngKeyDataRsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* output) {
@@ -1128,7 +1128,7 @@ static void xmlSecMSCngKeyDataRsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* outpu
     xmlSecAssert(output != NULL);
 
     fprintf(output, "<RSAKeyValue size=\"%d\" />\n",
-            xmlSecMSCngKeyDataRsaGetSize(data));
+            (int)xmlSecMSCngKeyDataRsaGetSize(data));
 }
 
 static int
@@ -1587,7 +1587,7 @@ xmlSecMSCngKeyDataEcdsaDebugDump(xmlSecKeyDataPtr data, FILE* output) {
     xmlSecAssert(output != NULL);
 
     fprintf(output, "=== rsa key: size = %d\n",
-            xmlSecMSCngKeyDataEcdsaGetSize(data));
+            (int)xmlSecMSCngKeyDataEcdsaGetSize(data));
 }
 
 static void xmlSecMSCngKeyDataEcdsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* output) {
@@ -1595,7 +1595,7 @@ static void xmlSecMSCngKeyDataEcdsaDebugXmlDump(xmlSecKeyDataPtr data, FILE* out
     xmlSecAssert(output != NULL);
 
     fprintf(output, "<ECDSAKeyValue size=\"%d\" />\n",
-            xmlSecMSCngKeyDataEcdsaGetSize(data));
+            (int)xmlSecMSCngKeyDataEcdsaGetSize(data));
 }
 
 static xmlSecKeyDataKlass xmlSecMSCngKeyDataEcdsaKlass = {

--- a/src/mscng/ciphers.c
+++ b/src/mscng/ciphers.c
@@ -313,7 +313,6 @@ xmlSecMSCngBlockCipherCtxInit(xmlSecMSCngBlockCipherCtxPtr ctx,
         return(-1);
     }
 
-    dwBlockLen;
     xmlSecAssert2(dwBlockLen > 0, -1);
     if(encrypt) {
         unsigned char* iv;

--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -491,7 +491,7 @@ xmlSecMSCngSignatureExecute(xmlSecTransformPtr transform, int last, xmlSecTransf
         transform->status = xmlSecTransformStatusWorking;
     }
 
-    if((transform->status == xmlSecTransformStatusWorking)) {
+    if(transform->status == xmlSecTransformStatusWorking) {
         if(inSize > 0) {
             xmlSecAssert2(outSize == 0, -1);
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -427,7 +427,7 @@ xmlSecTransformXPathExecute(xmlSecTransformPtr transform, int last,
     transform->outNodes = xmlSecXPathDataListExecute(dataList, doc,
                                 transform->hereNode, transform->inNodes);
     if(transform->outNodes == NULL) {
-        xmlSecInternalError("xmlSecXPathDataExecute",
+        xmlSecInternalError("xmlSecXPathDataListExecute",
                             xmlSecTransformGetName(transform));
         return(-1);
     }

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -347,7 +347,6 @@ CPPFLAGS 		= /nologo
 #
 # The compiler and its options.
 #
-CC 				= cl.exe
 CFLAGS 			= /nologo /D "WIN32" /D "_WINDOWS" /D inline=__inline
 # C4130: '!=': logical operation on address of string constant:
 #     this generates a false warning inside macros

--- a/win32/configure.js
+++ b/win32/configure.js
@@ -56,6 +56,7 @@ var withNT4 = 1;
 var buildUnicode = 1;
 var buildDebug = 0;
 var buildWerror = 0;
+var buildCc = "cl.exe";
 var buildStatic = 1;
 var buildWithDLSupport = 1;
 var buildPrefix = ".";
@@ -114,6 +115,7 @@ function usage()
 	txt += "  unicode:    Build Unicode version (" + (buildUnicode? "yes" : "no")  + ")\n";
 	txt += "  debug:      Build unoptimised debug executables (" + (buildDebug? "yes" : "no")  + ")\n";
 	txt += "  werror:     Build with warnings as errors(" + (buildWerror? "yes" : "no")  + ")\n";
+	txt += "  cc:         Build with the specified compiler(" + buildCc  + ")\n";
 	txt += "  static:     Link libxmlsec statically to xmlsec (" + (buildStatic? "yes" : "no")  + ")\n";
 	txt += "  with-dl:    Enable dynamic loading of xmlsec-crypto libraries (" + (buildWithDLSupport? "yes" : "no")  + ")\n";
 	txt += "  prefix:     Base directory for the installation (" + buildPrefix + ")\n";
@@ -178,6 +180,7 @@ function discoverVersion()
 	vf.WriteLine("UNICODE=" + (buildUnicode? "1" : "0"));
 	vf.WriteLine("DEBUG=" + (buildDebug? "1" : "0"));
 	vf.WriteLine("WERROR=" + (buildWerror? "1" : "0"));
+	vf.WriteLine("CC=" + buildCc);
 	vf.WriteLine("STATIC=" + (buildStatic? "1" : "0"));
 	vf.WriteLine("WITH_DL=" + (buildWithDLSupport ? "1" : "0"));
 	vf.WriteLine("PREFIX=" + buildPrefix);
@@ -312,6 +315,8 @@ for (i = 0; (i < WScript.Arguments.length) && (error == 0); i++) {
 			buildDebug = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "werror")
 			buildWerror = strToBool(arg.substring(opt.length + 1, arg.length));
+		else if (opt == "cc")
+			buildCc = arg.substring(opt.length + 1, arg.length);
 		else if (opt == "static")
 			buildStatic = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "with-dl")
@@ -438,6 +443,7 @@ txtOut += "  C-Runtime option: " + cruntime + "\n";
 txtOut += "           Unicode: " + boolToStr(buildUnicode) + "\n";
 txtOut += "     Debug symbols: " + boolToStr(buildDebug) + "\n";
 txtOut += "Warnings as errors: " + boolToStr(buildWerror) + "\n";
+txtOut += "        C compiler: " + buildCc + "\n";
 txtOut += "     Static xmlsec: " + boolToStr(buildStatic) + "\n";
 txtOut += " Enable DL support: " + boolToStr(buildWithDLSupport) + "\n";
 txtOut += "    Install prefix: " + buildPrefix + "\n";


### PR DESCRIPTION
And fix the warnings found by clang-cl in the mscng backend, one of them is gold, I think.