### PR TITLE
Fix warnings from xmlSecOpenSSLEvpSignatureVerify()

### DIFF
--- a/src/openssl/signatures.c
+++ b/src/openssl/signatures.c
@@ -982,7 +982,9 @@ xmlSecOpenSSLEvpSignatureVerify(xmlSecTransformPtr transform,
     unsigned int dgstSize = sizeof(dgst);
     EVP_PKEY_CTX *pKeyCtx = NULL;
     unsigned char * fixedData = NULL;
+#if !defined(XMLSEC_NO_DSA) || !defined(XMLSEC_NO_EC)
     int fixedDataLen = 0;
+#endif
     unsigned int dataLen;
     int ret;
     int res = -1;


### PR DESCRIPTION
Avoid such a warning when building with XMLSEC_NO_DSA or XMLSEC_NO_EC:

  CC       libxmlsec1_openssl_la-signatures.lo
../../../src/openssl/signatures.c: In function 'xmlSecOpenSSLEvpSignatureVerify':
../../../src/openssl/signatures.c:985:9: warning: unused variable 'fixedDataLen' [-Wunused-variable]
  985 |     int fixedDataLen = 0;