### PR TITLE
Conditional include for openssl engines

### DIFF
--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -24,7 +24,9 @@
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
 #include <openssl/conf.h>
+#if !defined(OPENSSL_NO_ENGINE) && (!defined(XMLSEC_OPENSSL_API_300) || defined(XMLSEC_OPENSSL3_ENGINES))
 #include <openssl/engine.h>
+#endif /* !defined(OPENSSL_NO_ENGINE) && (!defined(XMLSEC_OPENSSL_API_300) || defined(XMLSEC_OPENSSL3_ENGINES)) */
 #include <openssl/ui.h>
 
 #include <xmlsec/xmlsec.h>


### PR DESCRIPTION
xmlsec can't be compiled on systems where openss/engine.h is missing. In some distributions this file is in extra package (Fedora) or not present at all.

This update makes the include conditional based on `configure` option `--enable_openssl3_engines`.
