### PR TITLE
Fix OpenSSL lookup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -726,7 +726,7 @@ if test "z$OPENSSL_FOUND" = "zno" ; then
     LIBS="$LIBS $OPENSSL_LIBS $OPENSSL_LIBS_LIST"
     AC_LINK_IFELSE([
         AC_LANG_PROGRAM([[
-            #include <openssl/opensslv.h>
+            #include <openssl/ssl.h>
         ]],[[
             int main () {
                 #if OPENSSL_VERSION_NUMBER < 0x10100000L


### PR DESCRIPTION
Hello,

The validation of OpenSSL presence is done by the following program:
```c
  #include <openssl/opensslv.h>

  int main () {
  #if OPENSSL_VERSION_NUMBER < 0x10100000L
      SSL_library_init();
  #else
      OPENSSL_init_ssl(0, NULL);
  #endif
      return(0);
  }
```
But the function OPENSSL_init_ssl is not declared in this header but in
ssl.h.

This lead to the following error:
```
/home/docker/testconf_xmlsec.c: In function 'main':                                                                                                                                                                                                                            /home/docker/testconf_xmlsec.c:57:17: warning: implicit declaration of function 'OPENSSL_init_ssl' [-Wimplicit-function-declaration]
                 OPENSSL_init_ssl(0, NULL);
                 ^~~~~~~~~~~~~~~~
/home/docker/testconf_xmlsec.c:57:37: error: 'NULL' undeclared (first use in this function)
                 OPENSSL_init_ssl(0, NULL);
                                     ^~~~
/home/docker/testconf_xmlsec.c:57:37: note: 'NULL' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
/home/docker/testconf_xmlsec.c:48:1:
+#include <stddef.h>

/home/docker/testconf_xmlsec.c:57:37:
                 OPENSSL_init_ssl(0, NULL);
                                     ^~~~
/home/docker/testconf_xmlsec.c:57:37: note: each undeclared identifier is reported only once for each function it appears in
```