### PR TITLE
openssl_compat.h: Update LibreSSL UI_null() compat

### DIFF
--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -98,12 +98,12 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(uint8_t *out, size_t *out_len, size_t max_
  * LibreSSL compatibility (implements most of OpenSSL 1.1 API)
  *
  *****************************************************************************/
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x3070200fL)
 
 /* Needed for Engine initialization */
 #define UI_null()                          NULL
 
-#endif /* defined(LIBRESSL_VERSION_NUMBER) */
+#endif /* defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x3070200fL) */
 
 #if defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER < 0x30500000L)
 /* EVP_CIPHER_CTX stuff */


### PR DESCRIPTION
LibreSSL added `UI_null()` in 3.7.1.

There are still issues with the current commit (https://github.com/lsh123/xmlsec/commit/4c7500252f20170f379081abccb750f0840407f4), but that is less obvious to resolve and I will try to follow up later.