### PR TITLE
Fix functions export from xmlsec/mscng/certkeys.h on Windows MSVC build.

### DIFF
--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -35,6 +35,7 @@
 #include <xmlsec/bn.h>
 
 #include <xmlsec/mscng/crypto.h>
+#include <xmlsec/mscng/certkeys.h>
 
 typedef struct _xmlSecMSCngKeyDataCtx xmlSecMSCngKeyDataCtx,
                                       *xmlSecMSCngKeyDataCtxPtr;


### PR DESCRIPTION
libxmlsec-mscng.dll built with MSVC does not export certkeys related functions. This patch fixes it for me.