### PR TITLE
travis: enable warnings as errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 # install gnutls libraries
 - sudo apt-get install libgnutls28 libgnutls-dev
 script:
-- mkdir build && cd build && ../autogen.sh && make && make check
+- mkdir build && cd build && ../autogen.sh --enable-werror && make && make check


### PR DESCRIPTION
The intention is to catch new warnings early, rather than fixing them in
separate follow-up commits.

A local werror build works for me, let's see if it passes travis.