### PR TITLE
Fix errors building a static xmlsec library with a static openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -760,11 +760,8 @@ if test "z$OPENSSL_FOUND" = "zyes" -a "z$OPENSSL_LIB_PATH" != "z" ; then
         if test "z$with_gnu_ld" = "zyes" ; then
             OPENSSL_LIBS="$OPENSSL_LIBS -Wl,-rpath-link -Wl,$OPENSSL_LIB_PATH"
         fi
-        OPENSSL_LIBS="$OPENSSL_LIBS -L$OPENSSL_LIB_PATH $OPENSSL_LIBS_LIST"
-    elif test -f $OPENSSL_LIB_PATH/$OPENSSL_LIB_STATIC_MARKER ; then
-        OPENSSL_LIBS="$OPENSSL_LIBS $OPENSSL_LIB_PATH/libcrypto.a"
     fi
-    OPENSSL_LIBS="$OPENSSL_LIBS $OPENSSL_EXTRA_LIBS"
+    OPENSSL_LIBS="$OPENSSL_LIBS -L$OPENSSL_LIB_PATH $OPENSSL_LIBS_LIST $OPENSSL_EXTRA_LIBS"
 fi
 
 dnl Check the OpenSSL version; if you change this code then you probably want to


### PR DESCRIPTION
When xmlsec is configured to build a static library, and the build is configured to use a static openssl library, the build fails on macOS (Xcode 10, macOS 10.14) while linking the `xmlsec` library:
```
ld: warning: ignoring file ../src/openssl/.libs/libxmlsec1-openssl.a, file was built for archive which is not the architecture being linked (x86_64): ../src/openssl/.libs/libxmlsec1-openssl.a
Undefined symbols for architecture x86_64:
  "_xmlSecOpenSSLAppDefaultKeysMngrAdoptKey", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrKeyAndCertsLoad in crypto.o
      _xmlSecAppCryptoSimpleKeysMngrPkcs12KeyLoad in crypto.o
      _xmlSecAppCryptoSimpleKeysMngrBinaryKeyLoad in crypto.o
      _xmlSecAppCryptoSimpleKeysMngrKeyGenerate in crypto.o
  "_xmlSecOpenSSLAppDefaultKeysMngrInit", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrInit in crypto.o
  "_xmlSecOpenSSLAppDefaultKeysMngrLoad", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrLoad in crypto.o
  "_xmlSecOpenSSLAppDefaultKeysMngrSave", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrSave in crypto.o
  "_xmlSecOpenSSLAppGetDefaultPwdCallback", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrKeyAndCertsLoad in crypto.o
      _xmlSecAppCryptoSimpleKeysMngrPkcs12KeyLoad in crypto.o
  "_xmlSecOpenSSLAppInit", referenced from:
      _xmlSecAppCryptoInit in crypto.o
  "_xmlSecOpenSSLAppKeyCertLoad", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrKeyAndCertsLoad in crypto.o
  "_xmlSecOpenSSLAppKeyLoad", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrKeyAndCertsLoad in crypto.o
      _xmlSecAppCryptoSimpleKeysMngrPkcs12KeyLoad in crypto.o
  "_xmlSecOpenSSLAppKeysMngrCertLoad", referenced from:
      _xmlSecAppCryptoSimpleKeysMngrCertLoad in crypto.o
  "_xmlSecOpenSSLAppShutdown", referenced from:
      _xmlSecAppCryptoShutdown in crypto.o
  "_xmlSecOpenSSLInit", referenced from:
      _xmlSecAppCryptoInit in crypto.o
  "_xmlSecOpenSSLShutdown", referenced from:
      _xmlSecAppCryptoShutdown in crypto.o
  "_xmlSecOpenSSLTransformDes3CbcGetKlass", referenced from:
      _main in xmlsec.o
  "_xmlSecOpenSSLTransformHmacSha1GetKlass", referenced from:
      _main in xmlsec.o
  "_xmlSecOpenSSLTransformSha1GetKlass", referenced from:
      _main in xmlsec.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This problem does not seem to be specific to macOS. A build on Linux (CentOS 7.4, gcc 4.8.5) fails here as well.

I think the error message is misleading (there is not an architecture mismatch), and what is actually happening is that there are duplicate symbols. I think this is because libxmlsec1-openssl.a contains libcrypto.a, when it should not. Note the `ar` output for `libxmlsec1-openssl.a`:
```
libtool: link: ar vcru .libs/libxmlsec1-openssl.a /Users/craig65535/openssl/export/lib/libcrypto.a  libxmlsec1_openssl_la-app.o libxmlsec1_openssl_la-bn.o libxmlsec1_openssl_la-ciphers.o libxmlsec1_openssl_la-crypto.o libxmlsec1_openssl_la-digests.o libxmlsec1_openssl_la-evp.o libxmlsec1_openssl_la-evp_signatures.o libxmlsec1_openssl_la-hmac.o libxmlsec1_openssl_la-kw_aes.o libxmlsec1_openssl_la-kw_des.o libxmlsec1_openssl_la-kt_rsa.o libxmlsec1_openssl_la-signatures.o libxmlsec1_openssl_la-symkeys.o libxmlsec1_openssl_la-x509.o libxmlsec1_openssl_la-x509vfy.o
a - /Users/craig65535/openssl/export/lib/libcrypto.a
a - libxmlsec1_openssl_la-app.o
a - libxmlsec1_openssl_la-bn.o
a - libxmlsec1_openssl_la-ciphers.o
a - libxmlsec1_openssl_la-crypto.o
a - libxmlsec1_openssl_la-digests.o
a - libxmlsec1_openssl_la-evp.o
a - libxmlsec1_openssl_la-evp_signatures.o
a - libxmlsec1_openssl_la-hmac.o
a - libxmlsec1_openssl_la-kw_aes.o
a - libxmlsec1_openssl_la-kw_des.o
a - libxmlsec1_openssl_la-kt_rsa.o
a - libxmlsec1_openssl_la-signatures.o
a - libxmlsec1_openssl_la-symkeys.o
a - libxmlsec1_openssl_la-x509.o
a - libxmlsec1_openssl_la-x509vfy.o
```

`libcrypto.a` is being treated as a static library that should be a part of `libxmlsec1-openssl.a` rather than a dependency. I think the fix is to stop treating the static openssl library differently when defining `$(OPENSSL_LIBS)`.

After this change is applied, the `ar` output is:
```
libtool: link: ar vcru .libs/libxmlsec1-openssl.a  libxmlsec1_openssl_la-app.o libxmlsec1_openssl_la-bn.o libxmlsec1_openssl_la-ciphers.o libxmlsec1_openssl_la-crypto.o libxmlsec1_openssl_la-digests.o libxmlsec1_openssl_la-evp.o libxmlsec1_openssl_la-evp_signatures.o libxmlsec1_openssl_la-hmac.o libxmlsec1_openssl_la-kw_aes.o libxmlsec1_openssl_la-kw_des.o libxmlsec1_openssl_la-kt_rsa.o libxmlsec1_openssl_la-signatures.o libxmlsec1_openssl_la-symkeys.o libxmlsec1_openssl_la-x509.o libxmlsec1_openssl_la-x509vfy.o
a - libxmlsec1_openssl_la-app.o
a - libxmlsec1_openssl_la-bn.o
a - libxmlsec1_openssl_la-ciphers.o
a - libxmlsec1_openssl_la-crypto.o
a - libxmlsec1_openssl_la-digests.o
a - libxmlsec1_openssl_la-evp.o
a - libxmlsec1_openssl_la-evp_signatures.o
a - libxmlsec1_openssl_la-hmac.o
a - libxmlsec1_openssl_la-kw_aes.o
a - libxmlsec1_openssl_la-kw_des.o
a - libxmlsec1_openssl_la-kt_rsa.o
a - libxmlsec1_openssl_la-signatures.o
a - libxmlsec1_openssl_la-symkeys.o
a - libxmlsec1_openssl_la-x509.o
a - libxmlsec1_openssl_la-x509vfy.o
```
