### PR TITLE
xmlsec-mscng: fix CERT_CONTEXT leaks

### DIFF
--- a/src/mscng/x509.c
+++ b/src/mscng/x509.c
@@ -117,6 +117,7 @@ xmlSecMSCngKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
         dstCert = CertDuplicateCertificateContext(srcCert);
         if(dstCert == NULL) {
             xmlSecMSCngLastError("CertDuplicateCertificateContext", NULL);
+            CertFreeCertificateContext(srcCert);
             return(-1);
         }
 
@@ -125,6 +126,7 @@ xmlSecMSCngKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             ret = xmlSecMSCngKeyDataX509AdoptKeyCert(dst, dstCert);
             if (ret < 0) {
                 xmlSecInternalError("xmlSecMSCngKeyDataX509AdoptKeyCert", NULL);
+                CertFreeCertificateContext(srcCert);
                 CertFreeCertificateContext(dstCert);
                 return(-1);
             }
@@ -132,6 +134,7 @@ xmlSecMSCngKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             ret = xmlSecMSCngKeyDataX509AdoptCert(dst, dstCert);
             if (ret < 0) {
                 xmlSecInternalError("xmlSecMSCngKeyDataX509AdoptCert", NULL);
+                CertFreeCertificateContext(srcCert);
                 CertFreeCertificateContext(dstCert);
                 return(-1);
             }


### PR DESCRIPTION
srcCert isn't freed on error.

CNG counterpart of https://github.com/lsh123/xmlsec/pull/643.

Part of https://github.com/lsh123/xmlsec/issues/638.