### PR TITLE
Change LibreSSL guard to < 3.5.0, as all compat functions now exist

### DIFF
--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -75,7 +75,7 @@
  * LibreSSL 2.7 compatibility (implements most of OpenSSL 1.1 API)
  *
  *****************************************************************************/
-#if defined(LIBRESSL_VERSION_NUMBER) && defined(XMLSEC_OPENSSL_API_110)
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L && defined(XMLSEC_OPENSSL_API_110)
 /* EVP_CIPHER_CTX stuff */
 #define EVP_CIPHER_CTX_encrypting(x)       ((x)->encrypt)
 
@@ -83,6 +83,6 @@
 #define X509_STORE_CTX_get_by_subject      X509_STORE_get_by_subject
 #define X509_OBJECT_new()                  (calloc(1, sizeof(X509_OBJECT)))
 #define X509_OBJECT_free(x)                { X509_OBJECT_free_contents(x); free(x); }
-#endif /* defined(LIBRESSL_VERSION_NUMBER) && defined(XMLSEC_OPENSSL_API_110) */
+#endif /* defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L && defined(XMLSEC_OPENSSL_API_110) */
 
 #endif /* __XMLSEC_OPENSSL_OPENSSL_COMPAT_H__ */


### PR DESCRIPTION
These are mentioned in the [3.5.0 release notes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.0-relnotes.txt).