### PR TITLE
Force static linking for libraries when --enable-static-linking is specified on Windows (MinGW/Cygwin)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2350,6 +2350,9 @@ AC_MSG_CHECKING(for static linking)
 AC_ARG_ENABLE([static_linking], [AS_HELP_STRING([--enable-static-linking],[enable static linking (no)])])
 if test "z$enable_static_linking" = "zyes" -o "z$enable_static_linking" = "ztrue" ; then
     XMLSEC_STATIC_BINARIES="-static"
+    if test "z$build_on_windows" = "zyes" ; then
+        XMLSEC_DEFINES="$XMLSEC_DEFINES -DXMLSEC_STATIC=1"
+    fi
     XMLSEC_APP_DEFINES="$XMLSEC_APP_DEFINES -DXMLSEC_STATIC=1"
     enable_crypto_dl="no"
     AC_MSG_RESULT([yes])

--- a/include/xmlsec/exports.h
+++ b/include/xmlsec/exports.h
@@ -47,7 +47,7 @@ extern "C" {
 #      if !defined(XMLSEC_STATIC)
 #        define XMLSEC_EXPORT __declspec(dllimport)
 #      else
-#        define XMLSEC_EXPORT
+#        define XMLSEC_EXPORT extern
 #      endif
 #    endif /* defined(IN_XMLSEC) */
    /* This holds on all other platforms/compilers, which are easier to
@@ -71,7 +71,7 @@ extern "C" {
 #      if !defined(XMLSEC_STATIC)
 #        define XMLSEC_CRYPTO_EXPORT __declspec(dllimport)
 #      else
-#        define XMLSEC_CRYPTO_EXPORT
+#        define XMLSEC_CRYPTO_EXPORT extern
 #      endif
 #    endif /* defined(IN_XMLSEC_CRYPTO) */
    /* This holds on all other platforms/compilers, which are easier to


### PR DESCRIPTION
issue #675