### PR TITLE
build: do not extern "C" scope for include files

### DIFF
--- a/apps/cmdline.h
+++ b/apps/cmdline.h
@@ -10,11 +10,11 @@
 #ifndef __XMLSEC_APPS_CMDLINE_H__
 #define __XMLSEC_APPS_CMDLINE_H__    
 
+#include <time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */ 
-
-#include <time.h>
 
 typedef struct _xmlSecAppCmdLineParam           xmlSecAppCmdLineParam,
                                                 *xmlSecAppCmdLineParamPtr;

--- a/apps/crypto.h
+++ b/apps/crypto.h
@@ -9,16 +9,16 @@
 #ifndef __XMLSEC_APPS_CRYPTO_H__
 #define __XMLSEC_APPS_CRYPTO_H__    
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */ 
-
 #include <libxml/tree.h>
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/crypto.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 int     xmlSecAppCryptoInit                                     (const char* config);
 int     xmlSecAppCryptoShutdown                                 (void);

--- a/include/xmlsec/app.h
+++ b/include/xmlsec/app.h
@@ -16,10 +16,6 @@
 #error To use dynamic crypto engines loading define XMLSEC_CRYPTO_DYNAMIC_LOADING
 #endif /* !defined(IN_XMLSEC) && !defined(XMLSEC_CRYPTO_DYNAMIC_LOADING) */
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <libxml/xmlIO.h>
 
@@ -29,6 +25,10 @@ extern "C" {
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**********************************************************************
  *

--- a/include/xmlsec/base64.h
+++ b/include/xmlsec/base64.h
@@ -11,14 +11,14 @@
 #ifndef __XMLSEC_BASE64_H__
 #define __XMLSEC_BASE64_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * XMLSEC_BASE64_LINESIZE:

--- a/include/xmlsec/bn.h
+++ b/include/xmlsec/bn.h
@@ -11,13 +11,13 @@
 #ifndef __XMLSEC_BN_H__
 #define __XMLSEC_BN_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/buffer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef xmlSecBuffer                                            xmlSecBn,
                                                                 *xmlSecBnPtr;

--- a/include/xmlsec/buffer.h
+++ b/include/xmlsec/buffer.h
@@ -11,12 +11,12 @@
 #ifndef __XMLSEC_BUFFER_H__
 #define __XMLSEC_BUFFER_H__
 
+#include <libxml/tree.h>
+#include <xmlsec/xmlsec.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <libxml/tree.h>
-#include <xmlsec/xmlsec.h>
 
 typedef struct _xmlSecBuffer                                    xmlSecBuffer,
                                                                 *xmlSecBufferPtr;

--- a/include/xmlsec/crypto.h
+++ b/include/xmlsec/crypto.h
@@ -11,10 +11,6 @@
 #ifndef __XMLSEC_CRYPTO_H__
 #define __XMLSEC_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 
 /* include nothing if we compile xmlsec library itself */
@@ -73,10 +69,6 @@ extern "C" {
 
 #endif /* IN_XMLSEC_CRYPTO */
 #endif /* IN_XMLSEC */
-
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
 
 #endif /* __XMLSEC_CRYPTO_H__ */
 

--- a/include/xmlsec/dl.h
+++ b/include/xmlsec/dl.h
@@ -10,6 +10,19 @@
 #ifndef __XMLSEC_DL_H__
 #define __XMLSEC_DL_H__
 
+#ifndef XMLSEC_NO_CRYPTO_DYNAMIC_LOADING
+
+#include <libxml/tree.h>
+#include <libxml/xmlIO.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/keysdata.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/keysmngr.h>
+#include <xmlsec/transforms.h>
+
+#endif /* XMLSEC_NO_CRYPTO_DYNAMIC_LOADING */
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -21,15 +34,6 @@ XMLSEC_EXPORT int                               xmlSecCryptoDLFunctionsRegisterK
                                                                             (xmlSecCryptoDLFunctionsPtr functions);
 
 #ifndef XMLSEC_NO_CRYPTO_DYNAMIC_LOADING
-
-#include <libxml/tree.h>
-#include <libxml/xmlIO.h>
-
-#include <xmlsec/xmlsec.h>
-#include <xmlsec/keysdata.h>
-#include <xmlsec/keys.h>
-#include <xmlsec/keysmngr.h>
-#include <xmlsec/transforms.h>
 
 /****************************************************************************
  *

--- a/include/xmlsec/gcrypt/app.h
+++ b/include/xmlsec/gcrypt/app.h
@@ -9,14 +9,14 @@
 #ifndef __XMLSEC_GCRYPT_APP_H__
 #define __XMLSEC_GCRYPT_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/gcrypt/crypto.h
+++ b/include/xmlsec/gcrypt/crypto.h
@@ -9,16 +9,16 @@
 #ifndef __XMLSEC_GCRYPT_CRYPTO_H__
 #define __XMLSEC_GCRYPT_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
 
 #include <gcrypt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_gcrypt(void);
 

--- a/include/xmlsec/gnutls/app.h
+++ b/include/xmlsec/gnutls/app.h
@@ -9,14 +9,14 @@
 #ifndef __XMLSEC_GNUTLS_APP_H__
 #define __XMLSEC_GNUTLS_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/gnutls/crypto.h
+++ b/include/xmlsec/gnutls/crypto.h
@@ -9,14 +9,22 @@
 #ifndef __XMLSEC_GNUTLS_CRYPTO_H__
 #define __XMLSEC_GNUTLS_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
+#ifndef XMLSEC_NO_DSA
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+#endif /* XMLSEC_NO_DSA */
+#ifndef XMLSEC_NO_RSA
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+#endif /* XMLSEC_NO_RSA */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_gnutls(void);
 
@@ -152,9 +160,6 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecGnuTLSTransformKWDes3GetKlass(void)
  *******************************************************************/
 #ifndef XMLSEC_NO_DSA
 
-#include <gnutls/gnutls.h>
-#include <gnutls/x509.h>
-
 /**
  * xmlSecGnuTLSKeyDataDsaId:
  *
@@ -283,9 +288,6 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecGnuTLSTransformHmacSha512GetKlass(v
  *
  *******************************************************************/
 #ifndef XMLSEC_NO_RSA
-
-#include <gnutls/gnutls.h>
-#include <gnutls/x509.h>
 
 /**
  * xmlSecGnuTLSKeyDataRsaId:

--- a/include/xmlsec/gnutls/x509.h
+++ b/include/xmlsec/gnutls/x509.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_GNUTLS_X509_H__
 #define __XMLSEC_GNUTLS_X509_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #ifndef XMLSEC_NO_X509
 
 #include <gnutls/gnutls.h>
@@ -22,6 +18,9 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**************************************************************************
  *
@@ -101,10 +100,10 @@ XMLSEC_CRYPTO_EXPORT int                xmlSecGnuTLSX509StoreAdoptCert  (xmlSecK
 
 
 
-#endif /* XMLSEC_NO_X509 */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#endif /* XMLSEC_NO_X509 */
 
 #endif /* __XMLSEC_GNUTLS_X509_H__ */

--- a/include/xmlsec/io.h
+++ b/include/xmlsec/io.h
@@ -11,15 +11,15 @@
 #ifndef __XMLSEC_IO_H__
 #define __XMLSEC_IO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <libxml/xmlIO.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_EXPORT int       xmlSecIOInit                            (void);
 XMLSEC_EXPORT void      xmlSecIOShutdown                        (void);

--- a/include/xmlsec/keyinfo.h
+++ b/include/xmlsec/keyinfo.h
@@ -12,10 +12,6 @@
 #ifndef __XMLSEC_KEYINFO_H__
 #define __XMLSEC_KEYINFO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <time.h>
 
 #include <libxml/tree.h>
@@ -25,6 +21,10 @@ extern "C" {
 #include <xmlsec/keysdata.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /****************************************************************************
  *

--- a/include/xmlsec/keys.h
+++ b/include/xmlsec/keys.h
@@ -11,16 +11,15 @@
 #ifndef __XMLSEC_KEYS_H__
 #define __XMLSEC_KEYS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <time.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/list.h>
 #include <xmlsec/keysdata.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * xmlSecKeyUsage:

--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -11,15 +11,15 @@
 #ifndef __XMLSEC_KEYSDATA_H__
 #define __XMLSEC_KEYSDATA_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/buffer.h>
 #include <xmlsec/list.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /****************************************************************************
  *

--- a/include/xmlsec/keysmngr.h
+++ b/include/xmlsec/keysmngr.h
@@ -11,15 +11,15 @@
 #ifndef __XMLSEC_KEYSMGMR_H__
 #define __XMLSEC_KEYSMGMR_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/list.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keysdata.h>
 #include <xmlsec/keyinfo.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef const struct _xmlSecKeyKlass                    xmlSecKeyKlass,
                                                         *xmlSecKeyId;

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -11,12 +11,12 @@
 #ifndef __XMLSEC_LIST_H__
 #define __XMLSEC_LIST_H__
 
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/buffer.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <xmlsec/xmlsec.h>
-#include <xmlsec/buffer.h>
 
 typedef const struct _xmlSecPtrListKlass                        xmlSecPtrListKlass,
                                                                 *xmlSecPtrListId;

--- a/include/xmlsec/membuf.h
+++ b/include/xmlsec/membuf.h
@@ -11,15 +11,15 @@
 #ifndef __XMLSEC_MEMBUF_H__
 #define __XMLSEC_MEMBUF_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/buffer.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/mscng/app.h
+++ b/include/xmlsec/mscng/app.h
@@ -9,16 +9,16 @@
 #ifndef __XMLSEC_MSCNG_APP_H__
 #define __XMLSEC_MSCNG_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <windows.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/mscng/certkeys.h
+++ b/include/xmlsec/mscng/certkeys.h
@@ -9,15 +9,15 @@
 #ifndef __XMLSEC_MSCNG_CERTKEYS_H__
 #define __XMLSEC_MSCNG_CERTKEYS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <windows.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataPtr   xmlSecMSCngCertAdopt         (PCCERT_CONTEXT pCert,
                                                                       xmlSecKeyDataType type);

--- a/include/xmlsec/mscng/crypto.h
+++ b/include/xmlsec/mscng/crypto.h
@@ -9,16 +9,16 @@
 #ifndef __XMLSEC_MSCNG_CRYPTO_H__
 #define __XMLSEC_MSCNG_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <windows.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_mscng(void);
 

--- a/include/xmlsec/mscng/keysstore.h
+++ b/include/xmlsec/mscng/keysstore.h
@@ -9,11 +9,11 @@
 #ifndef __XMLSEC_MSCNG_KEYSSTORE_H__
 #define __XMLSEC_MSCNG_KEYSSTORE_H__
 
+#include <xmlsec/xmlsec.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <xmlsec/xmlsec.h>
 
 /**
  * xmlSecMSCngKeysStoreId:

--- a/include/xmlsec/mscng/x509.h
+++ b/include/xmlsec/mscng/x509.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_MSCNG_X509_H__
 #define __XMLSEC_MSCNG_X509_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #ifndef XMLSEC_NO_X509
 
 #include <xmlsec/xmlsec.h>
@@ -20,6 +16,10 @@ extern "C" {
 #include <xmlsec/transforms.h>
 
 #include <windows.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * xmlSecMSCngKeyDataX509Id:
@@ -74,10 +74,10 @@ PCCERT_CONTEXT                          xmlSecMSCngX509FindCertBySubject     (HC
                                                                               LPTSTR wcSubject,
                                                                               DWORD dwCertEncodingType);
 
-#endif /* XMLSEC_NO_X509 */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#endif /* XMLSEC_NO_X509 */
 
 #endif /* __XMLSEC_MSCNG_X509_H__ */

--- a/include/xmlsec/mscrypto/app.h
+++ b/include/xmlsec/mscrypto/app.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_MSCRYPTO_APP_H__
 #define __XMLSEC_MSCRYPTO_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
@@ -20,6 +16,10 @@ extern "C" {
 
 #include <windows.h>
 #include <wincrypt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/mscrypto/certkeys.h
+++ b/include/xmlsec/mscrypto/certkeys.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_MSCRYPTO_CERTKEYS_H__
 #define __XMLSEC_MSCRYPTO_CERTKEYS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <windows.h>
 #include <wincrypt.h>
 
@@ -20,6 +16,9 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT PCCERT_CONTEXT     xmlSecMSCryptoKeyDataGetCert    (xmlSecKeyDataPtr data);
 XMLSEC_CRYPTO_EXPORT HCRYPTKEY          xmlSecMSCryptoKeyDataGetKey     (xmlSecKeyDataPtr data,

--- a/include/xmlsec/mscrypto/crypto.h
+++ b/include/xmlsec/mscrypto/crypto.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_MSCRYPTO_CRYPTO_H__
 #define __XMLSEC_MSCRYPTO_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <windows.h>
 #include <wincrypt.h>
 
@@ -20,6 +16,10 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_mscrypto(void);
 

--- a/include/xmlsec/mscrypto/keysstore.h
+++ b/include/xmlsec/mscrypto/keysstore.h
@@ -11,11 +11,11 @@
 #ifndef __XMLSEC_MSCRYPTO_KEYSSTORE_H__
 #define __XMLSEC_MSCRYPTO_KEYSSTORE_H__
 
+#include <xmlsec/xmlsec.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <xmlsec/xmlsec.h>
 
 /****************************************************************************
  *

--- a/include/xmlsec/mscrypto/x509.h
+++ b/include/xmlsec/mscrypto/x509.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_MSCRYPTO_X509_H__
 #define __XMLSEC_MSCRYPTO_X509_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #ifndef XMLSEC_NO_X509
 
 #include <xmlsec/xmlsec.h>
@@ -21,6 +17,10 @@ extern "C" {
 
 #include <windows.h>
 #include <wincrypt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * xmlSecMSCryptoKeyDataX509Id:
@@ -83,10 +83,10 @@ XMLSEC_CRYPTO_EXPORT void               xmlSecMSCryptoX509StoreEnableSystemTrust
 
 
 
-#endif /* XMLSEC_NO_X509 */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#endif /* XMLSEC_NO_X509 */
 
 #endif /* __XMLSEC_MSCRYPTO_X509_H__ */

--- a/include/xmlsec/nodeset.h
+++ b/include/xmlsec/nodeset.h
@@ -11,14 +11,14 @@
 #ifndef __XMLSEC_NODESET_H__
 #define __XMLSEC_NODESET_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
 
 #include <xmlsec/xmlsec.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef struct _xmlSecNodeSet   xmlSecNodeSet, *xmlSecNodeSetPtr;
 

--- a/include/xmlsec/nss/app.h
+++ b/include/xmlsec/nss/app.h
@@ -10,10 +10,6 @@
 #ifndef __XMLSEC_NSS_APP_H__
 #define __XMLSEC_NSS_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <nspr.h>
 #include <nss.h>
 
@@ -21,6 +17,10 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/nss/bignum.h
+++ b/include/xmlsec/nss/bignum.h
@@ -11,16 +11,16 @@
 #ifndef __XMLSEC_NSS_BIGNUM_H__
 #define __XMLSEC_NSS_BIGNUM_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <nspr.h>
 #include <nss.h>
 
 #include <xmlsec/xmlsec.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT SECItem*   xmlSecNssNodeGetBigNumValue     (PRArenaPool *arena,
                                                                  const xmlNodePtr cur,

--- a/include/xmlsec/nss/crypto.h
+++ b/include/xmlsec/nss/crypto.h
@@ -10,10 +10,6 @@
 #ifndef __XMLSEC_NSS_CRYPTO_H__
 #define __XMLSEC_NSS_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <nspr.h>
 #include <nss.h>
 #include <pk11func.h>
@@ -22,6 +18,10 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_nss(void);
 

--- a/include/xmlsec/nss/keysstore.h
+++ b/include/xmlsec/nss/keysstore.h
@@ -11,11 +11,11 @@
 #ifndef __XMLSEC_NSS_KEYSSTORE_H__
 #define __XMLSEC_NSS_KEYSSTORE_H__
 
+#include <xmlsec/xmlsec.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
-
-#include <xmlsec/xmlsec.h>
 
 /****************************************************************************
  *

--- a/include/xmlsec/nss/pkikeys.h
+++ b/include/xmlsec/nss/pkikeys.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_NSS_PKIKEYS_H__
 #define __XMLSEC_NSS_PKIKEYS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <nspr.h>
 #include <nss.h>
 
@@ -20,6 +16,9 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecKeyDataPtr   xmlSecNssPKIAdoptKey           (SECKEYPrivateKey *privkey,
                                                                         SECKEYPublicKey  *pubkey);

--- a/include/xmlsec/nss/x509.h
+++ b/include/xmlsec/nss/x509.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_NSS_X509_H__
 #define __XMLSEC_NSS_X509_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #ifndef XMLSEC_NO_X509
 
 #include <nspr.h>
@@ -22,6 +18,10 @@ extern "C" {
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * xmlSecNssKeyDataX509Id:
@@ -82,10 +82,10 @@ XMLSEC_CRYPTO_EXPORT int                        xmlSecNssX509StoreAdoptCert (xml
                                                                              xmlSecKeyDataType type);
 
 
-#endif /* XMLSEC_NO_X509 */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#endif /* XMLSEC_NO_X509 */
 
 #endif /* __XMLSEC_NSS_X509_H__ */

--- a/include/xmlsec/openssl/app.h
+++ b/include/xmlsec/openssl/app.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_OPENSSL_APP_H__
 #define __XMLSEC_OPENSSL_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <openssl/pem.h>
 #include <openssl/bio.h>
 
@@ -20,6 +16,10 @@ extern "C" {
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/openssl/bn.h
+++ b/include/xmlsec/openssl/bn.h
@@ -11,15 +11,15 @@
 #ifndef __XMLSEC_BN_H__
 #define __XMLSEC_BN_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <openssl/bn.h>
 
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT BIGNUM*    xmlSecOpenSSLNodeGetBNValue     (const xmlNodePtr cur,
                                                                  BIGNUM **a);

--- a/include/xmlsec/openssl/crypto.h
+++ b/include/xmlsec/openssl/crypto.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_OPENSSL_CRYPTO_H__
 #define __XMLSEC_OPENSSL_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
@@ -22,6 +18,25 @@ extern "C" {
 #ifndef OPENSSL_IS_BORINGSSL
 #include <openssl/opensslconf.h>
 #endif /* OPENSSL_IS_BORINGSSL */
+
+#ifndef XMLSEC_NO_DSA
+#include <openssl/dsa.h>
+#include <openssl/evp.h>
+#endif /* XMLSEC_NO_DSA */
+
+#ifndef XMLSEC_NO_ECDSA
+#include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+#endif /* XMLSEC_NO_ECDSA */
+
+#ifndef XMLSEC_NO_RSA
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+#endif /* XMLSEC_NO_RSA */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_openssl(void);
 
@@ -264,8 +279,6 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecOpenSSLTransformKWDes3GetKlass(void
  *
  *******************************************************************/
 #ifndef XMLSEC_NO_DSA
-#include <openssl/dsa.h>
-#include <openssl/evp.h>
 
 /**
  * xmlSecOpenSSLKeyDataDsaId:
@@ -312,8 +325,6 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecOpenSSLTransformDsaSha256GetKlass(v
  *
  *******************************************************************/
 #ifndef XMLSEC_NO_ECDSA
-#include <openssl/ecdsa.h>
-#include <openssl/evp.h>
 
 /**
  * xmlSecOpenSSLKeyDataEcdsaId:
@@ -633,8 +644,6 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId xmlSecOpenSSLTransformRipemd160GetKlass(v
  *
  *******************************************************************/
 #ifndef XMLSEC_NO_RSA
-#include <openssl/rsa.h>
-#include <openssl/evp.h>
 
 /**
  * xmlSecOpenSSLKeyDataRsaId:

--- a/include/xmlsec/openssl/evp.h
+++ b/include/xmlsec/openssl/evp.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_OPENSSL_EVP_H__
 #define __XMLSEC_OPENSSL_EVP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <openssl/evp.h>
 
 #include <xmlsec/xmlsec.h>
@@ -21,6 +17,9 @@ extern "C" {
 
 #include <xmlsec/openssl/crypto.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT int                xmlSecOpenSSLEvpKeyDataAdoptEvp (xmlSecKeyDataPtr data,
                                                                          EVP_PKEY* pKey);

--- a/include/xmlsec/openssl/x509.h
+++ b/include/xmlsec/openssl/x509.h
@@ -9,10 +9,6 @@
 #ifndef __XMLSEC_OPENSSL_X509_H__
 #define __XMLSEC_OPENSSL_X509_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #ifndef XMLSEC_NO_X509
 
 #include <openssl/x509.h>
@@ -20,6 +16,10 @@ extern "C" {
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * XMLSEC_STACK_OF_X509:
@@ -100,10 +100,10 @@ XMLSEC_CRYPTO_EXPORT int                xmlSecOpenSSLX509StoreAddCertsPath(xmlSe
 XMLSEC_CRYPTO_EXPORT int                xmlSecOpenSSLX509StoreAddCertsFile(xmlSecKeyDataStorePtr store,
                                                                          const char* filename);
 
-#endif /* XMLSEC_NO_X509 */
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#endif /* XMLSEC_NO_X509 */
 
 #endif /* __XMLSEC_OPENSSL_X509_H__ */

--- a/include/xmlsec/parser.h
+++ b/include/xmlsec/parser.h
@@ -11,15 +11,14 @@
 #ifndef __XMLSEC_PARSER_H__
 #define __XMLSEC_PARSER_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/transforms.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_EXPORT xmlDocPtr         xmlSecParseFile         (const char *filename);
 XMLSEC_EXPORT xmlDocPtr         xmlSecParseMemory       (const xmlSecByte *buffer,

--- a/include/xmlsec/private.h
+++ b/include/xmlsec/private.h
@@ -16,10 +16,6 @@
 #error "xmlsec/private.h file contains private xmlsec definitions and should not be used outside xmlsec or xmlsec-$crypto libraries"
 #endif /* XMLSEC_PRIVATE */
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <libxml/xmlIO.h>
 
@@ -29,6 +25,19 @@ extern "C" {
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
 
+#ifdef __GNUC__
+#ifdef HAVE_ANSIDECL_H
+#include <ansidecl.h>
+#endif
+#endif
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /*****************************************************************************
  *
@@ -503,9 +512,6 @@ struct _xmlSecCryptoDLFunctions {
  * Macro used to signal to GCC unused function parameters
  */
 #ifdef __GNUC__
-#ifdef HAVE_ANSIDECL_H
-#include <ansidecl.h>
-#endif
 #ifndef ATTRIBUTE_UNUSED
 #define ATTRIBUTE_UNUSED
 #endif
@@ -518,9 +524,6 @@ struct _xmlSecCryptoDLFunctions {
  *
  * Macro used to signal to MSVC unused function parameters
  */
-#ifdef WIN32
-#include <windows.h>
-#endif
 #ifndef UNREFERENCED_PARAMETER
 #define UNREFERENCED_PARAMETER(x)
 #endif /* UNREFERENCED_PARAMETER */

--- a/include/xmlsec/skeleton/app.h
+++ b/include/xmlsec/skeleton/app.h
@@ -9,14 +9,14 @@
 #ifndef __XMLSEC_SKELETON_APP_H__
 #define __XMLSEC_SKELETON_APP_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /********************************************************************
  *

--- a/include/xmlsec/skeleton/crypto.h
+++ b/include/xmlsec/skeleton/crypto.h
@@ -9,14 +9,14 @@
 #ifndef __XMLSEC_SKELETON_CRYPTO_H__
 #define __XMLSEC_SKELETON_CRYPTO_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/dl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 XMLSEC_CRYPTO_EXPORT xmlSecCryptoDLFunctionsPtr xmlSecCryptoGetFunctions_skeleton(void);
 

--- a/include/xmlsec/soap.h
+++ b/include/xmlsec/soap.h
@@ -13,13 +13,12 @@
 
 #ifndef XMLSEC_NO_SOAP
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <xmlsec/xmlsec.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /***********************************************************************
  *

--- a/include/xmlsec/strings.h
+++ b/include/xmlsec/strings.h
@@ -11,13 +11,13 @@
 #ifndef __XMLSEC_STRINGS_H__
 #define __XMLSEC_STRINGS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /*************************************************************************
  *

--- a/include/xmlsec/templates.h
+++ b/include/xmlsec/templates.h
@@ -11,14 +11,14 @@
 #ifndef __XMLSEC_TEMPLATES_H__
 #define __XMLSEC_TEMPLATES_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /***********************************************************************
  *

--- a/include/xmlsec/transforms.h
+++ b/include/xmlsec/transforms.h
@@ -11,10 +11,6 @@
 #ifndef __XMLSEC_TRANSFORMS_H__
 #define __XMLSEC_TRANSFORMS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
 
@@ -23,6 +19,14 @@ extern "C" {
 #include <xmlsec/list.h>
 #include <xmlsec/nodeset.h>
 #include <xmlsec/keys.h>
+
+#ifndef XMLSEC_NO_XSLT
+#include <libxslt/security.h>
+#endif /* XMLSEC_NO_XSLT */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef const struct _xmlSecTransformKlass              xmlSecTransformKlass,
                                                         *xmlSecTransformId;
@@ -959,7 +963,6 @@ XMLSEC_EXPORT int               xmlSecTransformXPointerSetExpr          (xmlSecT
 XMLSEC_EXPORT xmlSecTransformId xmlSecTransformRelationshipGetKlass     (void);
 
 #ifndef XMLSEC_NO_XSLT
-#include <libxslt/security.h>
 
 /**
  * xmlSecTransformXsltId:

--- a/include/xmlsec/x509.h
+++ b/include/xmlsec/x509.h
@@ -11,9 +11,6 @@
 
 #ifndef XMLSEC_NO_X509
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
 #include <stdio.h>
 
 #include <libxml/tree.h>
@@ -26,6 +23,10 @@ extern "C" {
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * XMLSEC_X509DATA_CERTIFICATE_NODE:

--- a/include/xmlsec/xmldsig.h
+++ b/include/xmlsec/xmldsig.h
@@ -15,10 +15,6 @@
 
 #ifndef XMLSEC_NO_XMLDSIG
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 #include <libxml/parser.h>
 
@@ -30,6 +26,10 @@ extern "C" {
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 typedef struct _xmlSecDSigReferenceCtx          xmlSecDSigReferenceCtx,
                                                 *xmlSecDSigReferenceCtxPtr;

--- a/include/xmlsec/xmlenc.h
+++ b/include/xmlsec/xmlenc.h
@@ -14,9 +14,6 @@
 
 #ifndef XMLSEC_NO_XMLENC
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
 #include <stdio.h>
 
 #include <libxml/tree.h>
@@ -28,6 +25,10 @@ extern "C" {
 #include <xmlsec/keysmngr.h>
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/transforms.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * xmlEncCtxMode:

--- a/include/xmlsec/xmlsec.h
+++ b/include/xmlsec/xmlsec.h
@@ -11,15 +11,15 @@
 #ifndef __XMLSEC_H__
 #define __XMLSEC_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <libxml/tree.h>
 
 #include <xmlsec/version.h>
 #include <xmlsec/exports.h>
 #include <xmlsec/strings.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /***********************************************************************
  *

--- a/include/xmlsec/xmltree.h
+++ b/include/xmlsec/xmltree.h
@@ -11,15 +11,19 @@
 #ifndef __XMLSEC_TREE_H__
 #define __XMLSEC_TREE_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
 #include <stdio.h>
 
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
 #include <xmlsec/xmlsec.h>
+
+#ifdef WIN32
+#include <windows.h>
+#endif /* WIN32 */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /**
  * xmlSecNodeGetName:
@@ -273,7 +277,6 @@ XMLSEC_EXPORT void              xmlSecQName2BitMaskDebugXmlDump(xmlSecQName2BitM
  *
  ************************************************************************/
 #ifdef WIN32
-#include <windows.h>
 XMLSEC_EXPORT LPWSTR             xmlSecWin32ConvertLocaleToUnicode(const char* str);
 
 XMLSEC_EXPORT LPWSTR             xmlSecWin32ConvertUtf8ToUnicode  (const xmlChar* str);


### PR DESCRIPTION
C++ include files such as icu and others do not expect the scope to be in C,
as include directive is expected to be performed at global scope.

Example[1].

Yes, and include file of C++ can have extern "C++" to force C++ scope,
however, it is expected that global scope will be C++ already and most headers
do not do that.

[1] https://github.com/unicode-org/icu/pull/572

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>