### PR TITLE
xmldsigverify: Include xmlsec/parser.h

### DIFF
--- a/examples/xmldsigverify.c
+++ b/examples/xmldsigverify.c
@@ -25,6 +25,7 @@
 #include <xmlsec/xmldsig.h>
 #include <xmlsec/crypto.h>
 
+#include <xmlsec/parser.h>
 /* #define XMLDSIGVERIFY_DEFAULT_TRUSTED_CERTS_FOLDER   "/etc/httpd/conf/ssl.crt" */
 #define XMLDSIGVERIFY_DEFAULT_TRUSTED_CERTS_FOLDER      "/var/www/cgi-bin/keys-certs.def"
 #define XMLDSIGVERIFY_KEY_AND_CERTS_FOLDER              "/var/www/cgi-bin/keys-certs"
@@ -36,7 +37,7 @@ int verify_request(xmlSecKeysMngrPtr mngr);
 int url_decode(char *buf, size_t size);
 
 int
-main(int , char **) {
+main() {
     xmlSecKeysMngrPtr mngr;
 #ifndef XMLSEC_NO_XSLT
     xsltSecurityPrefsPtr xsltSecPrefs = NULL;


### PR DESCRIPTION
this ensures that xmlSecParserSetDefaultOptions definition is made available

Fixes
| xmldsigverify.c:275:5: error: call to undeclared function 'xmlSecParserSetDefaultOptions'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
|     xmlSecParserSetDefaultOptions(XML_PARSE_NOENT | XML_PARSE_NOCDATA |
|     ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>