### PR TITLE
Fix memory leak in xmlSecGCryptAsymKeyDataGenerate

### DIFF
--- a/src/gcrypt/asymkeys.c
+++ b/src/gcrypt/asymkeys.c
@@ -295,7 +295,6 @@ xmlSecGCryptAsymKeyDataGenerate(xmlSecKeyDataPtr data, const char * alg, xmlSecS
         xmlSecInternalError("xmlSecGCryptAsymKeyDataAdopt", NULL);
         goto done;
     }
-    key_pair = NULL; /* now owned by data */
 
     /* success */
     res = 0;


### PR DESCRIPTION
Generated key_pair must be also released. Individual keys are extracted in xmlSecGCryptAsymKeyDataAdoptKey using `gcry_sexp_find_token` which (by the documentation) allocates new S-expression.

This issue has been found by static analysis performed by our team and it looks to me like valid finding.