### PR TITLE
(xmlsec-openssl) Added an option to skip timestamp checks for certifcates and CLRs.

### DIFF
--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -945,6 +945,17 @@ static xmlSecAppCmdLineParam verificationGmtTimeParam = {
     NULL
 };
 
+static xmlSecAppCmdLineParam X509SkipTimeChecksParam = {
+    xmlSecAppCmdLineTopicX509Certs,
+    "--X509-skip-time-checks",
+    NULL,
+    "--X509-skip-time-checks"
+    "\n\tskip time checking of X509 certificates and CLRs",
+    xmlSecAppCmdLineParamTypeFlag,
+    xmlSecAppCmdLineParamFlagNone,
+    NULL
+};
+
 static xmlSecAppCmdLineParam depthParam = {
     xmlSecAppCmdLineTopicX509Certs,
     "--depth",
@@ -1065,6 +1076,7 @@ static xmlSecAppCmdLineParamPtr parameters[] = {
     &crlDerParam,
     &verificationTimeParam,
     &verificationGmtTimeParam,
+    &X509SkipTimeChecksParam,
     &depthParam,
     &X509SkipStrictChecksParam,
     &X509DontVerifyCerts,
@@ -2271,6 +2283,9 @@ xmlSecAppPrepareKeyInfoCtx(xmlSecKeyInfoCtxPtr keyInfoCtx) {
     }
     if(xmlSecAppCmdLineParamIsSet(&verificationGmtTimeParam)) {
         keyInfoCtx->certsVerificationTime = xmlSecAppCmdLineParamGetTime(&verificationGmtTimeParam, 0);
+    }
+    if(xmlSecAppCmdLineParamIsSet(&X509SkipTimeChecksParam)) {
+        keyInfoCtx->flags |= XMLSEC_KEYINFO_FLAGS_X509DATA_SKIP_TIME_CHECKS;
     }
     if(xmlSecAppCmdLineParamIsSet(&depthParam)) {
         keyInfoCtx->certsVerificationDepth = xmlSecAppCmdLineParamGetInt(&depthParam, 0);

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,6 +72,7 @@ see the Copyright file in the distribution  for details.<br><br></p>
         <ul>
             <li>(xmlsec-core) Disabled old crypto algorithms (MD5, RIPEMD160) and the old crypto engines (MSCrypto, GCrypt) by default (use "--with-legacy-features" option to reenable everything).</li>
             <li>(xmlsec-windows) Disabled old crypto algorithms (MD5, RIPEMD160), made "mscng" the default crypto engine on Windows, and added support for "legacy-features" flag for "configure.js".<li>
+            <li>(xmlsec-openssl) Added an option to skip timestamp checks for certificates and CLRs.</li>
             <li>Several other small fixes (see <a href="https://github.com/lsh123/xmlsec/commits/master">more details</a>).</li>
         </ul>
 	</li>

--- a/include/xmlsec/keyinfo.h
+++ b/include/xmlsec/keyinfo.h
@@ -166,6 +166,13 @@ typedef enum {
 #define XMLSEC_KEYINFO_FLAGS_LAX_KEY_SEARCH                     0x00008000
 
 /**
+ * XMLSEC_KEYINFO_FLAGS_X509DATA_SKIP_TIME_CHECKS:
+ *
+ * If the flag is set then we'll skip time checks of certs and CRLs
+ */
+#define XMLSEC_KEYINFO_FLAGS_X509DATA_SKIP_TIME_CHECKS          0x00010000
+
+/**
  * xmlSecKeyInfoCtx:
  * @userData:           the pointer to user data (xmlsec and xmlsec-crypto
  *                      never touch this).

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -674,6 +674,10 @@ xmlSecOpenSSLX509StoreSetCtx(X509_STORE_CTX* xsc, xmlSecKeyInfoCtx* keyInfoCtx) 
         vpm_flags |= X509_V_FLAG_USE_CHECK_TIME;
         X509_VERIFY_PARAM_set_time(vpm, keyInfoCtx->certsVerificationTime);
     }
+    if((keyInfoCtx->flags & XMLSEC_KEYINFO_FLAGS_X509DATA_SKIP_TIME_CHECKS) != 0) {
+        vpm_flags |= X509_V_FLAG_NO_CHECK_TIME;
+    }
+
     X509_VERIFY_PARAM_set_flags(vpm, vpm_flags);
     X509_VERIFY_PARAM_set_depth(vpm, keyInfoCtx->certsVerificationDepth);
 

--- a/tests/testDSig.sh
+++ b/tests/testDSig.sh
@@ -1146,6 +1146,19 @@ execDSigTest $res_success \
     "rsa x509" \
     "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509 --verification-gmt-time 2022-12-14+00:00:00"
 
+
+# currently only openssl supports skipping time checks
+# https://github.com/lsh123/xmlsec/issues/852
+if [ "z$crypto" = "zopenssl" ] ; then
+extra_message="Expired cert but we skip timestamp checks"
+execDSigTest $res_success \
+    "" \
+    "aleksey-xmldsig-01/enveloping-expired-cert" \
+    "sha1 rsa-sha1" \
+    "rsa x509" \
+    "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509 --X509-skip-time-checks"
+fi
+
 # 'Verify existing signature' MUST fail here, as --trusted-... is not passed.
 # If this passes, that's a bug. Note that we need to cleanup NSS certs DB
 # since it automaticall stores trusted certs


### PR DESCRIPTION
See issue #852 
