### PR TITLE
Add a new --disable-aes-gcm configure switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -951,8 +951,13 @@ dnl
 dnl ==========================================================================
 
 dnl After upgrading min ver >= 3.59, remove the check in include/nss/crypto.h (search for NSS_VMAJOR)
-NSS_MIN_VERSION="3.52"
-NSPR_MIN_VERSION="4.25.0"
+if test "z$enable_aes_gcm" = "zno" ; then
+    NSS_MIN_VERSION="3.35"
+    NSPR_MIN_VERSION="4.18.0"
+else
+    NSS_MIN_VERSION="3.52"
+    NSPR_MIN_VERSION="4.25.0"
+fi
 SEAMONKEY_MIN_VERSION="1.0"
 MOZILLA_MIN_VERSION="1.4"
 NSS_CRYPTO_LIB="$XMLSEC_PACKAGE-nss"
@@ -2198,6 +2203,22 @@ else
 fi
 AM_CONDITIONAL(XMLSEC_NO_AES, test "z$XMLSEC_NO_AES" = "z1")
 AC_SUBST(XMLSEC_NO_AES)
+
+dnl ==========================================================================
+dnl See do we need AES GCM support
+dnl ==========================================================================
+AC_MSG_CHECKING(for AES GCM support)
+AC_ARG_ENABLE([aes-gcm], [AS_HELP_STRING([--enable-aes-gcm],[enable AES GCM support])])
+if test "z$enable_aes_gcm" = "zno" ; then
+    XMLSEC_DEFINES="$XMLSEC_DEFINES -DXMLSEC_NO_AES_GCM=1"
+    XMLSEC_NO_AES_GCM="1"
+    AC_MSG_RESULT([disabled])
+else
+    XMLSEC_NO_AES_GCM="0"
+    AC_MSG_RESULT([yes])
+fi
+AM_CONDITIONAL(XMLSEC_NO_AES_GCM, test "z$XMLSEC_NO_AES_GCM" = "z1")
+AC_SUBST(XMLSEC_NO_AES_GCM)
 
 dnl ==========================================================================
 dnl See do we need ConcatKDF support

--- a/include/xmlsec/nss/crypto.h
+++ b/include/xmlsec/nss/crypto.h
@@ -105,6 +105,7 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId  xmlSecNssTransformAes192CbcGetKlass(void
 XMLSEC_CRYPTO_EXPORT xmlSecTransformId  xmlSecNssTransformAes256CbcGetKlass(void);
 
 
+#ifndef XMLSEC_NO_AES_GCM
 /**
  * xmlSecNssTransformAes128GcmId:
  *
@@ -131,6 +132,7 @@ XMLSEC_CRYPTO_EXPORT xmlSecTransformId  xmlSecNssTransformAes192GcmGetKlass(void
 #define xmlSecNssTransformAes256GcmId \
         xmlSecNssTransformAes256GcmGetKlass()
 XMLSEC_CRYPTO_EXPORT xmlSecTransformId  xmlSecNssTransformAes256GcmGetKlass(void);
+#endif
 
 
 /**

--- a/src/nss/ciphers_gcm.c
+++ b/src/nss/ciphers_gcm.c
@@ -31,6 +31,7 @@
 #include "../cast_helpers.h"
 #include "../kw_aes_des.h"
 
+#ifndef XMLSEC_NO_AES_GCM
 /* https://www.w3.org/TR/xmlenc-core1/#sec-AES-GCM
  *
  * For the purposes of this specification, AES-GCM shall be used with
@@ -591,3 +592,4 @@ xmlSecNssTransformAes256GcmGetKlass(void) {
 }
 
 #endif /* XMLSEC_NO_AES */
+#endif /* XMLSEC_NO_AES_GCM */

--- a/src/nss/crypto.c
+++ b/src/nss/crypto.c
@@ -131,9 +131,11 @@ xmlSecCryptoGetFunctions_nss(void) {
     gXmlSecNssFunctions->transformAes192CbcGetKlass     = xmlSecNssTransformAes192CbcGetKlass;
     gXmlSecNssFunctions->transformAes256CbcGetKlass     = xmlSecNssTransformAes256CbcGetKlass;
 
+#ifndef XMLSEC_NO_AES_GCM
     gXmlSecNssFunctions->transformAes128GcmGetKlass     = xmlSecNssTransformAes128GcmGetKlass;
     gXmlSecNssFunctions->transformAes192GcmGetKlass     = xmlSecNssTransformAes192GcmGetKlass;
     gXmlSecNssFunctions->transformAes256GcmGetKlass     = xmlSecNssTransformAes256GcmGetKlass;
+#endif /* XMLSEC_NO_AES_GCM */
 
     gXmlSecNssFunctions->transformKWAes128GetKlass      = xmlSecNssTransformKWAes128GetKlass;
     gXmlSecNssFunctions->transformKWAes192GetKlass      = xmlSecNssTransformKWAes192GetKlass;


### PR DESCRIPTION
When used, it's possible to require a much lower version of NSS, restoring the ability to build binaries on RHEL7 and run them on e.g. Ubuntu 18.04 and Ubuntu 20.04.