### PR TITLE
Fix some non-matching function names in xmlSecError() calls

### DIFF
--- a/src/bn.c
+++ b/src/bn.c
@@ -203,7 +203,7 @@ xmlSecBnFromString(xmlSecBnPtr bn, const xmlChar* str, xmlSecSize base) {
      */
     ret = xmlSecBufferSetMaxSize(bn, xmlSecBufferGetSize(bn) + len / 2 + 1 + 1);
     if(ret < 0) {
-        xmlSecInternalError2("xmlSecBnRevLookupTable", NULL, "size=%d", len / 2 + 1);
+        xmlSecInternalError2("xmlSecBufferSetMaxSize", NULL, "size=%d", len / 2 + 1);
         return (-1);
     }
 
@@ -321,7 +321,7 @@ xmlSecBnToString(xmlSecBnPtr bn, xmlSecSize base) {
     size = xmlSecBufferGetSize(bn);
     ret = xmlSecBnInitialize(&bn2, size);
     if(ret < 0) {
-        xmlSecInternalError2("xmlSecBnCreate", NULL, "size=%d", size);
+        xmlSecInternalError2("xmlSecBnInitialize", NULL, "size=%d", size);
         return (NULL);
     }
 

--- a/src/dl.c
+++ b/src/dl.c
@@ -335,7 +335,7 @@ xmlSecCryptoDLInit(void) {
     ret = xmlSecPtrListInitialize(&gXmlSecCryptoDLLibraries,
                                   xmlSecCryptoDLLibrariesListGetKlass());
     if(ret < 0) {
-        xmlSecInternalError("xmlSecPtrListPtrInitialize",
+        xmlSecInternalError("xmlSecPtrListInitialize",
                             "xmlSecCryptoDLLibrariesListGetKlass");
         return(-1);
     }

--- a/src/io.c
+++ b/src/io.c
@@ -157,7 +157,7 @@ xmlSecIOInit(void) {
 
     ret = xmlSecPtrListInitialize(&xmlSecAllIOCallbacks, xmlSecIOCallbackPtrListId);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecPtrListPtrInitialize", NULL);
+        xmlSecInternalError("xmlSecPtrListInitialize", NULL);
         return(-1);
     }
 

--- a/src/keysdata.c
+++ b/src/keysdata.c
@@ -64,7 +64,7 @@ xmlSecKeyDataIdsInit(void) {
 
     ret = xmlSecPtrListInitialize(xmlSecKeyDataIdsGet(), xmlSecKeyDataIdListId);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecPtrListPtrInitialize(xmlSecKeyDataIdListId)", NULL);
+        xmlSecInternalError("xmlSecPtrListInitialize(xmlSecKeyDataIdListId)", NULL);
         return(-1);
     }
 

--- a/src/list.c
+++ b/src/list.c
@@ -292,7 +292,7 @@ xmlSecPtrListAdd(xmlSecPtrListPtr list, xmlSecPtr item) {
 
     ret = xmlSecPtrListEnsureSize(list, list->use + 1);
     if(ret < 0) {
-        xmlSecInternalError2("xmlSecPtrListAdd",
+        xmlSecInternalError2("xmlSecPtrListEnsureSize",
                              xmlSecPtrListGetName(list),
                              "size=%d", list->use + 1);
         return(-1);


### PR DESCRIPTION
I think the shared code (not specific to backends) is now clean.