### PR TITLE
Make userData pointer available in referencePreExecuteCallback function when using xmldsig ctx

### DIFF
--- a/src/xmldsig.c
+++ b/src/xmldsig.c
@@ -1215,6 +1215,7 @@ xmlSecDSigReferenceCtxInitialize(xmlSecDSigReferenceCtxPtr dsigRefCtx, xmlSecDSi
     }
     dsigRefCtx->transformCtx.preExecCallback = dsigCtx->referencePreExecuteCallback;
     dsigRefCtx->transformCtx.enabledUris = dsigCtx->enabledReferenceUris;
+    dsigRefCtx->transformCtx.userData = dsigCtx->userData;
 
     if((dsigCtx->flags & XMLSEC_DSIG_FLAGS_USE_VISA3D_HACK) != 0) {
         dsigRefCtx->transformCtx.flags |= XMLSEC_TRANSFORMCTX_FLAGS_USE_VISA3D_HACK;


### PR DESCRIPTION
The userData pointer that upper layers using xmlsec could set to a xmlSecDSigCtx structure, before calling any xmldsig related function, is not available while executing referencePreExecuteCallback function. This change will allow upper layers to use that userData pointer, if desired, to pass some info which might be helpful for them while validating/changing the transform chain.