### PR TITLE
Revert "(xmlsec-core) Remove 'const struct' to avoid problems with some compilers"

### DIFF
--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -27,9 +27,9 @@ extern "C" {
  * Forward declarations
  *
  ****************************************************************************/
-typedef struct _xmlSecKeyDataKlass                      xmlSecKeyDataKlass,
+typedef const struct _xmlSecKeyDataKlass                xmlSecKeyDataKlass,
                                                         *xmlSecKeyDataId;
-typedef struct _xmlSecKeyDataStoreKlass                 xmlSecKeyDataStoreKlass,
+typedef const struct _xmlSecKeyDataStoreKlass           xmlSecKeyDataStoreKlass,
                                                         *xmlSecKeyDataStoreId;
 typedef struct _xmlSecKeyDataList                       xmlSecKeyDataList,
                                                         *xmlSecKeyDataListPtr;

--- a/include/xmlsec/keysmngr.h
+++ b/include/xmlsec/keysmngr.h
@@ -22,9 +22,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct _xmlSecKeyKlass                          xmlSecKeyKlass,
+typedef const struct _xmlSecKeyKlass                    xmlSecKeyKlass,
                                                         *xmlSecKeyId;
-typedef struct _xmlSecKeyStoreKlass                     xmlSecKeyStoreKlass,
+typedef const struct _xmlSecKeyStoreKlass               xmlSecKeyStoreKlass,
                                                         *xmlSecKeyStoreId;
 
 typedef struct _xmlSecKeyX509DataValue                  xmlSecKeyX509DataValue,

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct _xmlSecPtrListKlass                              xmlSecPtrListKlass,
+typedef const struct _xmlSecPtrListKlass                        xmlSecPtrListKlass,
                                                                 *xmlSecPtrListId;
 typedef struct _xmlSecPtrList                                   xmlSecPtrList,
                                                                 *xmlSecPtrListPtr;

--- a/include/xmlsec/transforms.h
+++ b/include/xmlsec/transforms.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct _xmlSecTransformKlass                    xmlSecTransformKlass,
+typedef const struct _xmlSecTransformKlass              xmlSecTransformKlass,
                                                         *xmlSecTransformId;
 
 /**********************************************************************

--- a/src/kw_aes_des.h
+++ b/src/kw_aes_des.h
@@ -76,7 +76,7 @@ struct _xmlSecKWDes3Klass {
     void*                               reserved0;
     void*                               reserved1;
 };
-typedef struct _xmlSecKWDes3Klass                   xmlSecKWDes3Klass,
+typedef const struct _xmlSecKWDes3Klass              xmlSecKWDes3Klass,
                                                     *xmlSecKWDes3Id;
 
 #define xmlSecKWDes3CheckId(id) \
@@ -156,7 +156,7 @@ struct _xmlSecKWAesKlass {
     void*                               reserved0;
     void*                               reserved1;
 };
-typedef struct _xmlSecKWAesKlass                    xmlSecKWAesKlass,
+typedef const struct _xmlSecKWAesKlass              xmlSecKWAesKlass,
                                                     *xmlSecKWAesId;
 
 /*********************************************************************


### PR DESCRIPTION
Reverts lsh123/xmlsec#807