### PR TITLE
Fix xmlSecOpenSSLX509VerifyCRL() unused parameters

### DIFF
--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -1347,6 +1347,11 @@ done:
 
 #else /* XMLSEC_OPENSSL_NO_CRL_VERIFICATION */
     /* boringssl doesn't have X509_OBJECT_new() or public definition of X509_OBJECT */
+    UNREFERENCED_PARAMETER(xst);
+    UNREFERENCED_PARAMETER(xsc);
+    UNREFERENCED_PARAMETER(untrusted);
+    UNREFERENCED_PARAMETER(crl);
+    UNREFERENCED_PARAMETER(keyInfoCtx);
     return(1);
 #endif /* XMLSEC_OPENSSL_NO_CRL_VERIFICATION */
 }


### PR DESCRIPTION
Prevent these warnings about unused parameter when building with XMLSEC_OPENSSL_NO_CRL_VERIFICATION. This is the case with aws-lc.

    ../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509VerifyCRL': ../../../src/openssl/x509vfy.c:1271:40: warning: unused parameter 'xst' [-Wunused-parameter] 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~~~^~~
    ../../../src/openssl/x509vfy.c:1271:61: warning: unused parameter 'xsc' [-Wunused-parameter] 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~~~~~~~^~~
    ../../../src/openssl/x509vfy.c:1271:82: warning: unused parameter 'untrusted' [-Wunused-parameter] 1271 | xmlSecOpenSSLX509VerifyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { ../../../src/openssl/x509vfy.c:1271:103: warning: unused parameter 'crl' [-Wunused-parameter] 1271 | fyCRL(X509_STORE* xst, X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~^~~

    ../../../src/openssl/x509vfy.c:1271:126: warning: unused parameter 'keyInfoCtx' [-Wunused-parameter] 1271 | X509_STORE_CTX* xsc, STACK_OF(X509)* untrusted, X509_CRL crl, xmlSecKeyInfoCtx keyInfoCtx) { | ~~~~~~~~~~~~~~~~~~^~~~~~~~