### PR TITLE
Allow compilation on UWP

### DIFF
--- a/src/dl.c
+++ b/src/dl.c
@@ -152,7 +152,7 @@ xmlSecCryptoDLLibraryCreate(const xmlChar* name) {
 	lib->handle = LoadLibraryA((char*)lib->filename);
 #else
     LPTSTR wcLibFilename = xmlSecWin32ConvertUtf8ToTstr((char*)lib->filename);
-	if(wcLibFilename == NULL) {
+    if(wcLibFilename == NULL) {
         xmlSecIOError("xmlSecWin32ConvertUtf8ToTstr", lib->filename, NULL);
         xmlSecCryptoDLLibraryDestroy(lib);
         return(NULL);

--- a/src/dl.c
+++ b/src/dl.c
@@ -155,6 +155,11 @@ xmlSecCryptoDLLibraryCreate(const xmlChar* name) {
 	wcLib = xmlSecWin32ConvertUtf8ToTstr((char*)lib->filename);
 	if (wcLib)
 		lib->handle = LoadPackagedLibrary(wcLib, 0);
+	else {
+        xmlSecIOError("xmlSecWin32ConvertUtf8ToTstr", lib->filename, NULL);
+        xmlSecCryptoDLLibraryDestroy(lib);
+        return(NULL);
+    }
 #endif
     if(lib->handle == NULL) {
         xmlSecIOError("LoadLibraryA", lib->filename, NULL);

--- a/src/dl.c
+++ b/src/dl.c
@@ -148,7 +148,14 @@ xmlSecCryptoDLLibraryCreate(const xmlChar* name) {
 #endif /* XMLSEC_DL_LIBLTDL */
 
 #ifdef XMLSEC_DL_WIN32
-    lib->handle = LoadLibraryA((char*)lib->filename);
+#if !defined(WINAPI_FAMILY) || WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP
+	lib->handle = LoadLibraryA((char*)lib->filename);
+#else
+    LPTSTR wcLib = NULL;
+	wcLib = xmlSecWin32ConvertUtf8ToTstr((char*)lib->filename);
+	if (wcLib)
+		lib->handle = LoadPackagedLibrary(wcLib, 0);
+#endif
     if(lib->handle == NULL) {
         xmlSecIOError("LoadLibraryA", lib->filename, NULL);
         xmlSecCryptoDLLibraryDestroy(lib);

--- a/src/dl.c
+++ b/src/dl.c
@@ -151,15 +151,14 @@ xmlSecCryptoDLLibraryCreate(const xmlChar* name) {
 #if !defined(WINAPI_FAMILY) || WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP
 	lib->handle = LoadLibraryA((char*)lib->filename);
 #else
-    LPTSTR wcLib = NULL;
-	wcLib = xmlSecWin32ConvertUtf8ToTstr((char*)lib->filename);
-	if (wcLib)
-		lib->handle = LoadPackagedLibrary(wcLib, 0);
-	else {
+    LPTSTR wcLibFilename = xmlSecWin32ConvertUtf8ToTstr((char*)lib->filename);
+	if(wcLibFilename == NULL) {
         xmlSecIOError("xmlSecWin32ConvertUtf8ToTstr", lib->filename, NULL);
         xmlSecCryptoDLLibraryDestroy(lib);
         return(NULL);
     }
+    lib->handle = LoadPackagedLibrary(wcLibFilename, 0);
+    xmlFree(wcLibFilename);
 #endif
     if(lib->handle == NULL) {
         xmlSecIOError("LoadLibraryA", lib->filename, NULL);


### PR DESCRIPTION
In an Universal Windows Platform app it is not allowed to LoadLibrary a classic desktop library, we have to use LoadPackagedLibrary instead.