### PR TITLE
nss: improve assert in xmlSecNssASN1IntegerWrite()

### DIFF
--- a/src/nss/x509.c
+++ b/src/nss/x509.c
@@ -1740,13 +1740,13 @@ xmlSecNssASN1IntegerWrite(SECItem *num) {
 
     xmlSecAssert2(num != NULL, NULL);
     xmlSecAssert2(num->type == siBuffer, NULL);
-    xmlSecAssert2(num->len <= 9, NULL);
     xmlSecAssert2(num->data != NULL, NULL);
 
     /* HACK : to be fixed after
      * NSS bug http://bugzilla.mozilla.org/show_bug.cgi?id=212864 is fixed
      */
     for(ii = num->len; ii > 0; --ii, shift += 8) {
+        xmlSecAssert2(shift < 64 || num->data[ii - 1] == 0, NULL);
         if(num->data[ii - 1] != 0) {
             val |= ((PRUint64)num->data[ii - 1]) << shift;
         }


### PR DESCRIPTION
The intention is that either we have data which can be represented with
a 64bit unsigned integer, or if the data is larger than that, then it's
just leading zeros one can ignore.