### PR TITLE
xmlsec-mscrypto/mscng: fix CERT_CONTEXT leaks

### DIFF
--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -605,6 +605,9 @@ cleanup:
     if(privKeyData != NULL) {
         xmlSecKeyDataDestroy(privKeyData);
     }
+    if(cert != NULL) {
+        CertFreeCertificateContext(cert);
+    }
     if(certDuplicate != NULL) {
         CertFreeCertificateContext(certDuplicate);
     }

--- a/src/mscrypto/app.c
+++ b/src/mscrypto/app.c
@@ -685,6 +685,9 @@ done:
     if(keyData != NULL) {
         xmlSecKeyDataDestroy(keyData);
     }
+    if(pCert != NULL) {
+        CertFreeCertificateContext(pCert);
+    }
     if(tmpcert != NULL) {
         CertFreeCertificateContext(tmpcert);
     }

--- a/src/mscrypto/keysstore.c
+++ b/src/mscrypto/keysstore.c
@@ -259,6 +259,7 @@ xmlSecMSCryptoKeysStoreFindCert(xmlSecKeyStorePtr store, const xmlChar* name,
 
             pbFriendlyName = xmlMalloc(dwPropSize);
             if(pbFriendlyName == NULL) {
+                CertFreeCertificateContext(pCertCtxIter);
                 xmlSecMallocError(dwPropSize, xmlSecKeyStoreGetName(store));
                 xmlFree(wcName);
                 CertCloseStore(hStoreHandle, 0);

--- a/src/mscrypto/x509.c
+++ b/src/mscrypto/x509.c
@@ -980,6 +980,9 @@ xmlSecMSCryptoKeyDataX509VerifyAndExtractKey(xmlSecKeyDataPtr data, xmlSecKeyPtr
                                 return(-1);
                         }
                         pCert = NULL ;
+                } else {
+                        CertFreeCertificateContext(pCert);
+                        pCert = NULL;
                 }
 
             /* verify that the key matches our expectations */


### PR DESCRIPTION
Some contexts are not freed on errors.

Part of https://github.com/lsh123/xmlsec/issues/638.