### PR TITLE
transforms: add missing include

### DIFF
--- a/include/xmlsec/transforms.h
+++ b/include/xmlsec/transforms.h
@@ -11,6 +11,8 @@
 #ifndef __XMLSEC_TRANSFORMS_H__
 #define __XMLSEC_TRANSFORMS_H__
 
+#include <stdint.h>
+
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
 


### PR DESCRIPTION
Otherwise gcc-12 breaks with:

In file included from ../include/xmlsec/keyinfo.h:24:0,
                 from ../include/xmlsec/keysmngr.h:19,
                 from ../include/xmlsec/app.h:26,
                 from app.c:30:
../include/xmlsec/transforms.h:449:5: error: unknown type name ‘uintptr_t’
     uintptr_t                           flags;
     ^~~~~~~~~