### PR TITLE
ensure linking against GCrypt libraries for xmlsec-gnutls

### DIFF
--- a/src/gnutls/Makefile.am
+++ b/src/gnutls/Makefile.am
@@ -42,6 +42,7 @@ libxmlsec1_gnutls_la_LIBADD = \
 	$(LIBXSLT_LIBS) \
 	$(LIBXML_LIBS) \
 	../libxmlsec1.la \
+	$(GCRYPT_LIBS) \
 	../gcrypt/libxmlsec1-gcrypt.la \
 	$(NULL)
 


### PR DESCRIPTION
Fixes issue #466 