### PR TITLE
gnutls: allow SHA-1 signed certificate when not in strict checks (#250)

### DIFF
--- a/src/gnutls/x509vfy.c
+++ b/src/gnutls/x509vfy.c
@@ -295,6 +295,9 @@ xmlSecGnuTLSX509StoreVerify(xmlSecKeyDataStorePtr store,
     if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_SKIP_STRICT_CHECKS) != 0) {
         flags |= GNUTLS_VERIFY_ALLOW_SIGN_RSA_MD2;
         flags |= GNUTLS_VERIFY_ALLOW_SIGN_RSA_MD5;
+#if GNUTLS_VERSION_NUMBER >= 0x030600
+        flags |= GNUTLS_VERIFY_ALLOW_SIGN_WITH_SHA1;
+#endif
     }
 
     /* We are going to build all possible cert chains and try to verify them */

--- a/tests/testrun.sh
+++ b/tests/testrun.sh
@@ -59,7 +59,7 @@ if [ "z$XMLSEC_DEFAULT_CRYPTO" != "z" ] ; then
 elif [ "z$crypto" != "z" ] ; then
     xmlsec_params="$xmlsec_params --crypto $crypto"
 fi
-xmlsec_params="$xmlsec_params --crypto-config $crypto_config"
+xmlsec_params="$xmlsec_params --X509-skip-strict-checks --crypto-config $crypto_config"
 
 #
 # Setup keys config


### PR DESCRIPTION
This is required for gnutls-3.6.x.

Allow tests to use no strict checks until all certificates will be converted
to stronger signature than SHA-1.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>