### PR TITLE
Fix 'make clean' before first full build

### DIFF
--- a/docs/api/Makefile.am
+++ b/docs/api/Makefile.am
@@ -268,9 +268,8 @@ clean-local:
 	-rm -rf $(SOURCE_CODE_DIR) $(EXAMPLES_DIR) $(SCAN_DIR)/*.txt $(SGML_DIR) $(GTKDOC_MKDB_OUTPUT_DIR)
 	-rm -f *.stamp *.types index.sgml
 	@( if [ z"$(builddir)" != z"$(srcdir)" ] ; then \
-    	chmod -R u+w $(builddir)/src && rm -rf $(builddir)/src ; \
-    	chmod -R u+w $(builddir)/images && rm -rf $(builddir)/images ; \
-    	chmod -R u+w $(builddir)/*.png && rm -rf $(builddir)/*.png ; \
+	find $(builddir) -name 'src' -o -name 'images' -o -name '*.png' -exec chmod u+w '{}' ';' ; \
+	rm -rf $(builddir)/src $(builddir)/images $(builddir)/*.png ; \
 	 fi ; )
 
 distclean-local: clean-local


### PR DESCRIPTION
When the build is configured out of tree (srcdir != builddir)
clean-local in docs/api tried to chmod a number of files and directories
prior to removing them. However make has not yet run these files and
directories won't exist yet and chmod will exit with a non-zero exit status
which aborts the make clean command with an error.
The changed build rules will do the file permission changes as part of the
find command, which will just skip over non-existing directories and files
instead of generating errors.

Note for ordinary builds this is probably of little relevance. However automated builds (like under the jhbuild build system) will often run make clean before starting a new build. This issue was found for example in the automated build system for gnucash.