### PR TITLE
mscng: fix cl.exe warnings

### DIFF
--- a/include/xmlsec/private.h
+++ b/include/xmlsec/private.h
@@ -518,6 +518,9 @@ struct _xmlSecCryptoDLFunctions {
  *
  * Macro used to signal to MSVC unused function parameters
  */
+#ifdef WIN32
+#include <windows.h>
+#endif
 #ifndef UNREFERENCED_PARAMETER
 #define UNREFERENCED_PARAMETER(x)
 #endif /* UNREFERENCED_PARAMETER */

--- a/src/keysmngr.c
+++ b/src/keysmngr.c
@@ -30,6 +30,7 @@
 #include <xmlsec/transforms.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/errors.h>
+#include <xmlsec/private.h>
 
 
 /****************************************************************************
@@ -397,6 +398,7 @@ xmlSecSimpleKeysStoreLoad(xmlSecKeyStorePtr store, const char *uri,
 
     xmlSecAssert2(xmlSecKeyStoreCheckId(store, xmlSecSimpleKeysStoreId), -1);
     xmlSecAssert2(uri != NULL, -1);
+    UNREFERENCED_PARAMETER(keysMngr);
 
     doc = xmlParseFile(uri);
     if(doc == NULL) {

--- a/src/mscng/keysstore.c
+++ b/src/mscng/keysstore.c
@@ -413,6 +413,7 @@ xmlSecMSCngKeysStoreLoad(xmlSecKeyStorePtr store, const char *uri,
 
     xmlSecAssert2(xmlSecKeyStoreCheckId(store, xmlSecMSCngKeysStoreId), -1);
     xmlSecAssert2((uri != NULL), -1);
+    UNREFERENCED_PARAMETER(keysMngr);
 
     doc = xmlParseFile(uri);
     if(doc == NULL) {

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -355,7 +355,9 @@ CPPFLAGS 		= /nologo
 CFLAGS 			= /nologo /D "WIN32" /D "_WINDOWS" /D inline=__inline
 # C4130: '!=': logical operation on address of string constant:
 #     this generates a false warning inside macros
-CFLAGS 			= $(CFLAGS) /D "_MBCS" /D "_REENTRANT"  /W4 /wd4130
+# C4127: conditional expression is constant
+#     this generates a false warning inside asserts
+CFLAGS 			= $(CFLAGS) /D "_MBCS" /D "_REENTRANT"  /W4 /wd4130 /wd4127
 
 !if "$(WERROR)" == "1"
 CFLAGS 			= $(CFLAGS) /WX

--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -357,7 +357,10 @@ CFLAGS 			= /nologo /D "WIN32" /D "_WINDOWS" /D inline=__inline
 #     this generates a false warning inside macros
 # C4127: conditional expression is constant
 #     this generates a false warning inside asserts
-CFLAGS 			= $(CFLAGS) /D "_MBCS" /D "_REENTRANT"  /W4 /wd4130 /wd4127
+# C4152: nonstandard extension, function/data pointer conversion in expression
+#     this generates a false warning for XMLSEC_PTR_TO_FUNC
+CFLAGS 			= $(CFLAGS) /D "_MBCS" /D "_REENTRANT"  /W4 /wd4130
+CFLAGS                  = $(CFLAGS) /wd4127 /wd4152
 
 !if "$(WERROR)" == "1"
 CFLAGS 			= $(CFLAGS) /WX


### PR DESCRIPTION
`cscript configure.js crypto=mscng iconv=no static=no debug=yes werror=yes && nmake` passes for me with these, with VS2017.