### PR TITLE
win32: allow custom compiler flags

### DIFF
--- a/win32/Makefile.msvc
+++ b/win32/Makefile.msvc
@@ -352,7 +352,7 @@ CPPFLAGS 		= /nologo
 #
 # The compiler and its options.
 #
-CFLAGS 			= /nologo /D "WIN32" /D "_WINDOWS" /D inline=__inline
+CFLAGS 			= $(CFLAGS) /nologo /D "WIN32" /D "_WINDOWS" /D inline=__inline
 # C4130: '!=': logical operation on address of string constant:
 #     this generates a false warning inside macros
 # C4127: conditional expression is constant

--- a/win32/configure.js
+++ b/win32/configure.js
@@ -57,6 +57,7 @@ var buildUnicode = 1;
 var buildDebug = 0;
 var buildWerror = 0;
 var buildCc = "cl.exe";
+var buildCflags = "";
 var buildStatic = 1;
 var buildWithDLSupport = 1;
 var buildPrefix = ".";
@@ -116,6 +117,7 @@ function usage()
 	txt += "  debug:      Build unoptimised debug executables (" + (buildDebug? "yes" : "no")  + ")\n";
 	txt += "  werror:     Build with warnings as errors(" + (buildWerror? "yes" : "no")  + ")\n";
 	txt += "  cc:         Build with the specified compiler(" + buildCc  + ")\n";
+	txt += "  cflags:     Build with the specified compiler flags('" + buildCflags  + "')\n";
 	txt += "  static:     Link libxmlsec statically to xmlsec (" + (buildStatic? "yes" : "no")  + ")\n";
 	txt += "  with-dl:    Enable dynamic loading of xmlsec-crypto libraries (" + (buildWithDLSupport? "yes" : "no")  + ")\n";
 	txt += "  prefix:     Base directory for the installation (" + buildPrefix + ")\n";
@@ -181,6 +183,7 @@ function discoverVersion()
 	vf.WriteLine("DEBUG=" + (buildDebug? "1" : "0"));
 	vf.WriteLine("WERROR=" + (buildWerror? "1" : "0"));
 	vf.WriteLine("CC=" + buildCc);
+	vf.WriteLine("CFLAGS=" + buildCflags);
 	vf.WriteLine("STATIC=" + (buildStatic? "1" : "0"));
 	vf.WriteLine("WITH_DL=" + (buildWithDLSupport ? "1" : "0"));
 	vf.WriteLine("PREFIX=" + buildPrefix);
@@ -317,6 +320,8 @@ for (i = 0; (i < WScript.Arguments.length) && (error == 0); i++) {
 			buildWerror = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "cc")
 			buildCc = arg.substring(opt.length + 1, arg.length);
+		else if (opt == "cflags")
+			buildCflags = arg.substring(opt.length + 1, arg.length);
 		else if (opt == "static")
 			buildStatic = strToBool(arg.substring(opt.length + 1, arg.length));
 		else if (opt == "with-dl")
@@ -444,6 +449,7 @@ txtOut += "           Unicode: " + boolToStr(buildUnicode) + "\n";
 txtOut += "     Debug symbols: " + boolToStr(buildDebug) + "\n";
 txtOut += "Warnings as errors: " + boolToStr(buildWerror) + "\n";
 txtOut += "        C compiler: " + buildCc + "\n";
+txtOut += "  C compiler flags: " + buildCflags + "\n";
 txtOut += "     Static xmlsec: " + boolToStr(buildStatic) + "\n";
 txtOut += " Enable DL support: " + boolToStr(buildWithDLSupport) + "\n";
 txtOut += "    Install prefix: " + buildPrefix + "\n";


### PR DESCRIPTION
Use-case is e.g. wanting to build the code with -arch:SSE. And this improves
consistency, autotools allows custom compiler flags as well.