### PR TITLE
xmlsec-mscrypto/mscng: fix CRL_CONTEXT leak

### DIFF
--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -382,6 +382,7 @@ xmlSecMSCngCheckRevocation(HCERTSTORE store, PCCERT_CONTEXT cert) {
 
         xmlSecOtherError(XMLSEC_ERRORS_R_CERT_VERIFY_FAILED, NULL,
             "cert found in CRL");
+        CertFreeCRLContext(crlCtx);
         return(-1);
     }
 

--- a/src/mscrypto/x509vfy.c
+++ b/src/mscrypto/x509vfy.c
@@ -226,6 +226,7 @@ xmlSecMSCryptoCheckRevocation(HCERTSTORE hStore, PCCERT_CONTEXT pCert) {
         if (CertFindCertificateInCRL(pCert, pCrl, 0, NULL, &pCrlEntry) && (pCrlEntry != NULL)) {
             xmlSecOtherError(XMLSEC_ERRORS_R_CERT_VERIFY_FAILED, NULL,
                              "CertFindCertificateInCRL: cert found in crl list");
+            CertFreeCRLContext(pCrl);
             return(FALSE);
         }
     }


### PR DESCRIPTION
If certificate is revoked then we should free CRL context explicitly because CertEnumCRLsInStore in this function will not be called again.

Part of #638.