### PR TITLE
Copyright: extend copyright notices for xmlsec-mscng

### DIFF
--- a/Copyright
+++ b/Copyright
@@ -92,6 +92,7 @@ ings in this Software without prior written authorization from him.
 xmlsec-mscng library
 ------------------------------------------------------------------------------
 
+Copyright (C) 2018 Aleksey Sanin. All Rights Reserved.
 Copyright (C) 2018 Miklos Vajna. All Rights Reserved.
 
 


### PR DESCRIPTION
The copyright notice and later wording referred to different names, resolve this.