### PR TITLE
CI: add initial macOS coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,28 @@ language: c
 sudo: required
 dist: trusty
 install:
-- sudo apt-get update
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
 # install build tools
-- sudo apt-get install automake autoconf libtool
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install automake autoconf libtool; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install libtool pkg-config; fi
 # install libxml2/libxslt libraries
-- sudo apt-get install libxml2 libxml2-dev libxslt1.1 libxslt1-dev
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libxml2 libxml2-dev libxslt1.1 libxslt1-dev; fi
 # install openssl libraries
-- sudo apt-get install libssl1.0.0 libssl-dev
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libssl1.0.0 libssl-dev; fi
 # install nspr/nss libraries
-- sudo apt-get install libnspr4 libnspr4-dev libnss3 libnss3-dev libnss3-tools
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libnspr4 libnspr4-dev libnss3 libnss3-dev libnss3-tools; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install nss; fi
 # install gcrypt libraries
-- sudo apt-get install libgcrypt11 libgcrypt11-dev
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libgcrypt11 libgcrypt11-dev; fi
 # install gnutls libraries
-- sudo apt-get install libgnutls28 libgnutls-dev
+- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libgnutls28 libgnutls-dev; fi
 script:
-- mkdir build && cd build && ../autogen.sh --enable-werror && make && make check
+- . scripts/travis-env.sh && mkdir build && cd build && ../autogen.sh --enable-werror && make && make check
+matrix:
+  include:
+  - name: "linux"
+    os: linux
+  - name: "osx"
+    os: osx
+    osx_image: xcode9.3

--- a/autogen.sh
+++ b/autogen.sh
@@ -14,9 +14,14 @@ DIE=0
 	DIE=1
 }
 
-(libtool --version) < /dev/null > /dev/null 2>&1 || {
+LIBTOOL="libtool"
+if [ "`uname`" = "Darwin" -a -n "`type -p glibtool`" ]; then
+	LIBTOOL=glibtool
+fi
+
+($LIBTOOL --version) < /dev/null > /dev/null 2>&1 || {
 	echo
-	echo "You must have libtool installed to compile xmlsec."
+	echo "You must have $LIBTOOL installed to compile xmlsec."
 	DIE=1
 }
 
@@ -51,10 +56,18 @@ if test -z "$*"; then
         echo "to pass any to it, please specify them on the $0 command line."
 fi
 
-echo "Running libtoolize..."
-libtoolize --copy --force
+LIBTOOLIZE="libtoolize"
+if [ "`uname`" = "Darwin" -a -n "`type -p glibtoolize`" ]; then
+	LIBTOOLIZE=glibtoolize
+fi
+echo "Running $LIBTOOLIZE..."
+$LIBTOOLIZE --copy --force
 echo "Running aclocal..."
-aclocal --force -I m4
+if [ -d /usr/local/share/aclocal ]; then
+	aclocal --force -I m4 -I /usr/local/share/aclocal
+else
+	aclocal --force -I m4
+fi
 echo "Running autoheader..."
 autoheader --force
 echo "Running autoconf..."

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -24,7 +24,7 @@ docs: docs-copy man-docs docs-format
 docs-copy:
 	@( \
 		echo "Copying docs..."; \
-		if [ z"$(srcdir)" != z"$(builddir)" ]; \
+		if [ z"$(srcdir)" != z"$(builddir)" -a z"`uname`" != z"Darwin" ]; \
 		then \
 		    $(CP) -ru $(srcdir)/*.html $(srcdir)/*.ico $(srcdir)/images $(builddir)/  ; \
 		    chmod u+w $(builddir)/*.html ; \

--- a/docs/api/Makefile.am
+++ b/docs/api/Makefile.am
@@ -80,7 +80,7 @@ else
 docs:
 	@( \
 		echo "Copying api-docs..."; \
-		if [ z"$(srcdir)" != z"$(builddir)" ]; \
+		if [ z"$(srcdir)" != z"$(builddir)" -a z"`uname`" != z"Darwin" ]; \
 		then \
 		    $(CP) -ru $(SOURCE_FILES_TO_COPY) $(builddir)/ ; \
 		fi \

--- a/scripts/travis-env.sh
+++ b/scripts/travis-env.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "`uname`" = "Darwin" ]; then
+	export PATH="/usr/local/opt/nss/bin:$PATH"
+	export PKG_CONFIG_PATH="/usr/local/opt/nss/lib/pkgconfig:$PKG_CONFIG_PATH"
+fi


### PR DESCRIPTION
Only the nss backend as a start.

Also, 'cp -u' is not handled by macOS, so just act similar to the
in-tree build for now.