### PR TITLE
Check for openssl/store.h during configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -890,6 +890,8 @@ if test "z$OPENSSL_FOUND" = "zyes" ; then
 
     CPPFLAGS=$OLD_CPPFLAGS
 
+    AC_CHECK_HEADERS([openssl/store.h])
+
     if test "z$OPENSSL_VERSION" != "z" ; then
         OPENSSL_FOUND=yes
     else

--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -48,9 +48,9 @@
 #include <openssl/x509.h>
 #include <openssl/ui.h>
 
-#ifndef XMLSEC_OPENSSL_NO_STORE
+#ifdef HAVE_OPENSSL_STORE_H
 #include <openssl/store.h>
-#endif /* XMLSEC_OPENSSL_NO_STORE */
+#endif /* HAVE_OPENSSL_STORE_H */
 
 #ifdef XMLSEC_OPENSSL_API_300
 #include <openssl/provider.h>
@@ -808,7 +808,7 @@ xmlSecOpenSSLAppFindKeyCert(EVP_PKEY * pKey, STACK_OF(X509) * certs) {
 
 static xmlSecKeyPtr
 xmlSecOpenSSLAppStoreKeyLoad(const char *uri, xmlSecKeyDataType type, const char *pwd, void* pwdCallback, void* pwdCallbackCtx) {
-#if !defined(XMLSEC_OPENSSL_NO_STORE) && !defined(XMLSEC_NO_X509)
+#if defined(HAVE_OPENSSL_STORE_H) && !defined(XMLSEC_NO_X509)
     UI_METHOD * ui_method = NULL;
     pem_password_cb * pwdCb;
     void * pwdCbCtx;
@@ -983,7 +983,7 @@ done:
     }
     return(res);
 
-#else /* !defined(XMLSEC_OPENSSL_NO_STORE) && !defined(XMLSEC_NO_X509) */
+#else /* defined(HAVE_OPENSSL_STORE_H) && !defined(XMLSEC_NO_X509) */
 
     xmlSecAssert2(uri != NULL, NULL);
     UNREFERENCED_PARAMETER(type);
@@ -993,7 +993,7 @@ done:
 
     xmlSecNotImplementedError("X509 or OpenSSL Stores support is disabled");
     return(NULL);
-#endif /* !defined(XMLSEC_OPENSSL_NO_STORE) && !defined(XMLSEC_NO_X509) */
+#endif /* defined(HAVE_OPENSSL_STORE_H) && !defined(XMLSEC_NO_X509) */
 }
 
 #ifndef XMLSEC_NO_X509

--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -105,7 +105,6 @@ int RSA_padding_check_PKCS1_OAEP_mgf1(uint8_t *out, size_t *out_len, size_t max_
 
 /* Not implemented by LibreSSL (yet?) */
 #define XMLSEC_OPENSSL_NO_ASN1_TIME_TO_TM   1
-#define XMLSEC_OPENSSL_NO_STORE             1
 #define XMLSEC_OPENSSL_NO_PWD_CALLBACK      1
 #define XMLSEC_OPENSSL_NO_DEEP_COPY         1
 #define XMLSEC_NO_DH                        1


### PR DESCRIPTION
This will allow the `openssl/store.h` to be automatically used if and when LibreSSL supports it.

I am not sure if I chose the correct place in `configure.ac` for the `AC_CHECK_HEADERS` test?