### PR TITLE
xmlsec-mscrypto/mscng: fix leaks in *AdoptCrl functions for WinAPI

### DIFF
--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -290,6 +290,7 @@ xmlSecMSCngKeyDataX509AdoptCrl(xmlSecKeyDataPtr data, PCCRL_CONTEXT crl) {
         xmlSecMSCngLastError("CertAddCRLContextToStore", NULL);
         return(-1);
     }
+    CertFreeCRLContext(crl);
 
     return(0);
 }

--- a/src/mscrypto/x509.c
+++ b/src/mscrypto/x509.c
@@ -341,6 +341,7 @@ xmlSecMSCryptoKeyDataX509AdoptCrl(xmlSecKeyDataPtr data, PCCRL_CONTEXT crl) {
                             xmlSecKeyDataGetName(data));
         return(-1);
     }
+    CertFreeCRLContext(crl);
     ctx->numCrls++;
 
     return(0);


### PR DESCRIPTION
*AdoptCert fuctions do free contexts on success while *AdoptCrl functions don't. If we check calls to both *AdoptCert and *AdoptCrl we'll see that high-level code always expects that contexts will not be freed on error and will be freed on success.

Part of https://github.com/lsh123/xmlsec/issues/638.