### PR TITLE
configure.ac: fix the build with slibtool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -806,7 +806,6 @@ if test "z$OPENSSL_FOUND" = "zyes" ; then
             #endif
         ],[
             OPENSSL_VERSION="LibreSSL >= 3.5"
-            OPENSSL_LIBS="-Wl,-Bstatic $OPENSSL_LIBS -Wl,-Bdynamic"
             enable_dh=no
         ],[
             OPENSSL_VERSION=""
@@ -824,7 +823,6 @@ if test "z$OPENSSL_FOUND" = "zyes" ; then
             #endif
         ],[
             OPENSSL_VERSION="BoringSSL >= 1.1.1"
-            OPENSSL_LIBS="-Wl,-Bstatic $OPENSSL_LIBS -Wl,-Bdynamic"
             enable_ripemd160=no
             enable_dsa=no
             enable_dh=no


### PR DESCRIPTION
When building with LibreSSL or BoringSSL the build will try to link the `$OPENSSL_LIBS` with `-Wl,-Bstatic`, but this will fail when using slibtool if only dynamic libssl and libcrypto libraries are installed.
```
ld: cannot find -lssl: No such file or directory
ld: cannot find -lcrypto: No such file or directory
```
With GNU libtool it will "helpfully" rearrange the linker output to obscure the issue.
```
-lssl -lcrypto -lxslt -lxml2 ../.libs/libxmlsec1.so -g -O2 -O -Wl,-Bstatic -Wl,-Bdynamic
```
While with slibtool it will do as instructed and produce a build failure.
```
-Wl,-Bstatic -lssl -lcrypto -Wl,-Bdynamic -lxslt
```