### PR TITLE
Fix PKCS12_parse return code handling

### DIFF
--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -629,7 +629,7 @@ xmlSecOpenSSLAppPkcs12LoadBIO(BIO* bio, const char *pwd,
     }
 
     ret = PKCS12_parse(p12, pwd, &pKey, &cert, &chain);
-    if(ret < 0) {
+    if(ret != 1) {
         xmlSecOpenSSLError("PKCS12_parse", NULL);
         goto done;
     }


### PR DESCRIPTION
Hello,
In OpenSSL, PKCS12_parse returns 0 in case of error. This commit properly handle the error case.

Note: it is not a severe error since if an error occurs when parsing the pkcs12 keystore, the call to xmlSecOpenSSLEvpKeyAdopt will immediatly fail. But it will not report the real root cause in the logs.

It will report:
```
func=xmlSecOpenSSLEvpKeyAdopt:file=evp.c:line=351:obj=unknown:subj=pKey != NULL:error=100:assertion:
```

With the fix, we will have the following line in the logs:
```
func=xmlSecOpenSSLAppPkcs12LoadBIO:file=app.c:line=633:obj=unknown:subj=PKCS12_parse:error=4:crypto library function failed:openssl error: 50856204: digital envelope routines: NULL unsupported
```
Regards,