### PR TITLE
mscrypto: fix the last cl.exe warning

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ environment:
       CRYPTO: mscrypto
       STATIC: no
       UNICODE: yes
-      WERROR: no
+      WERROR: yes
 
     - COMPILER: MSVC17
       CRYPTO: mscng
@@ -56,7 +56,7 @@ environment:
       CRYPTO: mscrypto
       STATIC: no
       UNICODE: no
-      WERROR: no
+      WERROR: yes
 
     - COMPILER: MSVC17
       CRYPTO: mscng

--- a/src/mscrypto/keysstore.c
+++ b/src/mscrypto/keysstore.c
@@ -150,6 +150,7 @@ xmlSecMSCryptoKeysStoreLoad(xmlSecKeyStorePtr store, const char *uri,
 
     xmlSecAssert2(xmlSecKeyStoreCheckId(store, xmlSecMSCryptoKeysStoreId), -1);
     xmlSecAssert2((uri != NULL), -1);
+    UNREFERENCED_PARAMETER(keysMngr);
 
     doc = xmlParseFile(uri);
     if(doc == NULL) {


### PR DESCRIPTION
And then turn on appveyor werror for that backend as well.