### PR TITLE
(xmlsec-mscng) Added an option to skip timestamp checks for certificates and CLRs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,7 @@ see the Copyright file in the distribution  for details.<br><br></p>
         <ul>
             <li>(xmlsec-core) Disabled old crypto algorithms (MD5, RIPEMD160) and the old crypto engines (MSCrypto, GCrypt) by default (use "--with-legacy-features" option to reenable everything).</li>
             <li>(xmlsec-windows) Disabled old crypto algorithms (MD5, RIPEMD160), made "mscng" the default crypto engine on Windows, and added support for "legacy-features" flag for "configure.js".<li>
-            <li>(xmlsec-openssl, xmlsec-gnutls) Added an option to skip timestamp checks for certificates and CLRs.</li>
+            <li>(xmlsec-openssl, xmlsec-gnutls, xmlsec-mscng) Added an option to skip timestamp checks for certificates and CLRs.</li>
             <li>Several other small fixes (see <a href="https://github.com/lsh123/xmlsec/commits/master">more details</a>).</li>
         </ul>
 	</li>

--- a/tests/testDSig.sh
+++ b/tests/testDSig.sh
@@ -1149,14 +1149,14 @@ execDSigTest $res_success \
 
 # currently only openssl and gnutls support skipping time checks
 # https://github.com/lsh123/xmlsec/issues/852
-if [ "z$crypto" = "zopenssl" -o "z$crypto" = "zgnutls"  ] ; then
-extra_message="Expired cert but we skip timestamp checks"
-execDSigTest $res_success \
-    "" \
-    "aleksey-xmldsig-01/enveloping-expired-cert" \
-    "sha1 rsa-sha1" \
-    "rsa x509" \
-    "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509 --X509-skip-time-checks"
+if [ "z$crypto" = "zopenssl" -o "z$crypto" = "zgnutls" -o "z$crypto" = "zmscng"  ] ; then
+    extra_message="Expired cert but we skip timestamp checks"
+    execDSigTest $res_success \
+        "" \
+        "aleksey-xmldsig-01/enveloping-expired-cert" \
+        "sha1 rsa-sha1" \
+        "rsa x509" \
+        "--trusted-$cert_format $topfolder/keys/cacert.$cert_format --enabled-key-data x509 --X509-skip-time-checks"
 fi
 
 # 'Verify existing signature' MUST fail here, as --trusted-... is not passed.


### PR DESCRIPTION
See issue #852