### PR TITLE
nss: fix memory leak in GetCertName()

### DIFF
--- a/src/nss/x509vfy.c
+++ b/src/nss/x509vfy.c
@@ -402,6 +402,7 @@ xmlSecNssGetCertName(const xmlChar * name) {
     }
 
     PORT_Free(tmp);
+    xmlFree(name2);
     return(res);
 }
 


### PR DESCRIPTION
As pointed out by valgrind:

==18992== 75 bytes in 1 blocks are definitely lost in loss record 47 of 69
==18992==    at 0x4C2E08F: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==18992==    by 0x5100DE1: xmlStrndup (in /usr/lib64/libxml2.so.2.9.7)
==18992==    by 0x53DAC44: xmlSecNssGetCertName (x509vfy.c:373)
==18992==    by 0x53DB08B: xmlSecNssX509FindCert (x509vfy.c:447)
==18992==    by 0x53DB08B: xmlSecNssX509StoreFindCert (x509vfy.c:147)
==18992==    by 0x53D9029: xmlSecNssX509IssuerSerialNodeRead (x509.c:1177)
==18992==    by 0x53D9029: xmlSecNssX509DataNodeRead (x509.c:918)
==18992==    by 0x53D9029: xmlSecNssKeyDataX509XmlRead (x509.c:683)
==18992==    by 0x56107FF: xmlSecKeyInfoNodeRead (keyinfo.c:112)
==18992==    by 0x5615D56: xmlSecKeysMngrGetKey (keys.c:1225)
==18992==    by 0x562F034: xmlSecDSigCtxProcessKeyInfoNode (xmldsig.c:785)
==18992==    by 0x562F034: xmlSecDSigCtxProcessSignatureNode (xmldsig.c:501)
==18992==    by 0x562FC45: xmlSecDSigCtxVerify (xmldsig.c:339)