### PR TITLE
xmlsec-mscrypto: remove CERT_CLOSE_STORE_FORCE_FLAG

### DIFF
--- a/src/mscrypto/x509.c
+++ b/src/mscrypto/x509.c
@@ -530,7 +530,7 @@ xmlSecMSCryptoKeyDataX509Finalize(xmlSecKeyDataPtr data) {
     }
 
     if (ctx->hMemStore != 0) {
-        if (!CertCloseStore(ctx->hMemStore, CERT_CLOSE_STORE_FORCE_FLAG)) {
+        if (!CertCloseStore(ctx->hMemStore, 0)) {
             xmlSecInternalError("CertCloseStore", NULL);
             return;
         }

--- a/src/mscrypto/x509vfy.c
+++ b/src/mscrypto/x509vfy.c
@@ -838,10 +838,10 @@ xmlSecMSCryptoX509StoreFinalize(xmlSecKeyDataStorePtr store) {
     xmlSecAssert(ctx != NULL);
 
     if (ctx->trusted) {
-        CertCloseStore(ctx->trusted, CERT_CLOSE_STORE_FORCE_FLAG);
+        CertCloseStore(ctx->trusted, 0);
     }
     if (ctx->untrusted) {
-        CertCloseStore(ctx->untrusted, CERT_CLOSE_STORE_FORCE_FLAG);
+        CertCloseStore(ctx->untrusted, 0);
     }
 
     memset(ctx, 0, sizeof(xmlSecMSCryptoX509StoreCtx));


### PR DESCRIPTION
As far as I can see, after all previous commits there should be no leaks regarding ctx->trusted, ctx->untrusted, ctx->hMemStore. CERT_CLOSE_STORE_FORCE_FLAG becomes useless so it's better to remove it because documentation advices against it's usage.

Part of https://github.com/lsh123/xmlsec/issues/638.