### PR TITLE
(xmlsec-gcrypt) Fix memory leak in xmlSecGCryptAsymKeyDataAdoptKey

### DIFF
--- a/src/gcrypt/asymkeys.c
+++ b/src/gcrypt/asymkeys.c
@@ -194,7 +194,7 @@ done:
         gcry_sexp_release(priv_key);
     }
 
-    /* Adopt functions assumes ownership thus the caller would expect this to be released */
+    /* Adopt functions assume ownership thus the caller would expect this to be released */
     gcry_sexp_release(key_pair);
 
     /* done */

--- a/src/gcrypt/asymkeys.c
+++ b/src/gcrypt/asymkeys.c
@@ -194,6 +194,9 @@ done:
         gcry_sexp_release(priv_key);
     }
 
+    /* Adopt functions assumes ownership thus the caller would expect this to be released */
+    gcry_sexp_release(key_pair);
+
     /* done */
     return(res);
 }


### PR DESCRIPTION
Found by @thalman in #788 