### PR TITLE
configure: Switch to OPENSSL_init_crypto in test program

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -795,9 +795,9 @@ if test "z$OPENSSL_FOUND" = "zno" ; then
     LIBS="$LIBS $OPENSSL_LIBS $OPENSSL_LIBS_LIST"
     AC_LINK_IFELSE([
         AC_LANG_PROGRAM([[
-            #include <openssl/ssl.h>
+            #include <openssl/crypto.h>
         ]],[[
-            OPENSSL_init_ssl(0, NULL);
+            OPENSSL_init_crypto(0, NULL);
         ]])
     ],[
         OPENSSL_FOUND=yes


### PR DESCRIPTION
Hi again! This is a follow-up for yesterday's https://github.com/lsh123/xmlsec/pull/661.

The 'Just try to compile/link and hope for the best' failed for me because the program used a function from `libssl`, but didn't link to it. The immediate workaround was to set `OPENSSL_LIBS="-lcrypto -lssl"`, but I don't think this is a good workaround -- it also links the main libraries/programs to `libssl`.

I think configure can test initialization from `libcrypto` instead. The call works fine for both 1.1.1 and 3.x, at least from what I tested.