### PR TITLE
Fix build for AWS-LC and BoringSSL

### DIFF
--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -760,7 +760,7 @@ xmlSecOpenSSLAppCheckCertMatchesKey(EVP_PKEY * pKey,  X509 * cert) {
 static X509 *
 xmlSecOpenSSLAppFindKeyCert(EVP_PKEY * pKey, STACK_OF(X509) * certs) {
     X509 * cert;
-    xmlSecOpenSSLX509Size ii, size;
+    xmlSecOpenSSLSizeT ii, size;
     int ret;
 
     xmlSecAssert2(pKey != NULL, NULL);

--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -760,7 +760,7 @@ xmlSecOpenSSLAppCheckCertMatchesKey(EVP_PKEY * pKey,  X509 * cert) {
 static X509 *
 xmlSecOpenSSLAppFindKeyCert(EVP_PKEY * pKey, STACK_OF(X509) * certs) {
     X509 * cert;
-    int ii, size;
+    xmlSecOpenSSLX509Size ii, size;
     int ret;
 
     xmlSecAssert2(pKey != NULL, NULL);

--- a/src/openssl/ciphers.c
+++ b/src/openssl/ciphers.c
@@ -127,7 +127,6 @@ xmlSecOpenSSLEvpBlockCipherCtxInit(xmlSecOpenSSLEvpBlockCipherCtxPtr ctx,
             xmlSecInternalError2("xmlSecBufferAppend", cipherName, "size=%d", ivLen);
             return(-1);
         }
-
     } else {
         /* if we don't have enough data, exit and hope that
          * we'll have iv next time */

--- a/src/openssl/globals.h
+++ b/src/openssl/globals.h
@@ -18,6 +18,8 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <openssl/crypto.h>
+
 #define IN_XMLSEC_CRYPTO
 #define XMLSEC_PRIVATE
 
@@ -31,6 +33,13 @@
  */
 #define XMLSEC_OPENSSL_ERROR_BUFFER_SIZE                1024
 
+/** AWS LC and OpenSSL have different types for error code type */
+#ifdef OPENSSL_IS_AWSLC
+typedef uint32_t xmlSecOpenSSLErrorType;
+#else /* OPENSSL_IS_AWSLC */
+typedef unsigned long xmlSecOpenSSLErrorType;
+#endif /* ! OPENSSL_IS_AWSLC */
+
 /**
  * xmlSecOpenSSLError:
  * @errorFunction:      the failed function name.
@@ -38,10 +47,10 @@
  *
  * Macro. The XMLSec library macro for reporting OpenSSL crypro errors.
  */
-#define __xmlSecOpenSSLError(errorType, errorFunction, errorObject)      \
+#define xmlSecOpenSSLError(errorFunction, errorObject)      \
     {                                                       \
         char _openssl_error_buf[XMLSEC_OPENSSL_ERROR_BUFFER_SIZE]; \
-        errorType _openssl_error_code = ERR_peek_last_error(); \
+        xmlSecOpenSSLErrorType _openssl_error_code = ERR_peek_last_error(); \
         ERR_error_string_n(_openssl_error_code, _openssl_error_buf, sizeof(_openssl_error_buf)); \
         xmlSecError(XMLSEC_ERRORS_HERE,                     \
                     (const char*)(errorObject),             \
@@ -62,9 +71,9 @@
  *
  * Macro. The XMLSec library macro for reporting OpenSSL crypro errors.
  */
-#define __xmlSecOpenSSLError2(errorType, errorFunction, errorObject, msg, param) \
+#define xmlSecOpenSSLError2(errorFunction, errorObject, msg, param) \
         char _openssl_error_buf[XMLSEC_OPENSSL_ERROR_BUFFER_SIZE];  \
-        errorType _openssl_error_code = ERR_peek_last_error();  \
+        xmlSecOpenSSLErrorType _openssl_error_code = ERR_peek_last_error();  \
         ERR_error_string_n(_openssl_error_code, _openssl_error_buf, sizeof(_openssl_error_buf)); \
         xmlSecError(XMLSEC_ERRORS_HERE,                     \
                     (const char*)(errorObject),             \
@@ -85,9 +94,9 @@
   *
   * Macro. The XMLSec library macro for reporting OpenSSL crypro errors.
   */
-#define __xmlSecOpenSSLError3(errorType, errorFunction, errorObject, msg, param1, param2) \
+#define xmlSecOpenSSLError3(errorFunction, errorObject, msg, param1, param2) \
         char _openssl_error_buf[XMLSEC_OPENSSL_ERROR_BUFFER_SIZE];  \
-        errorType _openssl_error_code = ERR_peek_last_error();  \
+        xmlSecOpenSSLErrorType _openssl_error_code = ERR_peek_last_error();  \
         ERR_error_string_n(_openssl_error_code, _openssl_error_buf, sizeof(_openssl_error_buf)); \
         xmlSecError(XMLSEC_ERRORS_HERE,                     \
                     (const char*)(errorObject),             \
@@ -98,27 +107,5 @@
                     (param2),                               \
                     xmlSecErrorsSafeString(_openssl_error_buf) \
         );                                                  \
-
-
-
-#ifdef OPENSSL_IS_BORINGSSL
-
-#define xmlSecOpenSSLError(errorFunction, errorObject) \
-	__xmlSecOpenSSLError(uint32_t, errorFunction, errorObject)
-#define xmlSecOpenSSLError2(errorFunction, errorObject, msg, param) \
-	__xmlSecOpenSSLError2(uint32_t, errorFunction, errorObject, msg, param)
-#define xmlSecOpenSSLError3(errorFunction, errorObject, msg, param1, param2) \
-	__xmlSecOpenSSLError3(uint32_t, errorFunction, errorObject, msg, param1, param2)
-
-#else /* OPENSSL_IS_BORINGSSL */
-
-#define xmlSecOpenSSLError(errorFunction, errorObject) \
-	__xmlSecOpenSSLError(unsigned long, errorFunction, errorObject)
-#define xmlSecOpenSSLError2(errorFunction, errorObject, msg, param) \
-	__xmlSecOpenSSLError2(unsigned long, errorFunction, errorObject, msg, param)
-#define xmlSecOpenSSLError3(errorFunction, errorObject, msg, param1, param2) \
-	__xmlSecOpenSSLError3(unsigned long, errorFunction, errorObject, msg, param1, param2)
-
-#endif /* ! OPENSSL_IS_BORINGSSL */
 
 #endif /* ! __XMLSEC_GLOBALS_H__ */

--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -7,9 +7,58 @@
 #ifndef __XMLSEC_OPENSSL_OPENSSL_COMPAT_H__
 #define __XMLSEC_OPENSSL_OPENSSL_COMPAT_H__
 
+#include <openssl/crypto.h>
 #include <openssl/rand.h>
 
 #include "../cast_helpers.h"
+
+
+/******************************************************************************
+ *
+ * AWS LC compatibility (based on BoringSSL)
+ *
+ *****************************************************************************/
+#ifdef OPENSSL_IS_AWSLC
+
+#ifndef OPENSSL_IS_BORINGSSL
+#define OPENSSL_IS_BORINGSSL
+#endif /* OPENSSL_IS_BORINGSSL */
+
+#define EVP_CIPHER_key_length   (int)EVP_CIPHER_key_length
+#define EVP_CIPHER_iv_length    (int)EVP_CIPHER_iv_length
+#define EVP_CIPHER_block_size   (int)EVP_CIPHER_block_size
+
+#define ECDSA_do_verify(digest, digest_len, sig, key) \
+       ECDSA_do_verify(digest, (size_t)(digest_len), sig, key)
+#define ECDSA_do_sign(digest, digest_len, key) \
+       ECDSA_do_sign(digest, (size_t)(digest_len), key)
+
+#define HMAC_Init_ex(ctx, key, key_len, md, impl) \
+       HMAC_Init_ex(ctx, key, (size_t)(key_len), md, impl)
+
+#define AES_set_encrypt_key(user_key, bits, aes_key) \
+       AES_set_encrypt_key(user_key, (unsigned)(bits), aes_key)
+#define AES_set_decrypt_key(user_key, bits, aes_key) \
+       AES_set_decrypt_key(user_key, (unsigned)(bits), aes_key)
+
+#define RSA_public_encrypt(flen, from, to, rsa, padding) \
+       RSA_public_encrypt((size_t)(flen), from, to, rsa, padding)
+#define RSA_private_decrypt(flen, from, to, rsa, padding) \
+       RSA_private_decrypt((size_t)(flen), from, to, rsa, padding)
+
+#define EVP_MD_size (int)EVP_MD_size
+#define RSA_size    (int)RSA_size
+
+#define BN_num_bytes (int)BN_num_bytes
+#define BN_num_bits  (int)BN_num_bits
+#define BN_bn2bin    (int)BN_bn2bin
+#define BN_bin2bn(in, len, ret) BN_bin2bn(in, (size_t)(len), ret)
+
+#define BIO_pending      (int)BIO_pending
+
+#define RAND_priv_bytes_ex(ctx,buf,num,strength)        RAND_priv_bytes((buf), (num))
+
+#endif /* ! OPENSSL_IS_AWSLC */
 
 
 /******************************************************************************
@@ -30,59 +79,14 @@
 #define XMLSEC_NO_SHA3                      1
 
 
-#define EVP_CIPHER_key_length   (int)EVP_CIPHER_key_length
-#define EVP_CIPHER_iv_length    (int)EVP_CIPHER_iv_length
-#define EVP_CIPHER_block_size   (int)EVP_CIPHER_block_size
-
-#define ECDSA_do_verify(digest, digest_len, sig, key) \
-    ECDSA_do_verify(digest, (size_t)(digest_len), sig, key)
-#define ECDSA_do_sign(digest, digest_len, key) \
-    ECDSA_do_sign(digest, (size_t)(digest_len), key)
-
-#define HMAC_Init_ex(ctx, key, key_len, md, impl) \
-       HMAC_Init_ex(ctx, key, (size_t)(key_len), md, impl)
-#define AES_set_encrypt_key(user_key, bits, aes_key) \
-       AES_set_encrypt_key(user_key, (unsigned)(bits), aes_key)
-#define AES_set_decrypt_key(user_key, bits, aes_key) \
-       AES_set_decrypt_key(user_key, (unsigned)(bits), aes_key)
-
-#define RSA_public_encrypt(flen, from, to, rsa, padding) \
-       RSA_public_encrypt((size_t)(flen), from, to, rsa, padding)
-#define RSA_private_decrypt(flen, from, to, rsa, padding) \
-       RSA_private_decrypt((size_t)(flen), from, to, rsa, padding)
-
-
-#define EVP_MD_size (int)EVP_MD_size
-#define RSA_size    (int)RSA_size
-
-#define BN_num_bytes (int)BN_num_bytes
-#define BN_num_bits  (int)BN_num_bits
-#define BN_bn2bin    (int)BN_bn2bin
-#define BN_bin2bn(in, len, ret) BN_bin2bn(in, (size_t)(len), ret)
-
-#define sk_X509_insert   (int)sk_X509_insert
-#define sk_X509_push     (int)sk_X509_push
-#define sk_X509_num      (int)sk_X509_num
-#define sk_X509_CRL_num  (int)sk_X509_CRL_num
-#define sk_X509_CRL_push (int)sk_X509_CRL_push
-#define sk_X509_CRL_value(sk, idx)        sk_X509_CRL_value(sk, (size_t)(idx))
-#define sk_X509_value(sk, idx)            sk_X509_value(sk, (size_t)(idx))
-#define sk_X509_NAME_ENTRY_value(sk, idx) sk_X509_NAME_ENTRY_value(sk, (size_t)(idx))
-#define sk_X509_REVOKED_value(sk, idx)    sk_X509_REVOKED_value(sk, (size_t)(idx))
-
-#define BIO_pending      (int)BIO_pending
-
-#define sk_X509_NAME_ENTRY_num (int)sk_X509_NAME_ENTRY_num
-#define sk_X509_NAME_ENTRY_push (int)sk_X509_NAME_ENTRY_push
-
 #define ENGINE_cleanup(...)                 {}
 #define CONF_modules_unload(...)            {}
 
-#define RAND_priv_bytes(buf,len)            RAND_bytes((buf), (size_t)(len))
+#define RAND_priv_bytes(buf,len)            RAND_bytes((buf), (len))
 #define RAND_write_file(file)               (0)
 
 #define EVP_PKEY_base_id(pkey)              EVP_PKEY_id(pkey)
-#define EVP_CipherFinal(ctx, out, out_len)  EVP_CipherFinal_ex(ctx, out, out_len)
+#define EVP_CipherFinal(ctx, out, out_len)  EVP_CipherFinal_ex((ctx), (out), (out_len))
 #define EVP_read_pw_string(...)             (-1)
 
 #define X509_get0_pubkey(cert)              X509_get_pubkey((cert))
@@ -93,6 +97,30 @@
 #define sk_X509_CRL_reserve(crls, num)      (1)
 
 #endif /* OPENSSL_IS_BORINGSSL */
+
+
+/* BoringSSL redefines int->size_t for bunch of x509 functions */
+#if defined(OPENSSL_IS_BORINGSSL)
+
+typedef size_t xmlSecOpenSSLX509Size;
+
+#define XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(srcVal, dstVal, errorAction, errorObject)  \
+       (dstVal) = (srcVal)
+#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(srcVal, dstVal, errorAction, errorObject) \
+       (dstVal) = (srcVal)
+
+#else /* defined(OPENSSL_IS_BORINGSSL) */
+
+typedef int xmlSecOpenSSLX509Size;
+
+#define XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(srcVal, dstVal, errorAction, errorObject) \
+       XMLSEC_SAFE_CAST_INT_TO_SIZE((srcVal), (dstVal), errorAction, (errorObject))
+
+#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(srcVal, dstVal, errorAction, errorObject) \
+       XMLSEC_SAFE_CAST_SIZE_TO_INT((srcVal), (dstVal), errorAction, (errorObject))
+
+#endif /* defined(OPENSSL_IS_BORINGSSL) */
+
 
 /******************************************************************************
  *
@@ -123,7 +151,6 @@
 #endif /* (LIBRESSL_VERSION_NUMBER < 0x3070200fL) */
 
 #endif /* defined(LIBRESSL_VERSION_NUMBER) */
-
 
 /******************************************************************************
  *
@@ -156,12 +183,14 @@
 #define X509_STORE_set_default_paths_ex(ctx,libctx,propq)           X509_STORE_set_default_paths((ctx))
 #define X509_NAME_hash_ex(x,libctx,propq,ok)                        X509_NAME_hash((x))
 
+#ifndef RAND_priv_bytes_ex
 #define RAND_priv_bytes_ex(ctx,buf,num,strength)                    xmlSecOpenSSLCompatRand((buf),(num))
 static inline int xmlSecOpenSSLCompatRand(unsigned char *buf, xmlSecSize size) {
     int num;
     XMLSEC_SAFE_CAST_SIZE_TO_INT(size, num, return(0), NULL);
     return(RAND_priv_bytes(buf, num));
 }
+#endif /* RAND_priv_bytes_ex */
 
 #endif /* !defined(XMLSEC_OPENSSL_API_300) */
 

--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -56,8 +56,6 @@
 
 #define BIO_pending      (int)BIO_pending
 
-#define RAND_priv_bytes_ex(ctx,buf,num,strength)        RAND_priv_bytes((buf), (num))
-
 #endif /* ! OPENSSL_IS_AWSLC */
 
 
@@ -102,21 +100,21 @@
 /* BoringSSL redefines int->size_t for bunch of x509 functions */
 #if defined(OPENSSL_IS_BORINGSSL)
 
-typedef size_t xmlSecOpenSSLX509Size;
+typedef size_t xmlSecOpenSSLSizeT;
 
-#define XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(srcVal, dstVal, errorAction, errorObject)  \
+#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_T_TO_SIZE(srcVal, dstVal, errorAction, errorObject)  \
        (dstVal) = (srcVal)
-#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(srcVal, dstVal, errorAction, errorObject) \
+#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_SIZE_T(srcVal, dstVal, errorAction, errorObject) \
        (dstVal) = (srcVal)
 
 #else /* defined(OPENSSL_IS_BORINGSSL) */
 
-typedef int xmlSecOpenSSLX509Size;
+typedef int xmlSecOpenSSLSizeT;
 
-#define XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(srcVal, dstVal, errorAction, errorObject) \
+#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_T_TO_SIZE(srcVal, dstVal, errorAction, errorObject) \
        XMLSEC_SAFE_CAST_INT_TO_SIZE((srcVal), (dstVal), errorAction, (errorObject))
 
-#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(srcVal, dstVal, errorAction, errorObject) \
+#define XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_SIZE_T(srcVal, dstVal, errorAction, errorObject) \
        XMLSEC_SAFE_CAST_SIZE_TO_INT((srcVal), (dstVal), errorAction, (errorObject))
 
 #endif /* defined(OPENSSL_IS_BORINGSSL) */
@@ -183,14 +181,12 @@ typedef int xmlSecOpenSSLX509Size;
 #define X509_STORE_set_default_paths_ex(ctx,libctx,propq)           X509_STORE_set_default_paths((ctx))
 #define X509_NAME_hash_ex(x,libctx,propq,ok)                        X509_NAME_hash((x))
 
-#ifndef RAND_priv_bytes_ex
 #define RAND_priv_bytes_ex(ctx,buf,num,strength)                    xmlSecOpenSSLCompatRand((buf),(num))
 static inline int xmlSecOpenSSLCompatRand(unsigned char *buf, xmlSecSize size) {
-    int num;
-    XMLSEC_SAFE_CAST_SIZE_TO_INT(size, num, return(0), NULL);
+    xmlSecOpenSSLSizeT num;
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_SIZE_T(size, num, return(0), NULL);
     return(RAND_priv_bytes(buf, num));
 }
-#endif /* RAND_priv_bytes_ex */
 
 #endif /* !defined(XMLSEC_OPENSSL_API_300) */
 

--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -211,7 +211,7 @@ xmlSecOpenSSLKeyDataX509GetKeyCert(xmlSecKeyDataPtr data) {
 static int
 xmlSecOpenSSLKeyDataX509AddCertInternal(xmlSecOpenSSLX509DataCtxPtr ctx, X509* cert, int keyCert) {
     X509* dup;
-    xmlSecOpenSSLX509Size ret;
+    xmlSecOpenSSLSizeT ret;
 
     xmlSecAssert2(ctx != NULL, -1);
     xmlSecAssert2(cert != NULL, -1);
@@ -332,7 +332,7 @@ xmlSecOpenSSLKeyDataX509AdoptCert(xmlSecKeyDataPtr data, X509* cert) {
 X509*
 xmlSecOpenSSLKeyDataX509GetCert(xmlSecKeyDataPtr data, xmlSecSize pos) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    xmlSecOpenSSLX509Size iPos;
+    xmlSecOpenSSLSizeT iPos;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), NULL);
 
@@ -342,7 +342,7 @@ xmlSecOpenSSLKeyDataX509GetCert(xmlSecKeyDataPtr data, xmlSecSize pos) {
 
     /* to ensure that key cert is always first we put it at the first position
      * in xmlSecOpenSSLKeyDataX509AddCertInternal */
-    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(pos, iPos, return(NULL), NULL);
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_SIZE_T(pos, iPos, return(NULL), NULL);
     xmlSecAssert2(iPos < sk_X509_num(ctx->certsList), NULL);
     return(sk_X509_value(ctx->certsList, iPos));
 }
@@ -358,7 +358,7 @@ xmlSecOpenSSLKeyDataX509GetCert(xmlSecKeyDataPtr data, xmlSecSize pos) {
 xmlSecSize
 xmlSecOpenSSLKeyDataX509GetCertsSize(xmlSecKeyDataPtr data) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    xmlSecOpenSSLX509Size ret;
+    xmlSecOpenSSLSizeT ret;
     xmlSecSize res;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), 0);
@@ -371,7 +371,7 @@ xmlSecOpenSSLKeyDataX509GetCertsSize(xmlSecKeyDataPtr data) {
     }
 
     ret = sk_X509_num(ctx->certsList);
-    XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(ret, res, return(0), NULL);
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_T_TO_SIZE(ret, res, return(0), NULL);
     return(res);
 }
 
@@ -387,7 +387,7 @@ xmlSecOpenSSLKeyDataX509GetCertsSize(xmlSecKeyDataPtr data) {
 int
 xmlSecOpenSSLKeyDataX509AdoptCrl(xmlSecKeyDataPtr data, X509_CRL* crl) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    xmlSecOpenSSLX509Size ret;
+    xmlSecOpenSSLSizeT ret;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), -1);
     xmlSecAssert2(crl != NULL, -1);
@@ -425,7 +425,7 @@ xmlSecOpenSSLKeyDataX509AdoptCrl(xmlSecKeyDataPtr data, X509_CRL* crl) {
 X509_CRL*
 xmlSecOpenSSLKeyDataX509GetCrl(xmlSecKeyDataPtr data, xmlSecSize pos) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    xmlSecOpenSSLX509Size iPos;
+    xmlSecOpenSSLSizeT iPos;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), NULL);
 
@@ -434,7 +434,7 @@ xmlSecOpenSSLKeyDataX509GetCrl(xmlSecKeyDataPtr data, xmlSecSize pos) {
 
     xmlSecAssert2(ctx->crlsList != NULL, NULL);
 
-    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(pos, iPos, return(NULL), NULL);
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_SIZE_T(pos, iPos, return(NULL), NULL);
     xmlSecAssert2(iPos < sk_X509_CRL_num(ctx->crlsList), NULL);
     return(sk_X509_CRL_value(ctx->crlsList, iPos));
 }
@@ -450,7 +450,7 @@ xmlSecOpenSSLKeyDataX509GetCrl(xmlSecKeyDataPtr data, xmlSecSize pos) {
 xmlSecSize
 xmlSecOpenSSLKeyDataX509GetCrlsSize(xmlSecKeyDataPtr data) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    xmlSecOpenSSLX509Size ret;
+    xmlSecOpenSSLSizeT ret;
     xmlSecSize res;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), 0);
@@ -463,7 +463,7 @@ xmlSecOpenSSLKeyDataX509GetCrlsSize(xmlSecKeyDataPtr data) {
     }
 
     ret = sk_X509_CRL_num(ctx->crlsList);
-    XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(ret, res, return(0), NULL);
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_T_TO_SIZE(ret, res, return(0), NULL);
     return(res);
 }
 
@@ -553,10 +553,10 @@ xmlSecOpenSSLKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             return(-1);
         }
 #else /* XMLSEC_OPENSSL_NO_DEEP_COPY */
-        xmlSecOpenSSLX509Size size, ii;
+        xmlSecOpenSSLSizeT size, ii;
         X509* certSrc;
         X509* certDst;
-        xmlSecOpenSSLX509Size ret;
+        xmlSecOpenSSLSizeT ret;
 
         ctxDst->certsList = sk_X509_new_null();
         if(ctxDst->certsList == NULL) {
@@ -597,10 +597,10 @@ xmlSecOpenSSLKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             return(-1);
         }
 #else /* XMLSEC_OPENSSL_NO_DEEP_COPY */
-        xmlSecOpenSSLX509Size size, ii;
+        xmlSecOpenSSLSizeT size, ii;
         X509_CRL* crlSrc;
         X509_CRL* crlDst;
-        xmlSecOpenSSLX509Size ret;
+        xmlSecOpenSSLSizeT ret;
 
         ctxDst->crlsList = sk_X509_CRL_new_null();
         if(ctxDst->crlsList == NULL) {
@@ -630,7 +630,7 @@ xmlSecOpenSSLKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
 
     /* keyCert: should be in the same position in certsList after copy */
     if(ctxSrc->keyCert != NULL) {
-        xmlSecOpenSSLX509Size ii, len;
+        xmlSecOpenSSLSizeT ii, len;
 
         len = sk_X509_num(ctxSrc->certsList);
         xmlSecAssert2(len == sk_X509_num(ctxDst->certsList), -1);

--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -211,7 +211,7 @@ xmlSecOpenSSLKeyDataX509GetKeyCert(xmlSecKeyDataPtr data) {
 static int
 xmlSecOpenSSLKeyDataX509AddCertInternal(xmlSecOpenSSLX509DataCtxPtr ctx, X509* cert, int keyCert) {
     X509* dup;
-    int ret;
+    xmlSecOpenSSLX509Size ret;
 
     xmlSecAssert2(ctx != NULL, -1);
     xmlSecAssert2(cert != NULL, -1);
@@ -332,7 +332,7 @@ xmlSecOpenSSLKeyDataX509AdoptCert(xmlSecKeyDataPtr data, X509* cert) {
 X509*
 xmlSecOpenSSLKeyDataX509GetCert(xmlSecKeyDataPtr data, xmlSecSize pos) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    int iPos;
+    xmlSecOpenSSLX509Size iPos;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), NULL);
 
@@ -342,7 +342,7 @@ xmlSecOpenSSLKeyDataX509GetCert(xmlSecKeyDataPtr data, xmlSecSize pos) {
 
     /* to ensure that key cert is always first we put it at the first position
      * in xmlSecOpenSSLKeyDataX509AddCertInternal */
-    XMLSEC_SAFE_CAST_SIZE_TO_INT(pos, iPos, return(NULL), NULL);
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(pos, iPos, return(NULL), NULL);
     xmlSecAssert2(iPos < sk_X509_num(ctx->certsList), NULL);
     return(sk_X509_value(ctx->certsList, iPos));
 }
@@ -358,7 +358,7 @@ xmlSecOpenSSLKeyDataX509GetCert(xmlSecKeyDataPtr data, xmlSecSize pos) {
 xmlSecSize
 xmlSecOpenSSLKeyDataX509GetCertsSize(xmlSecKeyDataPtr data) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    int ret;
+    xmlSecOpenSSLX509Size ret;
     xmlSecSize res;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), 0);
@@ -371,12 +371,7 @@ xmlSecOpenSSLKeyDataX509GetCertsSize(xmlSecKeyDataPtr data) {
     }
 
     ret = sk_X509_num(ctx->certsList);
-    if(ret < 0) {
-        xmlSecOpenSSLError("sk_X509_num", NULL);
-        return(0);
-    }
-    XMLSEC_SAFE_CAST_INT_TO_SIZE(ret, res, return(0), NULL);
-
+    XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(ret, res, return(0), NULL);
     return(res);
 }
 
@@ -392,7 +387,7 @@ xmlSecOpenSSLKeyDataX509GetCertsSize(xmlSecKeyDataPtr data) {
 int
 xmlSecOpenSSLKeyDataX509AdoptCrl(xmlSecKeyDataPtr data, X509_CRL* crl) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    int ret;
+    xmlSecOpenSSLX509Size ret;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), -1);
     xmlSecAssert2(crl != NULL, -1);
@@ -430,7 +425,7 @@ xmlSecOpenSSLKeyDataX509AdoptCrl(xmlSecKeyDataPtr data, X509_CRL* crl) {
 X509_CRL*
 xmlSecOpenSSLKeyDataX509GetCrl(xmlSecKeyDataPtr data, xmlSecSize pos) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    int iPos;
+    xmlSecOpenSSLX509Size iPos;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), NULL);
 
@@ -439,7 +434,7 @@ xmlSecOpenSSLKeyDataX509GetCrl(xmlSecKeyDataPtr data, xmlSecSize pos) {
 
     xmlSecAssert2(ctx->crlsList != NULL, NULL);
 
-    XMLSEC_SAFE_CAST_SIZE_TO_INT(pos, iPos, return(NULL), NULL);
+    XMLSEC_OPENSSL_SAFE_CAST_SIZE_TO_X509_SIZE(pos, iPos, return(NULL), NULL);
     xmlSecAssert2(iPos < sk_X509_CRL_num(ctx->crlsList), NULL);
     return(sk_X509_CRL_value(ctx->crlsList, iPos));
 }
@@ -455,7 +450,7 @@ xmlSecOpenSSLKeyDataX509GetCrl(xmlSecKeyDataPtr data, xmlSecSize pos) {
 xmlSecSize
 xmlSecOpenSSLKeyDataX509GetCrlsSize(xmlSecKeyDataPtr data) {
     xmlSecOpenSSLX509DataCtxPtr ctx;
-    int ret;
+    xmlSecOpenSSLX509Size ret;
     xmlSecSize res;
 
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecOpenSSLKeyDataX509Id), 0);
@@ -468,12 +463,7 @@ xmlSecOpenSSLKeyDataX509GetCrlsSize(xmlSecKeyDataPtr data) {
     }
 
     ret = sk_X509_CRL_num(ctx->crlsList);
-    if(ret < 0) {
-        xmlSecOpenSSLError("sk_X509_CRL_num", NULL);
-        return(0);
-    }
-    XMLSEC_SAFE_CAST_INT_TO_SIZE(ret, res, return(0), NULL);
-
+    XMLSEC_OPENSSL_SAFE_CAST_X509_SIZE_TO_SIZE(ret, res, return(0), NULL);
     return(res);
 }
 
@@ -563,10 +553,10 @@ xmlSecOpenSSLKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             return(-1);
         }
 #else /* XMLSEC_OPENSSL_NO_DEEP_COPY */
-        int size, ii;
+        xmlSecOpenSSLX509Size size, ii;
         X509* certSrc;
         X509* certDst;
-        int ret;
+        xmlSecOpenSSLX509Size ret;
 
         ctxDst->certsList = sk_X509_new_null();
         if(ctxDst->certsList == NULL) {
@@ -607,10 +597,10 @@ xmlSecOpenSSLKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
             return(-1);
         }
 #else /* XMLSEC_OPENSSL_NO_DEEP_COPY */
-        int size, ii;
+        xmlSecOpenSSLX509Size size, ii;
         X509_CRL* crlSrc;
         X509_CRL* crlDst;
-        int ret;
+        xmlSecOpenSSLX509Size ret;
 
         ctxDst->crlsList = sk_X509_CRL_new_null();
         if(ctxDst->crlsList == NULL) {
@@ -640,7 +630,7 @@ xmlSecOpenSSLKeyDataX509Duplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
 
     /* keyCert: should be in the same position in certsList after copy */
     if(ctxSrc->keyCert != NULL) {
-        int ii, len;
+        xmlSecOpenSSLX509Size ii, len;
 
         len = sk_X509_num(ctxSrc->certsList);
         xmlSecAssert2(len == sk_X509_num(ctxDst->certsList), -1);
@@ -949,7 +939,7 @@ xmlSecOpenSSLX509CertDerWrite(X509* cert, xmlSecBufferPtr buf) {
         goto done;
     }
 
-    len = BIO_get_mem_data(mem, &data);
+    len = BIO_get_mem_data(mem, (char**)&data);
     if((len <= 0) || (data == NULL)){
         xmlSecOpenSSLError("BIO_get_mem_data", NULL);
         goto done;
@@ -1001,7 +991,7 @@ xmlSecOpenSSLX509CrlDerWrite(X509_CRL* crl, xmlSecBufferPtr buf) {
         goto done;
     }
 
-    len = BIO_get_mem_data(mem, &data);
+    len = BIO_get_mem_data(mem, (char**)&data);
     if((len <= 0) || (data == NULL)){
         xmlSecOpenSSLError("BIO_get_mem_data", NULL);
         goto done;

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -186,7 +186,7 @@ xmlSecOpenSSLX509StoreFindCert_ex(xmlSecKeyDataStorePtr store,
 ) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
     xmlSecOpenSSLX509FindCertCtx findCertCtx;
-    xmlSecOpenSSLX509Size ii;
+    xmlSecOpenSSLSizeT ii;
     int ret;
     X509* res = NULL;
 
@@ -235,7 +235,7 @@ X509*
 xmlSecOpenSSLX509StoreFindCertByValue(xmlSecKeyDataStorePtr store, xmlSecKeyX509DataValuePtr x509Value) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
     xmlSecOpenSSLX509FindCertCtx findCertCtx;
-    xmlSecOpenSSLX509Size ii;
+    xmlSecOpenSSLSizeT ii;
     int ret;
     X509* res = NULL;
 
@@ -338,7 +338,7 @@ xmlSecOpenSSLX509StoreVerifyAndCopyCrls(X509_STORE* xst, X509_STORE_CTX* xsc, ST
     xmlSecKeyInfoCtx* keyInfoCtx
 ) {
     STACK_OF(X509_CRL)* verified_crls = NULL;
-    xmlSecOpenSSLX509Size ii, num, num2;
+    xmlSecOpenSSLSizeT ii, num, num2;
     int ret;
 
     xmlSecAssert2(xst != NULL, NULL);
@@ -402,7 +402,7 @@ xmlSecOpenSSLX509StoreVerifyCertAgainstRevoked(X509 * cert, STACK_OF(X509_REVOKE
     X509_REVOKED * revoked_cert;
     const ASN1_INTEGER * revoked_cert_serial;
     const ASN1_INTEGER * cert_serial;
-    xmlSecOpenSSLX509Size ii, num;
+    xmlSecOpenSSLSizeT ii, num;
     int ret;
 
     xmlSecAssert2(cert != NULL, -1);
@@ -488,7 +488,7 @@ xmlSecOpenSSLX509StoreFindBestCrl(X509_NAME *cert_issuer, STACK_OF(X509_CRL) *cr
     X509_NAME *crl_issuer;
     const ASN1_TIME * lastUpdate;
     time_t resLastUpdateTime = 0;
-    xmlSecOpenSSLX509Size ii, num;
+    xmlSecOpenSSLSizeT ii, num;
     int ret;
 
     xmlSecAssert2(cert_issuer != NULL, -1);
@@ -616,7 +616,7 @@ xmlSecOpenSSLX509StoreVerifyCertAgainstCrls(STACK_OF(X509_CRL) *crls, X509* cert
 static int
 xmlSecOpenSSLX509StoreVerifyCertsAgainstCrls(STACK_OF(X509)* chain, STACK_OF(X509_CRL)* crls, xmlSecKeyInfoCtx* keyInfoCtx) {
     X509 * cert;
-    xmlSecOpenSSLX509Size ii, num_certs;
+    xmlSecOpenSSLSizeT ii, num_certs;
     int ret;
 
     xmlSecAssert2(chain != NULL, -1);
@@ -824,7 +824,7 @@ xmlSecOpenSSLX509StoreVerify(xmlSecKeyDataStorePtr store, XMLSEC_STACK_OF_X509* 
     X509 * res = NULL;
     X509 * cert;
     X509_STORE_CTX *xsc = NULL;
-    xmlSecOpenSSLX509Size ii, num;
+    xmlSecOpenSSLSizeT ii, num;
     int ret;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecOpenSSLX509StoreId), NULL);
@@ -1040,7 +1040,7 @@ xmlSecOpenSSLX509StoreAdoptCert(xmlSecKeyDataStorePtr store, X509* cert, xmlSecK
         /* add cert increments the reference */
         X509_free(cert);
     } else {
-        xmlSecOpenSSLX509Size ret;
+        xmlSecOpenSSLSizeT ret;
 
         xmlSecAssert2(ctx->untrusted != NULL, -1);
 
@@ -1065,7 +1065,7 @@ xmlSecOpenSSLX509StoreAdoptCert(xmlSecKeyDataStorePtr store, X509* cert, xmlSecK
 int
 xmlSecOpenSSLX509StoreAdoptCrl(xmlSecKeyDataStorePtr store, X509_CRL* crl) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
-    xmlSecOpenSSLX509Size ret;
+    xmlSecOpenSSLSizeT ret;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecOpenSSLX509StoreId), -1);
     xmlSecAssert2(crl != NULL, -1);
@@ -1693,8 +1693,8 @@ xmlSecOpenSSLX509StoreCombineCerts(STACK_OF(X509)* certs1, STACK_OF(X509)* certs
         }
     } else if(certs2 != NULL) {
         X509 * cert;
-        xmlSecOpenSSLX509Size ii, num;
-        xmlSecOpenSSLX509Size ret;
+        xmlSecOpenSSLSizeT ii, num;
+        xmlSecOpenSSLSizeT ret;
 
         /* append certs2 to result */
         num = sk_X509_num(certs2);
@@ -1730,7 +1730,7 @@ static X509*
 xmlSecOpenSSLX509FindChildCert(STACK_OF(X509) *chain, X509 *cert) {
     unsigned long certNameHash;
     unsigned long certNameHash2;
-    xmlSecOpenSSLX509Size ii;
+    xmlSecOpenSSLSizeT ii;
 
     xmlSecAssert2(chain != NULL, NULL);
     xmlSecAssert2(cert != NULL, NULL);
@@ -1970,7 +1970,7 @@ static STACK_OF(X509_NAME_ENTRY)*
 xmlSecOpenSSLX509_NAME_ENTRIES_copy(X509_NAME * a) {
     STACK_OF(X509_NAME_ENTRY) * res = NULL;
     int ii;
-    xmlSecOpenSSLX509Size ret;
+    xmlSecOpenSSLSizeT ret;
 
     res = sk_X509_NAME_ENTRY_new(xmlSecOpenSSLX509_NAME_ENTRY_cmp);
     if(res == NULL) {
@@ -1994,8 +1994,8 @@ static
 int xmlSecOpenSSLX509_NAME_ENTRIES_cmp(STACK_OF(X509_NAME_ENTRY)* a,  STACK_OF(X509_NAME_ENTRY)* b) {
     const X509_NAME_ENTRY *na;
     const X509_NAME_ENTRY *nb;
-    xmlSecOpenSSLX509Size ii;
-    xmlSecOpenSSLX509Size num_a, num_b;
+    xmlSecOpenSSLSizeT ii;
+    xmlSecOpenSSLSizeT num_a, num_b;
     int ret;
 
     xmlSecAssert2(a != NULL, -1);

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -2004,9 +2004,9 @@ int xmlSecOpenSSLX509_NAME_ENTRIES_cmp(STACK_OF(X509_NAME_ENTRY)* a,  STACK_OF(X
     num_a = sk_X509_NAME_ENTRY_num(a);
     num_b = sk_X509_NAME_ENTRY_num(b);
     if (num_a > num_b) {
-        return(-1);
-    } else if (num_a < num_b) {
         return(1);
+    } else if (num_a < num_b) {
+        return(-1);
     }
 
     /* num_a == num_b */

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -45,12 +45,6 @@
 #include "openssl_compat.h"
 #include "private.h"
 
-#ifdef OPENSSL_IS_BORINGSSL
-typedef size_t x509_size_t;
-#else /* OPENSSL_IS_BORINGSSL */
-typedef int x509_size_t;
-#endif /* OPENSSL_IS_BORINGSSL */
-
 /**************************************************************************
  *
  * Internal OpenSSL X509 store CTX
@@ -192,7 +186,7 @@ xmlSecOpenSSLX509StoreFindCert_ex(xmlSecKeyDataStorePtr store,
 ) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
     xmlSecOpenSSLX509FindCertCtx findCertCtx;
-    x509_size_t ii;
+    xmlSecOpenSSLX509Size ii;
     int ret;
     X509* res = NULL;
 
@@ -241,7 +235,7 @@ X509*
 xmlSecOpenSSLX509StoreFindCertByValue(xmlSecKeyDataStorePtr store, xmlSecKeyX509DataValuePtr x509Value) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
     xmlSecOpenSSLX509FindCertCtx findCertCtx;
-    x509_size_t ii;
+    xmlSecOpenSSLX509Size ii;
     int ret;
     X509* res = NULL;
 
@@ -344,7 +338,7 @@ xmlSecOpenSSLX509StoreVerifyAndCopyCrls(X509_STORE* xst, X509_STORE_CTX* xsc, ST
     xmlSecKeyInfoCtx* keyInfoCtx
 ) {
     STACK_OF(X509_CRL)* verified_crls = NULL;
-    x509_size_t ii, num;
+    xmlSecOpenSSLX509Size ii, num, num2;
     int ret;
 
     xmlSecAssert2(xst != NULL, NULL);
@@ -391,8 +385,8 @@ xmlSecOpenSSLX509StoreVerifyAndCopyCrls(X509_STORE* xst, X509_STORE_CTX* xsc, ST
         }
         /* dont duplicate or up_ref the crl since we own
          * pointer to it */
-        ret = sk_X509_CRL_push(verified_crls, crl);
-        if(ret <= 0) {
+        num2 = sk_X509_CRL_push(verified_crls, crl);
+        if(num2 <= 0) {
             xmlSecOpenSSLError("sk_X509_CRL_push", NULL);
             sk_X509_CRL_free(verified_crls);
             return(NULL);
@@ -408,7 +402,7 @@ xmlSecOpenSSLX509StoreVerifyCertAgainstRevoked(X509 * cert, STACK_OF(X509_REVOKE
     X509_REVOKED * revoked_cert;
     const ASN1_INTEGER * revoked_cert_serial;
     const ASN1_INTEGER * cert_serial;
-    x509_size_t ii, num;
+    xmlSecOpenSSLX509Size ii, num;
     int ret;
 
     xmlSecAssert2(cert != NULL, -1);
@@ -494,7 +488,7 @@ xmlSecOpenSSLX509StoreFindBestCrl(X509_NAME *cert_issuer, STACK_OF(X509_CRL) *cr
     X509_NAME *crl_issuer;
     const ASN1_TIME * lastUpdate;
     time_t resLastUpdateTime = 0;
-    x509_size_t ii, num;
+    xmlSecOpenSSLX509Size ii, num;
     int ret;
 
     xmlSecAssert2(cert_issuer != NULL, -1);
@@ -622,7 +616,7 @@ xmlSecOpenSSLX509StoreVerifyCertAgainstCrls(STACK_OF(X509_CRL) *crls, X509* cert
 static int
 xmlSecOpenSSLX509StoreVerifyCertsAgainstCrls(STACK_OF(X509)* chain, STACK_OF(X509_CRL)* crls, xmlSecKeyInfoCtx* keyInfoCtx) {
     X509 * cert;
-    x509_size_t ii, num_certs;
+    xmlSecOpenSSLX509Size ii, num_certs;
     int ret;
 
     xmlSecAssert2(chain != NULL, -1);
@@ -830,7 +824,7 @@ xmlSecOpenSSLX509StoreVerify(xmlSecKeyDataStorePtr store, XMLSEC_STACK_OF_X509* 
     X509 * res = NULL;
     X509 * cert;
     X509_STORE_CTX *xsc = NULL;
-    x509_size_t ii, num;
+    xmlSecOpenSSLX509Size ii, num;
     int ret;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecOpenSSLX509StoreId), NULL);
@@ -1025,7 +1019,6 @@ done:
 int
 xmlSecOpenSSLX509StoreAdoptCert(xmlSecKeyDataStorePtr store, X509* cert, xmlSecKeyDataType type) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
-    int ret;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecOpenSSLX509StoreId), -1);
     xmlSecAssert2(cert != NULL, -1);
@@ -1034,6 +1027,8 @@ xmlSecOpenSSLX509StoreAdoptCert(xmlSecKeyDataStorePtr store, X509* cert, xmlSecK
     xmlSecAssert2(ctx != NULL, -1);
 
     if((type & xmlSecKeyDataTypeTrusted) != 0) {
+        int ret;
+
         xmlSecAssert2(ctx->xst != NULL, -1);
 
         ret = X509_STORE_add_cert(ctx->xst, cert);
@@ -1045,6 +1040,8 @@ xmlSecOpenSSLX509StoreAdoptCert(xmlSecKeyDataStorePtr store, X509* cert, xmlSecK
         /* add cert increments the reference */
         X509_free(cert);
     } else {
+        xmlSecOpenSSLX509Size ret;
+
         xmlSecAssert2(ctx->untrusted != NULL, -1);
 
         ret = sk_X509_push(ctx->untrusted, cert);
@@ -1068,7 +1065,7 @@ xmlSecOpenSSLX509StoreAdoptCert(xmlSecKeyDataStorePtr store, X509* cert, xmlSecK
 int
 xmlSecOpenSSLX509StoreAdoptCrl(xmlSecKeyDataStorePtr store, X509_CRL* crl) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
-    int ret;
+    xmlSecOpenSSLX509Size ret;
 
     xmlSecAssert2(xmlSecKeyDataStoreCheckId(store, xmlSecOpenSSLX509StoreId), -1);
     xmlSecAssert2(crl != NULL, -1);
@@ -1696,8 +1693,8 @@ xmlSecOpenSSLX509StoreCombineCerts(STACK_OF(X509)* certs1, STACK_OF(X509)* certs
         }
     } else if(certs2 != NULL) {
         X509 * cert;
-        x509_size_t ii, num;
-        int ret;
+        xmlSecOpenSSLX509Size ii, num;
+        xmlSecOpenSSLX509Size ret;
 
         /* append certs2 to result */
         num = sk_X509_num(certs2);
@@ -1733,7 +1730,7 @@ static X509*
 xmlSecOpenSSLX509FindChildCert(STACK_OF(X509) *chain, X509 *cert) {
     unsigned long certNameHash;
     unsigned long certNameHash2;
-    x509_size_t ii;
+    xmlSecOpenSSLX509Size ii;
 
     xmlSecAssert2(chain != NULL, NULL);
     xmlSecAssert2(cert != NULL, NULL);
@@ -1973,7 +1970,7 @@ static STACK_OF(X509_NAME_ENTRY)*
 xmlSecOpenSSLX509_NAME_ENTRIES_copy(X509_NAME * a) {
     STACK_OF(X509_NAME_ENTRY) * res = NULL;
     int ii;
-    int ret;
+    xmlSecOpenSSLX509Size ret;
 
     res = sk_X509_NAME_ENTRY_new(xmlSecOpenSSLX509_NAME_ENTRY_cmp);
     if(res == NULL) {
@@ -1997,16 +1994,23 @@ static
 int xmlSecOpenSSLX509_NAME_ENTRIES_cmp(STACK_OF(X509_NAME_ENTRY)* a,  STACK_OF(X509_NAME_ENTRY)* b) {
     const X509_NAME_ENTRY *na;
     const X509_NAME_ENTRY *nb;
-    int ii, ret;
+    xmlSecOpenSSLX509Size ii;
+    xmlSecOpenSSLX509Size num_a, num_b;
+    int ret;
 
     xmlSecAssert2(a != NULL, -1);
     xmlSecAssert2(b != NULL, 1);
 
-    if (sk_X509_NAME_ENTRY_num(a) != sk_X509_NAME_ENTRY_num(b)) {
-        return sk_X509_NAME_ENTRY_num(a) - sk_X509_NAME_ENTRY_num(b);
+    num_a = sk_X509_NAME_ENTRY_num(a);
+    num_b = sk_X509_NAME_ENTRY_num(b);
+    if (num_a > num_b) {
+        return(-1);
+    } else if (num_a < num_b) {
+        return(1);
     }
 
-    for (ii = sk_X509_NAME_ENTRY_num(a) - 1; ii >= 0; --ii) {
+    /* num_a == num_b */
+    for (ii = 0; ii < num_a; ++ii) {
         na = sk_X509_NAME_ENTRY_value(a, ii);
         nb = sk_X509_NAME_ENTRY_value(b, ii);
 


### PR DESCRIPTION
@haproxyFred the original patches broke BoringSSL build. I also feel this is a bit more readable. The remaining casts could be done the same way too (I will do it in another patch). This builds cleanly for me on OpenSSL/BoringSSL/AWS-LC. Can you check that this works for you too?