### PR TITLE
Fix typo with xmlSecKeyDataEcGetKlass in app.h include

### DIFF
--- a/include/xmlsec/app.h
+++ b/include/xmlsec/app.h
@@ -85,7 +85,7 @@ XMLSEC_EXPORT xmlSecKeyDataId                   xmlSecKeyDataDsaGetKlass(void);
  *
  * The EC key klass.
  */
-#define xmlSecKeyDataEcId                       xmlSecKeyDataEcetKlass()
+#define xmlSecKeyDataEcId                       xmlSecKeyDataEcGetKlass()
 XMLSEC_EXPORT xmlSecKeyDataId                   xmlSecKeyDataEcGetKlass(void);
 /**
  * xmlSecKeyDataGost2001Id:


### PR DESCRIPTION
Fixed typo introduced by https://github.com/lsh123/xmlsec/commit/aa98f933293b592421bf968c6bff74b1e1eff102