### PR TITLE
openssl: fix gcc7 -Werror,-Wparentheses-equality

### DIFF
--- a/src/openssl/evp.c
+++ b/src/openssl/evp.c
@@ -1305,7 +1305,7 @@ xmlSecOpenSSLKeyDataEcdsaGetSize(xmlSecKeyDataPtr data) {
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataEcdsaId), 0);
 
     ecdsa = xmlSecOpenSSLKeyDataEcdsaGetEcdsa(data);
-    if((ecdsa == NULL)) {
+    if(ecdsa == NULL) {
         return(0);
     }
 


### PR DESCRIPTION
The motivation is that if ((...)) is usually used for a condition with side effects, and if that's not the case, if (...) should be used.