### PR TITLE
Fix xmlSecOpenSSLX509VerifyCRL() unused parameters

### DIFF
--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -1274,7 +1274,11 @@ xmlSecOpenSSLX509StoreFinalize(xmlSecKeyDataStorePtr store) {
  *
  *****************************************************************************/
 static int
-xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL *crl, xmlSecKeyInfoCtx* keyInfoCtx) {
+xmlSecOpenSSLX509VerifyCRL(ATTRIBUTE_UNUSED X509_STORE* xst,
+                           ATTRIBUTE_UNUSED X509_STORE_CTX* xsc,
+                           ATTRIBUTE_UNUSED STACK_OF(X509)* untrusted,
+                           ATTRIBUTE_UNUSED X509_CRL *crl,
+                           ATTRIBUTE_UNUSED xmlSecKeyInfoCtx* keyInfoCtx) {
 #ifndef XMLSEC_OPENSSL_NO_CRL_VERIFICATION
     X509_OBJECT *xobj = NULL;
     EVP_PKEY *pKey = NULL;


### PR DESCRIPTION
Prevent these warnings about unused parameter when building with XMLSEC_OPENSSL_NO_CRL_VERIFICATION. This is the case with aws-lc.

../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509VerifyCRL': ../../../src/openssl/x509vfy.c:1271:40: warning: unused parameter 'xst' [-Wunused-parameter] 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~~~^~~
../../../src/openssl/x509vfy.c:1271:61: warning: unused parameter 'xsc' [-Wunused-parameter] 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~~~~~~~^~~
../../../src/openssl/x509vfy.c:1271:82: warning: unused parameter 'untrusted' [-Wunused-parameter] 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { ../../../src/openssl/x509vfy.c:1271:103: warning: unused parameter 'crl' [-Wunused-parameter] 1271 | fyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~^~~

../../../src/openssl/x509vfy.c:1271:126: warning: unused parameter 'keyInfoCtx' [-Wunused-parameter] 1271 | X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~~~~~~~~~^~~~~~~~