### PR TITLE
xmlsec-mscrypto: fix CRL_CONTEXT leaks

### DIFF
--- a/src/mscrypto/x509.c
+++ b/src/mscrypto/x509.c
@@ -424,7 +424,7 @@ xmlSecMSCryptoKeyDataX509Initialize(xmlSecKeyDataPtr data) {
 static int
 xmlSecMSCryptoKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
     PCCERT_CONTEXT certSrc, certDst;
-    PCCRL_CONTEXT crlSrc, crlDst;
+    PCCRL_CONTEXT crlSrc;
     xmlSecSize size, pos;
     int ret;
 
@@ -472,18 +472,11 @@ xmlSecMSCryptoKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             return(-1);
         }
 
-        crlDst = CertDuplicateCRLContext(crlSrc);
-        if(crlDst == NULL) {
-            xmlSecMSCryptoError("CertDuplicateCRLContext",
-                                xmlSecKeyDataGetName(dst));
-            return(-1);
-        }
-
-        ret = xmlSecMSCryptoKeyDataX509AdoptCrl(dst, crlDst);
+        ret = xmlSecMSCryptoKeyDataX509AdoptCrl(dst, crlSrc);
         if(ret < 0) {
             xmlSecInternalError("xmlSecMSCryptoKeyDataX509AdoptCrl",
                                 xmlSecKeyDataGetName(dst));
-            CertFreeCRLContext(crlDst);
+            CertFreeCRLContext(crlSrc);
             return(-1);
         }
     }
@@ -883,9 +876,11 @@ xmlSecMSCryptoKeyDataX509Write(xmlSecKeyDataPtr data, xmlSecKeyX509DataValuePtr 
                     xmlSecKeyDataGetName(data),
                     "pos=" XMLSEC_SIZE_FMT "; crlSize=%lu",
                     ctx->crlPos, crl->cbCrlEncoded);
+                CertFreeCRLContext(crl);
                 return(-1);
             }
         }
+        CertFreeCRLContext(crl);
         ++ctx->crlPos;
     }
     else {


### PR DESCRIPTION
xmlSecMSCryptoKeyDataX509GetCrl creates CRL contexts, so they should be freed one way or another.

Looks like CNG counterpart of this patch does not exist. I don't see similar problems there. Presumably this is a positive side effect of refactoring: someone removed old certificate/CRL traversing code with O(n^2) complexity.

Part of https://github.com/lsh123/xmlsec/issues/638.