### PR TITLE
Fix xmlSecOpenSSLX509VerifyCRL() unused parameters warnings

### DIFF
--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -1274,7 +1274,11 @@ xmlSecOpenSSLX509StoreFinalize(xmlSecKeyDataStorePtr store) {
  *
  *****************************************************************************/
 static int
-xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
+xmlSecOpenSSLX509VerifyCRL(__attribute__((unused)) X509_STORE* xst,
+                           __attribute__((unused)) X509_STORE_CTX* xsc,
+                           __attribute__((unused)) STACK_OF(X509)* untrusted,
+                           __attribute__((unused)) X509_CRL *crl,
+                           __attribute__((unused)) xmlSecKeyInfoCtx* keyInfoCtx) {
 #ifndef XMLSEC_OPENSSL_NO_CRL_VERIFICATION
     X509_OBJECT *xobj = NULL;
     EVP_PKEY *pKey = NULL;


### PR DESCRIPTION
Prevent these warnings about unused parameter when building against AWS-LC:

../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509VerifyCRL': ../../../src/openssl/x509vfy.c:1271:40: warning: unused parameter 'xst' [-Wunused-parameter]
 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
      |                            ~~~~~~~~~~~~^~~
../../../src/openssl/x509vfy.c:1271:61: warning: unused parameter 'xsc' [-Wunused-parameter]
 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
      |                                             ~~~~~~~~~~~~~~~~^~~
../../../src/openssl/x509vfy.c:1271:82: warning: unused parameter 'untrusted' [-Wunused-parameter]
 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
../../../src/openssl/x509vfy.c:1271:103: warning: unused parameter 'crl' [-Wunused-parameter]
 1271 | fyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
      |                                                                        ~~~~~~~~~~^~~

../../../src/openssl/x509vfy.c:1271:126: warning: unused parameter 'keyInfoCtx' [-Wunused-parameter]
 1271 | X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
      |                                                                ~~~~~~~~~~~~~~~~~~^~~~~~~~~~