### PR TITLE
Fix warnings from xmlSecOpenSSLEvpSignatureVerify()

### DIFF
--- a/src/openssl/signatures.c
+++ b/src/openssl/signatures.c
@@ -981,8 +981,10 @@ xmlSecOpenSSLEvpSignatureVerify(xmlSecTransformPtr transform,
     xmlSecByte dgst[EVP_MAX_MD_SIZE];
     unsigned int dgstSize = sizeof(dgst);
     EVP_PKEY_CTX *pKeyCtx = NULL;
+#if !defined(XMLSEC_NO_DSA) || !defined(XMLSEC_NO_EC)
     unsigned char * fixedData = NULL;
     int fixedDataLen = 0;
+#endif
     unsigned int dataLen;
     int ret;
     int res = -1;
@@ -1073,9 +1075,11 @@ xmlSecOpenSSLEvpSignatureVerify(xmlSecTransformPtr transform,
     res = 0;
 
 done:
+#if !defined(XMLSEC_NO_DSA) || !defined(XMLSEC_NO_EC)
     if(fixedData != NULL) {
         OPENSSL_free(fixedData);
     }
+#endif
     if(pKeyCtx != NULL) {
         EVP_PKEY_CTX_free(pKeyCtx);
     }


### PR DESCRIPTION
Avoid such a warning when building with XMLSEC_NO_DSA or XMLSEC_NO_EC:

      CC       libxmlsec1_openssl_la-signatures.lo
    ../../../src/openssl/signatures.c: In function 'xmlSecOpenSSLEvpSignatureVerify':
    ../../../src/openssl/signatures.c:985:9: warning: unused variable 'fixedDataLen' [-Wunused-variable]
      985 |     int fixedDataLen = 0;