### PR TITLE
(xmlsec-core) Remove 'const struct' to avoid problems with some compilers

### DIFF
--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -27,9 +27,9 @@ extern "C" {
  * Forward declarations
  *
  ****************************************************************************/
-typedef const struct _xmlSecKeyDataKlass                xmlSecKeyDataKlass,
+typedef struct _xmlSecKeyDataKlass                xmlSecKeyDataKlass,
                                                         *xmlSecKeyDataId;
-typedef const struct _xmlSecKeyDataStoreKlass           xmlSecKeyDataStoreKlass,
+typedef struct _xmlSecKeyDataStoreKlass           xmlSecKeyDataStoreKlass,
                                                         *xmlSecKeyDataStoreId;
 typedef struct _xmlSecKeyDataList                       xmlSecKeyDataList,
                                                         *xmlSecKeyDataListPtr;

--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -27,9 +27,9 @@ extern "C" {
  * Forward declarations
  *
  ****************************************************************************/
-typedef struct _xmlSecKeyDataKlass                xmlSecKeyDataKlass,
+typedef struct _xmlSecKeyDataKlass                      xmlSecKeyDataKlass,
                                                         *xmlSecKeyDataId;
-typedef struct _xmlSecKeyDataStoreKlass           xmlSecKeyDataStoreKlass,
+typedef struct _xmlSecKeyDataStoreKlass                 xmlSecKeyDataStoreKlass,
                                                         *xmlSecKeyDataStoreId;
 typedef struct _xmlSecKeyDataList                       xmlSecKeyDataList,
                                                         *xmlSecKeyDataListPtr;

--- a/include/xmlsec/keysmngr.h
+++ b/include/xmlsec/keysmngr.h
@@ -22,9 +22,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef const struct _xmlSecKeyKlass                    xmlSecKeyKlass,
+typedef struct _xmlSecKeyKlass                    xmlSecKeyKlass,
                                                         *xmlSecKeyId;
-typedef const struct _xmlSecKeyStoreKlass               xmlSecKeyStoreKlass,
+typedef struct _xmlSecKeyStoreKlass               xmlSecKeyStoreKlass,
                                                         *xmlSecKeyStoreId;
 
 typedef struct _xmlSecKeyX509DataValue                  xmlSecKeyX509DataValue,

--- a/include/xmlsec/keysmngr.h
+++ b/include/xmlsec/keysmngr.h
@@ -22,9 +22,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct _xmlSecKeyKlass                    xmlSecKeyKlass,
+typedef struct _xmlSecKeyKlass                          xmlSecKeyKlass,
                                                         *xmlSecKeyId;
-typedef struct _xmlSecKeyStoreKlass               xmlSecKeyStoreKlass,
+typedef struct _xmlSecKeyStoreKlass                     xmlSecKeyStoreKlass,
                                                         *xmlSecKeyStoreId;
 
 typedef struct _xmlSecKeyX509DataValue                  xmlSecKeyX509DataValue,

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef const struct _xmlSecPtrListKlass                        xmlSecPtrListKlass,
+typedef struct _xmlSecPtrListKlass                        xmlSecPtrListKlass,
                                                                 *xmlSecPtrListId;
 typedef struct _xmlSecPtrList                                   xmlSecPtrList,
                                                                 *xmlSecPtrListPtr;

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct _xmlSecPtrListKlass                        xmlSecPtrListKlass,
+typedef struct _xmlSecPtrListKlass                              xmlSecPtrListKlass,
                                                                 *xmlSecPtrListId;
 typedef struct _xmlSecPtrList                                   xmlSecPtrList,
                                                                 *xmlSecPtrListPtr;

--- a/include/xmlsec/transforms.h
+++ b/include/xmlsec/transforms.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct _xmlSecTransformKlass              xmlSecTransformKlass,
+typedef struct _xmlSecTransformKlass                    xmlSecTransformKlass,
                                                         *xmlSecTransformId;
 
 /**********************************************************************

--- a/include/xmlsec/transforms.h
+++ b/include/xmlsec/transforms.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef const struct _xmlSecTransformKlass              xmlSecTransformKlass,
+typedef struct _xmlSecTransformKlass              xmlSecTransformKlass,
                                                         *xmlSecTransformId;
 
 /**********************************************************************

--- a/src/kw_aes_des.h
+++ b/src/kw_aes_des.h
@@ -156,7 +156,7 @@ struct _xmlSecKWAesKlass {
     void*                               reserved0;
     void*                               reserved1;
 };
-typedef struct _xmlSecKWAesKlass              xmlSecKWAesKlass,
+typedef struct _xmlSecKWAesKlass                    xmlSecKWAesKlass,
                                                     *xmlSecKWAesId;
 
 /*********************************************************************

--- a/src/kw_aes_des.h
+++ b/src/kw_aes_des.h
@@ -76,7 +76,7 @@ struct _xmlSecKWDes3Klass {
     void*                               reserved0;
     void*                               reserved1;
 };
-typedef struct _xmlSecKWDes3Klass              xmlSecKWDes3Klass,
+typedef struct _xmlSecKWDes3Klass                   xmlSecKWDes3Klass,
                                                     *xmlSecKWDes3Id;
 
 #define xmlSecKWDes3CheckId(id) \

--- a/src/kw_aes_des.h
+++ b/src/kw_aes_des.h
@@ -76,7 +76,7 @@ struct _xmlSecKWDes3Klass {
     void*                               reserved0;
     void*                               reserved1;
 };
-typedef const struct _xmlSecKWDes3Klass              xmlSecKWDes3Klass,
+typedef struct _xmlSecKWDes3Klass              xmlSecKWDes3Klass,
                                                     *xmlSecKWDes3Id;
 
 #define xmlSecKWDes3CheckId(id) \
@@ -156,7 +156,7 @@ struct _xmlSecKWAesKlass {
     void*                               reserved0;
     void*                               reserved1;
 };
-typedef const struct _xmlSecKWAesKlass              xmlSecKWAesKlass,
+typedef struct _xmlSecKWAesKlass              xmlSecKWAesKlass,
                                                     *xmlSecKWAesId;
 
 /*********************************************************************


### PR DESCRIPTION
see issue #805 