### PR TITLE
Fix double conversion due to aws-lc/boringssl API

### DIFF
--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -45,11 +45,7 @@
 #include "openssl_compat.h"
 #include "private.h"
 
-#ifdef OPENSSL_IS_BORINGSSL
-typedef size_t x509_size_t;
-#else /* OPENSSL_IS_BORINGSSL */
 typedef int x509_size_t;
-#endif /* OPENSSL_IS_BORINGSSL */
 
 /**************************************************************************
  *


### PR DESCRIPTION
This previous patch fixes some warning where several sk_509*() functions return a size_t (awl-lc/boringSSL API) in place of an int (OpenSSL API): https://github.com/lsh123/xmlsec/commit/3cd3932ca270a050b5afeaf4c27571c808934f87

But this introduced others warnings where a double conversions were done into x509vfy.c where a "typedef size_t x509_siz_t" is implemented to fix the same API issue. This is correct but leads after the mentioned commit to such double conversion:
       x509_size_t num = sk_X509_CRL_num(crls) ->
       size_t num = (int)sk_X509_CRL_num(crls)

This does not please to the compiler ;-)

This simple patch fixes these warnings:

../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreFindCert_ex': ../../../src/openssl/x509vfy.c:218:20: warning: comparison of integer expressions of different signedness: 'x509_size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  218 |     for(ii = 0; ii < sk_X509_num(ctx->untrusted); ++ii) {
      |                    ^
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreFindCertByValue':
../../../src/openssl/x509vfy.c:265:20: warning: comparison of integer expressions of different signedness: 'x509_size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  265 |     for(ii = 0; ii < sk_X509_num(ctx->untrusted); ++ii) {
      |                    ^
In file included from ../../../src/openssl/x509vfy.c:37:
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreVerifyAndCopyCrls':
../../../src/openssl/openssl_compat.h:66:26: warning: conversion to 'x509_size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
   66 | #define sk_X509_CRL_num  (int)sk_X509_CRL_num
      |                          ^
../../../src/openssl/x509vfy.c:358:11: note: in expansion of macro 'sk_X509_CRL_num'
  358 |     num = sk_X509_CRL_num(crls);
      |           ^~~~~~~~~~~~~~~
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreFindBestCrl':
../../../src/openssl/openssl_compat.h:66:26: warning: conversion to 'x509_size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
   66 | #define sk_X509_CRL_num  (int)sk_X509_CRL_num
      |                          ^
../../../src/openssl/x509vfy.c:506:11: note: in expansion of macro 'sk_X509_CRL_num'
  506 |     num = sk_X509_CRL_num(crls);
      |           ^~~~~~~~~~~~~~~
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreVerifyCertsAgainstCrls':
../../../src/openssl/openssl_compat.h:65:26: warning: conversion to 'x509_size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
   65 | #define sk_X509_num      (int)sk_X509_num
      |                          ^
../../../src/openssl/x509vfy.c:633:17: note: in expansion of macro 'sk_X509_num'
  633 |     num_certs = sk_X509_num(chain);
      |                 ^~~~~~~~~~~
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreVerify':
../../../src/openssl/openssl_compat.h:65:26: warning: conversion to 'x509_size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
   65 | #define sk_X509_num      (int)sk_X509_num
      |                          ^
../../../src/openssl/x509vfy.c:862:11: note: in expansion of macro 'sk_X509_num'
  862 |     num = sk_X509_num(certs);
      |           ^~~~~~~~~~~
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509StoreCombineCerts':
../../../src/openssl/openssl_compat.h:65:26: warning: conversion to 'x509_size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
   65 | #define sk_X509_num      (int)sk_X509_num
      |                          ^
../../../src/openssl/x509vfy.c:1703:15: note: in expansion of macro 'sk_X509_num'
 1703 |         num = sk_X509_num(certs2);
      |               ^~~~~~~~~~~
In file included from ../../../src/openssl/x509vfy.c:15:
../../../src/openssl/x509vfy.c:1707:38: warning: conversion to 'x509_size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
 1707 |                 "size=%d", (int)(num + sk_X509_num(res)));
      |                                      ^
../../../src/openssl/globals.h:74:22: note: in definition of macro '__xmlSecOpenSSLError2'
   74 |                     (param),                                \
      |                      ^~~~~
../../../src/openssl/x509vfy.c:1706:13: note: in expansion of macro 'xmlSecOpenSSLError2'
 1706 |             xmlSecOpenSSLError2("sk_X509_reserve(res)", NULL,
      |             ^~~~~~~~~~~~~~~~~~~
../../../src/openssl/x509vfy.c: In function 'xmlSecOpenSSLX509FindChildCert':
../../../src/openssl/x509vfy.c:1746:20: warning: comparison of integer expressions of different signedness: 'x509_size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
 1746 |     for(ii = 0; ii < sk_X509_num(chain); ++ii) {