### PR TITLE
build: add --enable-mans configuration options

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,11 @@ SUBDIRS 	    = include src
 if XMLSEC_APPS
 SUBDIRS += apps
 endif
+if XMLSEC_MANS
+SUBDIRS += man
+endif
 if XMLSEC_DOCS
-SUBDIRS += man docs
+SUBDIRS += docs
 endif
 TEST_APP 	    = apps/xmlsec1$(EXEEXT)
 DEFAULT_CRYPTO	= @XMLSEC_DEFAULT_CRYPTO@

--- a/configure.ac
+++ b/configure.ac
@@ -2110,6 +2110,21 @@ fi
 AM_CONDITIONAL(XMLSEC_ENABLE_SOAP, test "z$XMLSEC_ENABLE_SOAP" = "z1")
 
 dnl ==========================================================================
+dnl See do we need mans
+dnl ==========================================================================
+AC_MSG_CHECKING(for mans)
+AC_ARG_ENABLE(mans,   [  --enable-mans         enable manual pages (yes)])
+if test "z$enable_mans" = "zno" ; then
+    XMLSEC_MANS="0"
+    AC_MSG_RESULT([disabled])
+else
+    XMLSEC_MANS="1"
+    AC_MSG_RESULT([yes])
+fi
+AM_CONDITIONAL(XMLSEC_MANS, test "z$XMLSEC_MANS" = "z1")
+AC_SUBST(XMLSEC_MANS)
+
+dnl ==========================================================================
 dnl See do we need docs
 dnl ==========================================================================
 AC_MSG_CHECKING(for docs)


### PR DESCRIPTION
Add --enable-mans to install man pages, while --enable-docs installs the
remaining documentation.

This is useful for minimal documentation installation in distributions in
which the additional documentation requires explicit option.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>

---

In Gentoo[1] we hack the build to make it happen, it will be nice if we can do this without modifying the build.

Thanks!

[1] https://github.com/gentoo/gentoo/blob/master/dev-libs/xmlsec/xmlsec-1.2.27-r1.ebuild#L45
