### PR TITLE
mingw64 build: move openssl header includes to the last

### DIFF
--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -26,11 +26,6 @@
 #include <time.h>
 
 #include <libxml/tree.h>
-#include <openssl/evp.h>
-#include <openssl/x509.h>
-#include <openssl/x509_vfy.h>
-#include <openssl/x509v3.h>
-#include <openssl/asn1.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/xmltree.h>
@@ -45,6 +40,12 @@
 #include <xmlsec/openssl/evp.h>
 #include <xmlsec/openssl/x509.h>
 #include "openssl_compat.h"
+
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
+#include <openssl/asn1.h>
 
 /* The ASN1_TIME_check() function was changed from ASN1_TIME * to
  * const ASN1_TIME * in 1.1.0. To avoid compiler warnings, we use this hack.

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -25,10 +25,6 @@
 #include <errno.h>
 
 #include <libxml/tree.h>
-#include <openssl/evp.h>
-#include <openssl/x509.h>
-#include <openssl/x509_vfy.h>
-#include <openssl/x509v3.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/xmltree.h>
@@ -42,6 +38,11 @@
 #include <xmlsec/openssl/evp.h>
 #include <xmlsec/openssl/x509.h>
 #include "openssl_compat.h"
+
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
 
 /**************************************************************************
  *


### PR DESCRIPTION
Windows headers also #define some names that openssl uses too.
Openssl headers #undef the offending names before reusing them.
But if those offending Windows headers get included _after_ the
openssl headers the namespace gets polluted.