### PR TITLE
Added --privkey-openssl-engine option to enhance openssl engine support

### DIFF
--- a/apps/crypto.h
+++ b/apps/crypto.h
@@ -47,6 +47,12 @@ int     xmlSecAppCryptoSimpleKeysMngrKeyAndCertsLoad            (xmlSecKeysMngrP
                                                                  const char* pwd, 
                                                                  const char* name,
                                                                  xmlSecKeyDataFormat format);
+int     xmlSecAppCryptoSimpleKeysMngrKeyAndCertsSeparedLoad     (xmlSecKeysMngrPtr mngr, 
+                                                                 const char *files, 
+                                                                 const char* pwd, 
+                                                                 const char* name,
+                                                                 xmlSecKeyDataFormat keyFormat,
+                                                                 xmlSecKeyDataFormat certFormat);
 int     xmlSecAppCryptoSimpleKeysMngrPkcs12KeyLoad              (xmlSecKeysMngrPtr mngr, 
                                                                  const char *filename, 
                                                                  const char* pwd, 

--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -393,6 +393,20 @@ static xmlSecAppCmdLineParam enabledRetrievalMethodUrisParam = {
     NULL
 };
 
+static xmlSecAppCmdLineParam privkeyOpensslEngineParam = { 
+    xmlSecAppCmdLineTopicKeysMngr,
+    "--privkey-openssl-engine",
+    NULL,
+    "--privkey-openssl-engine[:<name>] <openssl-engine>;<openssl-key-id>,[,<crtfile>[,<cafile>[...]]]"
+    "\n\tload private key by OpenSSL ENGINE interface; specify the name of engine"
+    "\n\t(like with -engine params), the key specs (like with -inkey or -key params)"
+    "\n\tand certificates that verify this key",
+    xmlSecAppCmdLineParamTypeStringList,
+    xmlSecAppCmdLineParamFlagParamNameValue | xmlSecAppCmdLineParamFlagMultipleValues,
+    NULL
+};
+
+
 /****************************************************************
  *
  * Common params
@@ -856,6 +870,7 @@ static xmlSecAppCmdLineParamPtr parameters[] = {
     &X509SkipStrictChecksParam,    
     &X509DontVerifyCerts,
 #endif /* XMLSEC_NO_X509 */    
+    &privkeyOpensslEngineParam,
     
     /* General configuration params */
     &cryptoParam,
@@ -2265,6 +2280,24 @@ xmlSecAppLoadKeys(void) {
     }
 
 #endif /* XMLSEC_NO_X509 */    
+
+    for(value = privkeyOpensslEngineParam.value; value != NULL; value = value->next) {
+        if(value->strValue == NULL) {
+            fprintf(stderr, "Error: invalid value for option \"%s\".\n", 
+                    privkeyOpensslEngineParam.fullName);
+            return(-1);
+        } else if(xmlSecAppCryptoSimpleKeysMngrKeyAndCertsSeparedLoad(gKeysMngr, 
+                    value->strListValue, 
+                    xmlSecAppCmdLineParamGetString(&pwdParam),
+                    value->paramNameValue,
+                    xmlSecKeyDataFormatOpensslEngine,
+                    xmlSecKeyDataFormatPem) < 0) {
+            fprintf(stderr, "Error: failed to load private key from \"%s\".\n", 
+                    value->strListValue);
+            return(-1);
+        }
+    }
+
 
     return(0);
 }

--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -220,6 +220,7 @@ typedef unsigned int                            xmlSecKeyDataType;
  * @xmlSecKeyDataFormatPkcs12:          the PKCS12 format (bag of keys and certs)
  * @xmlSecKeyDataFormatCertPem:         the PEM cert.
  * @xmlSecKeyDataFormatCertDer:         the DER cert.
+ * @xmlSecKeyDataFormatOpensslEngine:   the OpenSSL ENGINE format.
  *
  * The key data format (binary, der, pem, etc.).
  */
@@ -232,7 +233,8 @@ typedef enum {
     xmlSecKeyDataFormatPkcs8Der,
     xmlSecKeyDataFormatPkcs12,
     xmlSecKeyDataFormatCertPem,
-    xmlSecKeyDataFormatCertDer
+    xmlSecKeyDataFormatCertDer,
+    xmlSecKeyDataFormatOpensslEngine
 } xmlSecKeyDataFormat;
 
 /**************************************************************************

--- a/include/xmlsec/openssl/app.h
+++ b/include/xmlsec/openssl/app.h
@@ -86,6 +86,11 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyPtr       xmlSecOpenSSLAppKeyLoadBIO      (BIO* bi
                                                                          const char *pwd,
                                                                          void* pwdCallback,
                                                                          void* pwdCallbackCtx);
+XMLSEC_CRYPTO_EXPORT xmlSecKeyPtr       xmlSecOpenSSLAppKeyLoadENGINE   (const char *filename,
+                                                                         xmlSecKeyDataFormat format,
+                                                                         const char *pwd,
+                                                                         void* pwdCallback,
+                                                                         void* pwdCallbackCtx);
 
 #ifndef XMLSEC_NO_X509
 XMLSEC_CRYPTO_EXPORT xmlSecKeyPtr       xmlSecOpenSSLAppPkcs12Load      (const char* filename,

--- a/include/xmlsec/openssl/app.h
+++ b/include/xmlsec/openssl/app.h
@@ -86,7 +86,8 @@ XMLSEC_CRYPTO_EXPORT xmlSecKeyPtr       xmlSecOpenSSLAppKeyLoadBIO      (BIO* bi
                                                                          const char *pwd,
                                                                          void* pwdCallback,
                                                                          void* pwdCallbackCtx);
-XMLSEC_CRYPTO_EXPORT xmlSecKeyPtr       xmlSecOpenSSLAppKeyLoadENGINE   (const char *filename,
+XMLSEC_CRYPTO_EXPORT xmlSecKeyPtr       xmlSecOpenSSLAppKeyLoadENGINE   (const char *engineName,
+                                                                         const char *engineKeyId,
                                                                          xmlSecKeyDataFormat format,
                                                                          const char *pwd,
                                                                          void* pwdCallback,


### PR DESCRIPTION
Dear xmlsec community,

I'd like to share with you a patch I developed to allow usage of an OpenSSL's engine in xmlsec.

The usage with command line is simple, I added the option --privkey-openssl-engine to supply the engine's name and the key specs.

 --privkey-openssl-engine[:<name>] <openssl-engine>;<openssl-key-id>,[,<crtfile>[,<cafile>[...]]]
       load private key by OpenSSL ENGINE interface; specify the name of engine (like with -engine params), the key specs
       (like with -inkey or -key params) and certificates that verify this key

At moment I tested only pkcs11 engine with SoftHSM2 but I'd like that all of you interested in using HSM or smartcard with xmlsec make a test .

To setup a token with SoftHSM run:
  softhsm2-util --init-token --free --label "XmlsecToken" --pin password --so-pin password

To create a key pair in token run:
  pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so -l -k --key-type rsa:2048 --id 1000 --label XmlsecKey --pin password

To generate a certificate run:
  openssl req -new -x509 -subj "/CN=Xmlsec" -engine pkcs11 -keyform engine -key \ 
        "pkcs11:token=XmlsecToken;object=XmlsecKey;type=private;pin-value=password" -out Xmlsec.pem

To sign an xml with a patched xmlsec run:
  xmlsec1 --sign "--privkey-openssl-engine:XmlsecKey" \
        "pkcs11;pkcs11:token=XmlsecToken;object=XmlsecKey;pin-value=password,Xmlsec.pem" sample.xml

