### PR TITLE
reduce nss/nspr lib versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -948,8 +948,8 @@ dnl
 dnl   2 overrides 1
 dnl
 dnl ==========================================================================
-NSS_MIN_VERSION="3.50.1"
-NSPR_MIN_VERSION="4.25.1"
+NSS_MIN_VERSION="3.49"
+NSPR_MIN_VERSION="4.25.0"
 SEAMONKEY_MIN_VERSION="1.0"
 MOZILLA_MIN_VERSION="1.4"
 NSS_CRYPTO_LIB="$XMLSEC_PACKAGE-nss"


### PR DESCRIPTION
See reasons: https://github.com/lsh123/xmlsec/discussions/410