### PR TITLE
Copyright: add an mscng section

### DIFF
--- a/Copyright
+++ b/Copyright
@@ -89,6 +89,32 @@ be used in advertising or otherwise to promote the sale, use or other deal-
 ings in this Software without prior written authorization from him.
 
 
+xmlsec-mscng library
+------------------------------------------------------------------------------
+
+Copyright (C) 2018 Miklos Vajna. All Rights Reserved.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is fur-
+nished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
+NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ALEKSEY SANIN BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CON-
+NECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of Aleksey Sanin shall not
+be used in advertising or otherwise to promote the sale, use or other deal-
+ings in this Software without prior written authorization from him.
 
 References
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Feel free to tweak the copyright notice section -- I just took what is used in src/mscng/ .c files, but naturally I have no problems with adding your name to the list or anything.

(Noticed this while we did a systematic update of the LibreOffice license file, noticed that this file covers the nss backend but not the mscrypto one -- we don't use the other backends.)