### PR TITLE
(xmlsec-openssl) Fix memory leak if file doesn't exist

### DIFF
--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -265,11 +265,11 @@ xmlSecOpenSSLAppKeyLoadEx(const char *filename, xmlSecKeyDataType type, xmlSecKe
         if(key == NULL) {
             xmlSecInternalError2("xmlSecOpenSSLAppKeyLoadBIO", NULL,
                                 "filename=%s", xmlSecErrorsSafeString(filename));
-            BIO_free(bio);
+            BIO_free_all(bio);
             return(NULL);
         }
 
-        BIO_free(bio);
+        BIO_free_all(bio);
     }
 
     return(key);
@@ -309,11 +309,11 @@ xmlSecOpenSSLAppKeyLoadMemory(const xmlSecByte* data, xmlSecSize dataSize,
     key = xmlSecOpenSSLAppKeyLoadBIO (bio, format, pwd, pwdCallback, pwdCallbackCtx);
     if(key == NULL) {
         xmlSecInternalError("xmlSecOpenSSLAppKeyLoadBIO", NULL);
-        BIO_free(bio);
+        BIO_free_all(bio);
         return(NULL);
     }
 
-    BIO_free(bio);
+    BIO_free_all(bio);
     return(key);
 }
 

--- a/src/openssl/crypto.c
+++ b/src/openssl/crypto.c
@@ -774,6 +774,7 @@ xmlSecOpenSSLCreateReadFileBio(const char* path) {
     if(BIO_read_filename(bio, path) != 1) {
         xmlSecOpenSSLError2("BIO_read_filename", NULL,
             "path=%s", xmlSecErrorsSafeString(path));
+        BIO_free_all(bio);
         return(NULL);
     }
     return(bio);


### PR DESCRIPTION
Issue #802 