### PR TITLE
Add configure support for further OS's

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -641,6 +641,8 @@ case $host in
     *-*-osf5*)    OPENSSL_EXTRA_LIBS=;;
     *-*-openbsd*) OPENSSL_EXTRA_LIBS=;;
     *-*-netbsd*)  OPENSSL_EXTRA_LIBS=;;
+    *-*-freebsd*|*-*-dragonfly*) OPENSSL_EXTRA_LIBS=;;
+    *-*-darwin*) OPENSSL_EXTRA_LIBS=;;
     #FIXME: check if lib "dl" is required
     *)            OPENSSL_EXTRA_LIBS=-ldl;;
 esac


### PR DESCRIPTION
The change in this pull request is based on a patch in the pkgsrc repository that is required in order to compile xmlsec in other OSs supported by pkgsrc.

Currently pkgsrc is using xmlsec1 1.2.25.  Merging this pull request would make it simpler to upgrade the xmlsec version shipped with pkgsrc.

See also https://github.com/NetBSD/pkgsrc/blob/pkgsrc-2018Q4/security/xmlsec1/patches/patch-ab#L39