### PR TITLE
Fix function prototypes with a size_t parameter

### DIFF
--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -34,18 +34,40 @@
 #define EVP_CIPHER_iv_length    (int)EVP_CIPHER_iv_length
 #define EVP_CIPHER_block_size   (int)EVP_CIPHER_block_size
 
+#define ECDSA_do_verify(digest, digest_len, sig, key) \
+    ECDSA_do_verify(digest, (size_t)(digest_len), sig, key)
+#define ECDSA_do_sign(digest, digest_len, key) \
+    ECDSA_do_sign(digest, (size_t)(digest_len), key)
+
+#define HMAC_Init_ex(ctx, key, key_len, md, impl) \
+       HMAC_Init_ex(ctx, key, (size_t)(key_len), md, impl)
+#define AES_set_encrypt_key(user_key, bits, aes_key) \
+       AES_set_encrypt_key(user_key, (unsigned)(bits), aes_key)
+#define AES_set_decrypt_key(user_key, bits, aes_key) \
+       AES_set_decrypt_key(user_key, (unsigned)(bits), aes_key)
+
+#define RSA_public_encrypt(flen, from, to, rsa, padding) \
+       RSA_public_encrypt((size_t)(flen), from, to, rsa, padding)
+#define RSA_private_decrypt(flen, from, to, rsa, padding) \
+       RSA_private_decrypt((size_t)(flen), from, to, rsa, padding)
+
+
 #define EVP_MD_size (int)EVP_MD_size
 #define RSA_size    (int)RSA_size
 
 #define BN_num_bytes (int)BN_num_bytes
 #define BN_num_bits  (int)BN_num_bits
 #define BN_bn2bin    (int)BN_bn2bin
+#define BN_bin2bn(in, len, ret) BN_bin2bn(in, (size_t)(len), ret)
 
 #define sk_X509_insert   (int)sk_X509_insert
 #define sk_X509_push     (int)sk_X509_push
 #define sk_X509_num      (int)sk_X509_num
 #define sk_X509_CRL_num  (int)sk_X509_CRL_num
 #define sk_X509_CRL_push (int)sk_X509_CRL_push
+#define sk_X509_CRL_value(sk, idx)        sk_X509_CRL_value(sk, (size_t)(idx))
+#define sk_X509_value(sk, idx)            sk_X509_value(sk, (size_t)(idx))
+#define sk_X509_NAME_ENTRY_value(sk, idx) sk_X509_NAME_ENTRY_value(sk, (size_t)(idx))
 
 #define BIO_pending      (int)BIO_pending
 

--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -68,6 +68,7 @@
 #define sk_X509_CRL_value(sk, idx)        sk_X509_CRL_value(sk, (size_t)(idx))
 #define sk_X509_value(sk, idx)            sk_X509_value(sk, (size_t)(idx))
 #define sk_X509_NAME_ENTRY_value(sk, idx) sk_X509_NAME_ENTRY_value(sk, (size_t)(idx))
+#define sk_X509_REVOKED_value(sk, idx)    sk_X509_REVOKED_value(sk, (size_t)(idx))
 
 #define BIO_pending      (int)BIO_pending
 


### PR DESCRIPTION
All these functions take a size_t as parameter in aws-lc/boringssl API in place of an int in OpenSSL API. This is safe to cast int to size_t for value which are not supposed to be negative (lengths or number of bits here).

This patch fixes these warnings:

    ../../../src/openssl/evp.c: In function 'xmlSecOpenSSLGetBNValue':
    ../../../src/openssl/evp.c:58:35: warning: conversion to 'size_t' {aka 'long unsigned in t'} from 'int' may change the sign of the result [-Wsign-conversion]
       58 |     (*bigNum) = BN_bin2bn(bufPtr, bufLen, (*bigNum));
          |                                   ^~~~~~
      CC       libxmlsec1_openssl_la-kdf.lo
      CC       libxmlsec1_openssl_la-key_agrmnt.lo
      CC       libxmlsec1_openssl_la-keysstore.lo
      CC       libxmlsec1_openssl_la-hmac.lo
    ../../../src/openssl/hmac.c: In function 'xmlSecOpenSSLHmacSetKeyImpl':
    ../../../src/openssl/hmac.c:339:43: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      339 |     ret = HMAC_Init_ex(ctx->hmacCtx, key, keyLen, ctx->hmacDgst, NULL);
          |                                           ^~~~~~
      CC       libxmlsec1_openssl_la-kw_aes.lo
    ../../../src/openssl/kw_aes.c: In function 'xmlSecOpenSSLKWAesEncryptDecrypt':
    ../../../src/openssl/kw_aes.c:393:46: warning: conversion to 'unsigned int' from 'int' may change the sign of the result [-Wsign-conversion]
      393 |         ret = AES_set_encrypt_key(keyData, 8 * keyLen, &aesKey);
          |                                            ~~^~~~~~~~
    ../../../src/openssl/kw_aes.c:400:46: warning: conversion to 'unsigned int' from 'int' may change the sign of the result [-Wsign-conversion]
      400 |         ret = AES_set_decrypt_key(keyData, 8 * keyLen, &aesKey);
          |                                            ~~^~~~~~~~
      CC       libxmlsec1_openssl_la-kw_des.lo
      CC       libxmlsec1_openssl_la-kt_rsa.lo
    ../../../src/openssl/kt_rsa.c: In function 'xmlSecOpenSSLRsaPkcs1ProcessImpl':
    ../../../src/openssl/kt_rsa.c:176:34: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      176 |         ret = RSA_public_encrypt(inLen, inBuf, outBuf, rsa, RSA_PKCS1_PADDING);
          |                                  ^~~~~
    ../../../src/openssl/kt_rsa.c:184:35: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      184 |         ret = RSA_private_decrypt(inLen, inBuf, outBuf, rsa, RSA_PKCS1_PADDING);
          |                                   ^~~~~
      CC       libxmlsec1_openssl_la-signatures.lo
      CC       libxmlsec1_openssl_la-signatures_legacy.lo
    ../../../src/openssl/signatures_legacy.c: In function 'xmlSecOpenSSLSignatureLegacyEcdsaSignImpl':
    ../../../src/openssl/signatures_legacy.c:597:30: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      597 |     sig = ECDSA_do_sign(buf, dgstLen, ecKey);
          |                              ^~~~~~~
    ../../../src/openssl/signatures_legacy.c: In function 'xmlSecOpenSSLSignatureLegacyEcdsaVerifyImpl':
    ../../../src/openssl/signatures_legacy.c:639:32: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      639 |     ret = ECDSA_do_verify(buf, bufLen, sig, ecKey);
          |                                ^~~~~~
    ../../../src/openssl/signatures_legacy.c: In function 'xmlSecOpenSSLSignatureLegacyEcdsaVerify':
    ../../../src/openssl/signatures_legacy.c:782:30: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      782 |     rr = BN_bin2bn(signData, signHalfLen, NULL);
          |                              ^~~~~~~~~~~
    ../../../src/openssl/signatures_legacy.c:787:44: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      787 |     ss = BN_bin2bn(signData + signHalfLen, signHalfLen, NULL);

    ../../../src/openssl/x509.c: In function 'xmlSecOpenSSLKeyDataX509GetCert':
    ../../../src/openssl/x509.c:347:42: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      347 |     return(sk_X509_value(ctx->certsList, iPos));
          |                                          ^~~~
    ../../../src/openssl/x509.c: In function 'xmlSecOpenSSLKeyDataX509GetCrl':
    ../../../src/openssl/x509.c:444:45: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      444 |     return(sk_X509_CRL_value(ctx->crlsList, iPos));
          |                                             ^~~~
    ../../../src/openssl/x509.c: In function 'xmlSecOpenSSLKeyDataX509Duplicate':
    ../../../src/openssl/x509.c:578:56: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      578 |             certSrc = sk_X509_value(ctxSrc->certsList, ii);
          |                                                        ^~
    ../../../src/openssl/x509.c:622:58: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      622 |             crlSrc = sk_X509_CRL_value(ctxSrc->crlsList, ii);
          |                                                          ^~
    ../../../src/openssl/x509.c:648:59: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
      648 |             X509* cert = sk_X509_value(ctxSrc->certsList, ii);

    ../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509_NAME_ENTRIES_cmp':
    ../../../src/openssl/x509vfy.c:2010:42: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
     2010 |         na = sk_X509_NAME_ENTRY_value(a, ii);
          |                                          ^~
    ../../../src/openssl/x509vfy.c:2011:42: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
     2011 |         nb = sk_X509_NAME_ENTRY_value(b, ii);