### PR TITLE
(xmlsec-core) Rename ATTRIBUTE_UNUSED to XMLSEC_ATTRIBUTE_UNUSED and fix includes

### DIFF
--- a/include/xmlsec/private.h
+++ b/include/xmlsec/private.h
@@ -650,17 +650,17 @@ struct _xmlSecCryptoDLFunctions {
 };
 
 /**
- * ATTRIBUTE_UNUSED:
+ * XMLSEC_ATTRIBUTE_UNUSED:
  *
- * Macro used to signal to GCC unused function parameters
+ * Macro used to signal unused function parameters
  */
-#ifndef ATTRIBUTE_UNUSED
-#ifdef __GNUC__
-#define ATTRIBUTE_UNUSED __attribute__((unused))
-#else  /* __GNUC__ */
-#define ATTRIBUTE_UNUSED
-#endif /* __GNUC__ */
-#endif  /* ATTRIBUTE_UNUSED */
+#ifndef XMLSEC_ATTRIBUTE_UNUSED
+#if defined(__GNUC__) || defined(__clang__)
+#define XMLSEC_ATTRIBUTE_UNUSED __attribute__((unused))
+#else  /*  defined(__GNUC__) || defined(__clang__) */
+#define XMLSEC_ATTRIBUTE_UNUSED
+#endif /*  defined(__GNUC__) || defined(__clang__) */
+#endif  /* XMLSEC_ATTRIBUTE_UNUSED */
 
 /**
  * UNREFERENCED_PARAMETER:

--- a/src/gcrypt/app.c
+++ b/src/gcrypt/app.c
@@ -23,8 +23,8 @@
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/gcrypt/app.h>
 #include <xmlsec/gcrypt/crypto.h>
@@ -43,7 +43,7 @@
  * Returns: 0 on success or a negative value otherwise.
  */
 int
-xmlSecGCryptAppInit(const char* config ATTRIBUTE_UNUSED) {
+xmlSecGCryptAppInit(const char* config XMLSEC_ATTRIBUTE_UNUSED) {
     gcry_error_t err;
     /* Secure memory initialisation based on documentation from:
          http://www.gnupg.org/documentation/manuals/gcrypt/Initializing-the-library.html
@@ -161,7 +161,7 @@ xmlSecGCryptAppShutdown(void) {
  * Returns: pointer to the key or NULL if an error occurs.
  */
 xmlSecKeyPtr
-xmlSecGCryptAppKeyLoadEx(const char *filename, xmlSecKeyDataType type ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
+xmlSecGCryptAppKeyLoadEx(const char *filename, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
     const char *pwd, void* pwdCallback, void* pwdCallbackCtx
 ) {
     xmlSecKeyPtr key;
@@ -217,9 +217,9 @@ xmlSecGCryptAppKeyLoadEx(const char *filename, xmlSecKeyDataType type ATTRIBUTE_
 xmlSecKeyPtr
 xmlSecGCryptAppKeyLoadMemory(const xmlSecByte* data, xmlSecSize dataSize,
                         xmlSecKeyDataFormat format,
-                        const char *pwd ATTRIBUTE_UNUSED,
-                        void* pwdCallback ATTRIBUTE_UNUSED,
-                        void* pwdCallbackCtx ATTRIBUTE_UNUSED)
+                        const char *pwd XMLSEC_ATTRIBUTE_UNUSED,
+                        void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                        void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED)
 {
     xmlSecKeyPtr key = NULL;
     xmlSecKeyDataPtr key_data = NULL;
@@ -342,9 +342,9 @@ xmlSecGCryptAppKeyCertLoadMemory(xmlSecKeyPtr key,
  */
 xmlSecKeyPtr
 xmlSecGCryptAppPkcs12Load(const char *filename,
-                          const char *pwd ATTRIBUTE_UNUSED,
-                          void* pwdCallback ATTRIBUTE_UNUSED,
-                          void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                          const char *pwd XMLSEC_ATTRIBUTE_UNUSED,
+                          void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                          void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(filename != NULL, NULL);
 
     /* GCrypt  does not support X509 certificates */
@@ -370,9 +370,9 @@ xmlSecGCryptAppPkcs12Load(const char *filename,
  */
 xmlSecKeyPtr
 xmlSecGCryptAppPkcs12LoadMemory(const xmlSecByte* data, xmlSecSize dataSize,
-                           const char *pwd ATTRIBUTE_UNUSED,
-                           void* pwdCallback ATTRIBUTE_UNUSED,
-                           void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                           const char *pwd XMLSEC_ATTRIBUTE_UNUSED,
+                           void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                           void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(data != NULL, NULL);
     xmlSecAssert2(dataSize > 0, NULL);
 
@@ -400,7 +400,7 @@ int
 xmlSecGCryptAppKeysMngrCertLoad(xmlSecKeysMngrPtr mngr,
                                 const char *filename,
                                 xmlSecKeyDataFormat format,
-                                xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+                                xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(mngr != NULL, -1);
     xmlSecAssert2(filename != NULL, -1);
     xmlSecAssert2(format != xmlSecKeyDataFormatUnknown, -1);
@@ -453,7 +453,7 @@ xmlSecGCryptAppKeysMngrCertLoadMemory(xmlSecKeysMngrPtr mngr,
                                       const xmlSecByte* data,
                                       xmlSecSize dataSize,
                                       xmlSecKeyDataFormat format,
-                                      xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+                                      xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(mngr != NULL, -1);
     xmlSecAssert2(data != NULL, -1);
     xmlSecAssert2(dataSize > 0, -1);

--- a/src/gcrypt/asymkeys.c
+++ b/src/gcrypt/asymkeys.c
@@ -734,7 +734,7 @@ xmlSecGCryptKeyDataDsaFinalize(xmlSecKeyDataPtr data) {
 }
 
 static int
-xmlSecGCryptKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecGCryptKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecGCryptKeyDataDsaId), -1);
     xmlSecAssert2(sizeBits > 0, -1);
 
@@ -1248,7 +1248,7 @@ xmlSecGCryptKeyDataRsaFinalize(xmlSecKeyDataPtr data) {
 }
 
 static int
-xmlSecGCryptKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecGCryptKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecGCryptKeyDataRsaId), -1);
     xmlSecAssert2(sizeBits > 0, -1);
 

--- a/src/gcrypt/hmac.c
+++ b/src/gcrypt/hmac.c
@@ -211,7 +211,7 @@ xmlSecGCryptHmacFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecGCryptHmacNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                         xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                         xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptHmacCtxPtr ctx;
     int ret;
 
@@ -299,7 +299,7 @@ xmlSecGCryptHmacSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 static int
 xmlSecGCryptHmacVerify(xmlSecTransformPtr transform,
                         const xmlSecByte* data, xmlSecSize dataSize,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptHmacCtxPtr ctx;
     int ret;
 

--- a/src/gcrypt/kt_rsa.c
+++ b/src/gcrypt/kt_rsa.c
@@ -442,7 +442,7 @@ done:
 
 static int
 xmlSecGCryptRsaPkcs1Execute(xmlSecTransformPtr transform, int last,
-                             xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                             xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptRsaPkcs1CtxPtr ctx;
     int ret;
 
@@ -668,7 +668,7 @@ xmlSecGCryptRsaOaepFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecGCryptRsaOaepNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                            xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                            xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptRsaOaepCtxPtr ctx;
     xmlSecTransformRsaOaepParams oaepParams;
     const char* mgf1Alg = NULL;
@@ -1011,7 +1011,7 @@ done:
 
 static int
 xmlSecGCryptRsaOaepExecute(xmlSecTransformPtr transform, int last,
-                             xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                             xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptRsaOaepCtxPtr ctx;
     int ret;
 

--- a/src/gcrypt/kw_aes.c
+++ b/src/gcrypt/kw_aes.c
@@ -204,7 +204,7 @@ xmlSecGCryptKWAesSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecGCryptKWAesExecute(xmlSecTransformPtr transform, int last,
-                         xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                         xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptKWAesCtxPtr ctx;
     int ret;
 

--- a/src/gcrypt/kw_des.c
+++ b/src/gcrypt/kw_des.c
@@ -229,7 +229,7 @@ xmlSecGCryptKWDes3SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecGCryptKWDes3Execute(xmlSecTransformPtr transform, int last,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGCryptKWDes3CtxPtr ctx;
     int ret;
 
@@ -309,7 +309,7 @@ xmlSecGCryptKWDes3Sha1(xmlSecTransformPtr transform,
 }
 
 static int
-xmlSecGCryptKWDes3GenerateRandom(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
+xmlSecGCryptKWDes3GenerateRandom(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED,
                                  xmlSecByte * out, xmlSecSize outSize,
                                  xmlSecSize * outWritten) {
     UNREFERENCED_PARAMETER(transform);

--- a/src/gcrypt/signatures.c
+++ b/src/gcrypt/signatures.c
@@ -826,7 +826,7 @@ xmlSecGCryptAppendMpi(gcry_mpi_t a, xmlSecBufferPtr out, xmlSecSize min_size) {
 #define XMLSEC_GCRYPT_DSA_SIG_SIZE  20
 
 static int
-xmlSecGCryptDsaSign(int digest ATTRIBUTE_UNUSED, xmlSecKeyDataPtr key_data,
+xmlSecGCryptDsaSign(int digest XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataPtr key_data,
                       const xmlSecByte* dgst, xmlSecSize dgstSize,
                       xmlSecBufferPtr out) {
     gcry_mpi_t m_hash = NULL;
@@ -962,7 +962,7 @@ done:
 }
 
 static int
-xmlSecGCryptDsaVerify(int digest ATTRIBUTE_UNUSED, xmlSecKeyDataPtr key_data,
+xmlSecGCryptDsaVerify(int digest XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataPtr key_data,
                         const xmlSecByte* dgst, xmlSecSize dgstSize,
                         const xmlSecByte* data, xmlSecSize dataSize) {
     gcry_mpi_t m_hash = NULL;

--- a/src/gcrypt/symkeys.c
+++ b/src/gcrypt/symkeys.c
@@ -129,7 +129,7 @@ xmlSecGCryptSymKeyDataBinWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecGCryptSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecGCryptSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBufferPtr buffer;
 
     xmlSecAssert2(xmlSecGCryptSymKeyDataCheckId(data), -1);

--- a/src/gnutls/app.c
+++ b/src/gnutls/app.c
@@ -25,8 +25,8 @@
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/gnutls/app.h>
 #include <xmlsec/gnutls/crypto.h>
@@ -66,7 +66,7 @@ static xmlSecKeyPtr     xmlSecGnuTLSAppKeyFromCertLoadMemory    (const xmlSecByt
  * Returns: 0 on success or a negative value otherwise.
  */
 int
-xmlSecGnuTLSAppInit(const char* config ATTRIBUTE_UNUSED) {
+xmlSecGnuTLSAppInit(const char* config XMLSEC_ATTRIBUTE_UNUSED) {
     int err;
 
     err = gnutls_global_init();
@@ -107,7 +107,7 @@ xmlSecGnuTLSAppShutdown(void) {
  * Returns: pointer to the key or NULL if an error occurs.
  */
 xmlSecKeyPtr
-xmlSecGnuTLSAppKeyLoadEx(const char *filename, xmlSecKeyDataType type ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
+xmlSecGnuTLSAppKeyLoadEx(const char *filename, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
     const char *pwd, void* pwdCallback, void* pwdCallbackCtx
 ) {
     xmlSecKeyPtr key;
@@ -455,7 +455,7 @@ xmlSecGnuTLSAppPkcs12Load(const char *filename,
  */
 xmlSecKeyPtr
 xmlSecGnuTLSAppPkcs12LoadMemory(const xmlSecByte* data, xmlSecSize dataSize,
-    const char *pwd, void* pwdCallback ATTRIBUTE_UNUSED, void* pwdCallbackCtx ATTRIBUTE_UNUSED
+    const char *pwd, void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED, void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED
 ) {
     xmlSecKeyPtr key = NULL;
     xmlSecKeyPtr res = NULL;
@@ -704,7 +704,7 @@ xmlSecGnuTLSAppPemDerKeyLoadMemory(const xmlSecByte * data, xmlSecSize dataSize,
 
 static xmlSecKeyPtr
 xmlSecGnuTLSAppPkcs8KeyLoadMemory(const xmlSecByte * data, xmlSecSize dataSize, gnutls_x509_crt_fmt_t fmt,
-    const char *pwd, void* pwdCallback ATTRIBUTE_UNUSED, void* pwdCallbackCtx ATTRIBUTE_UNUSED)
+    const char *pwd, void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED, void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED)
 {
     gnutls_x509_privkey_t x509_privkey = NULL;
     gnutls_privkey_t privkey = NULL;

--- a/src/gnutls/asymkeys.c
+++ b/src/gnutls/asymkeys.c
@@ -882,7 +882,7 @@ xmlSecGnuTLSKeyDataDsaDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
 }
 
 static int
-xmlSecGnuTLSKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecGnuTLSKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecGnuTLSKeyDataDsaId), -1);
     xmlSecAssert2(sizeBits > 0, -1);
 
@@ -1875,7 +1875,7 @@ xmlSecGnuTLSKeyDataRsaDuplicate(xmlSecKeyDataPtr dst, xmlSecKeyDataPtr src) {
 }
 
 static int
-xmlSecGnuTLSKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecGnuTLSKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecAssert2(xmlSecKeyDataCheckId(data, xmlSecGnuTLSKeyDataRsaId), -1);
     xmlSecAssert2(sizeBits > 0, -1);
 

--- a/src/gnutls/hmac.c
+++ b/src/gnutls/hmac.c
@@ -24,8 +24,8 @@
 #include <xmlsec/xmlsec.h>
 #include <xmlsec/errors.h>
 #include <xmlsec/keys.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/gnutls/app.h>
 #include <xmlsec/gnutls/crypto.h>
@@ -181,7 +181,7 @@ xmlSecGnuTLSHmacFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecGnuTLSHmacNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                      xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                      xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGnuTLSHmacCtxPtr ctx;
     int ret;
 
@@ -271,7 +271,7 @@ xmlSecGnuTLSHmacSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 static int
 xmlSecGnuTLSHmacVerify(xmlSecTransformPtr transform,
                         const xmlSecByte* data, xmlSecSize dataSize,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGnuTLSHmacCtxPtr ctx;
     int ret;
 

--- a/src/gnutls/keysstore.c
+++ b/src/gnutls/keysstore.c
@@ -208,7 +208,7 @@ xmlSecGnuTLSKeysStoreAdoptKey(xmlSecKeyStorePtr store, xmlSecKeyPtr key) {
  */
 int
 xmlSecGnuTLSKeysStoreLoad(xmlSecKeyStorePtr store, const char *uri,
-                            xmlSecKeysMngrPtr keysMngr ATTRIBUTE_UNUSED) {
+                            xmlSecKeysMngrPtr keysMngr XMLSEC_ATTRIBUTE_UNUSED) {
     return(xmlSecSimpleKeysStoreLoad_ex(store, uri, keysMngr,
         xmlSecGnuTLSKeysStoreAdoptKey));
 }

--- a/src/gnutls/kw_aes.c
+++ b/src/gnutls/kw_aes.c
@@ -210,7 +210,7 @@ xmlSecGnuTLSKWAesSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecGnuTLSKWAesExecute(xmlSecTransformPtr transform, int last,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGnuTLSKWAesCtxPtr ctx;
     int ret;
 

--- a/src/gnutls/kw_des.c
+++ b/src/gnutls/kw_des.c
@@ -229,7 +229,7 @@ xmlSecGnuTLSKWDes3SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecGnuTLSKWDes3Execute(xmlSecTransformPtr transform, int last,
-                           xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                           xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGnuTLSKWDes3CtxPtr ctx;
     int ret;
 

--- a/src/gnutls/pbkdf2.c
+++ b/src/gnutls/pbkdf2.c
@@ -30,8 +30,8 @@
 #include <xmlsec/base64.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
-#include <xmlsec/private.h>
 #include <xmlsec/xmltree.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/gnutls/crypto.h>
 
@@ -211,7 +211,7 @@ xmlSecGnuTLSPbkdf2GetMacFromHref(const xmlChar* href) {
 
 static int
 xmlSecGnuTLSPbkdf2NodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecGnuTLSPbkdf2CtxPtr ctx;
     xmlNodePtr cur;
     int ret;

--- a/src/gnutls/symkeys.c
+++ b/src/gnutls/symkeys.c
@@ -131,7 +131,7 @@ xmlSecGnuTLSSymKeyDataBinWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecGnuTLSSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecGnuTLSSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBufferPtr buffer;
 
     xmlSecAssert2(xmlSecGnuTLSSymKeyDataCheckId(data), -1);

--- a/src/keysmngr.c
+++ b/src/keysmngr.c
@@ -488,7 +488,7 @@ xmlSecSimpleKeysStoreEnableAllKeyData(xmlSecKeyInfoCtxPtr keyInfoCtx) {
  */
 int
 xmlSecSimpleKeysStoreLoad_ex(xmlSecKeyStorePtr store, const char *uri,
-                            xmlSecKeysMngrPtr keysMngr ATTRIBUTE_UNUSED,
+                            xmlSecKeysMngrPtr keysMngr XMLSEC_ATTRIBUTE_UNUSED,
                             xmlSecSimpleKeysStoreAdoptKeyFunc adoptKeyFunc) {
     xmlDocPtr doc;
     xmlNodePtr root;

--- a/src/mscng/app.c
+++ b/src/mscng/app.c
@@ -23,9 +23,9 @@
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
 #include <xmlsec/keysmngr.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/xmltree.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscng/app.h>
 #include <xmlsec/mscng/crypto.h>
@@ -120,7 +120,7 @@ xmlSecMSCngAppGetCertStoreName(void) {
  * Returns: pointer to the key or NULL if an error occurs.
  */
 xmlSecKeyPtr
-xmlSecMSCngAppKeyLoadEx(const char *filename, xmlSecKeyDataType type ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
+xmlSecMSCngAppKeyLoadEx(const char *filename, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
     const char *pwd, void* pwdCallback, void* pwdCallbackCtx
 ) {
     xmlSecBuffer buffer;

--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -933,7 +933,7 @@ done:
 static int
 xmlSecMSCngKeyDataDsaWrite(xmlSecKeyDataId id, xmlSecKeyDataPtr data,
                         xmlSecKeyValueDsaPtr dsaValue,
-                        int writePrivateKey ATTRIBUTE_UNUSED) {
+                        int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngKeyDataCtxPtr ctx;
     NTSTATUS status;
     xmlSecBuffer buf;
@@ -1375,7 +1375,7 @@ done:
 static int
 xmlSecMSCngKeyDataRsaWrite(xmlSecKeyDataId id, xmlSecKeyDataPtr data,
                            xmlSecKeyValueRsaPtr rsaValue,
-                           int writePrivateKey ATTRIBUTE_UNUSED) {
+                           int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngKeyDataCtxPtr ctx;
     NTSTATUS status;
     xmlSecBuffer buf;

--- a/src/mscng/concatkdf.c
+++ b/src/mscng/concatkdf.c
@@ -26,8 +26,8 @@
 #include <xmlsec/base64.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
-#include <xmlsec/private.h>
 #include <xmlsec/xmltree.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscng/crypto.h>
 
@@ -217,7 +217,7 @@ xmlSecMSCngConcatKdfGetDigestFromHref(const xmlChar* href) {
 
 static int
 xmlSecMSCngConcatKdfNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngConcatKdfCtxPtr ctx;
     xmlNodePtr cur;
     int ret;

--- a/src/mscng/hmac.c
+++ b/src/mscng/hmac.c
@@ -21,8 +21,8 @@
 #include <xmlsec/errors.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keyinfo.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscng/crypto.h>
 
@@ -165,7 +165,7 @@ xmlSecMSCngHmacFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecMSCngHmacNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngHmacCtxPtr ctx;
     int ret;
 
@@ -290,7 +290,7 @@ xmlSecMSCngHmacSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecMSCngHmacVerify(xmlSecTransformPtr transform, const xmlSecByte* data,
-        xmlSecSize dataSize, xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+        xmlSecSize dataSize, xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngHmacCtxPtr ctx;
     int ret;
 

--- a/src/mscng/kt_rsa.c
+++ b/src/mscng/kt_rsa.c
@@ -23,9 +23,9 @@
 #include <xmlsec/errors.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/keyinfo.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/xmltree.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscng/crypto.h>
 #include <xmlsec/mscng/certkeys.h>
@@ -384,7 +384,7 @@ xmlSecMSCngRsaPkcs1OaepProcess(xmlSecTransformPtr transform) {
 
 static int
 xmlSecMSCngRsaPkcs1OaepExecute(xmlSecTransformPtr transform, int last,
-                               xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                               xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngRsaPkcs1OaepCtxPtr ctx;
     int ret;
 
@@ -424,7 +424,7 @@ xmlSecMSCngRsaPkcs1OaepExecute(xmlSecTransformPtr transform, int last,
 
 static int
 xmlSecMSCngRsaOaepNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                           xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                           xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngRsaPkcs1OaepCtxPtr ctx;
     xmlSecTransformRsaOaepParams oaepParams;
     LPCWSTR mgf1AlgId = NULL;

--- a/src/mscng/kw_aes.c
+++ b/src/mscng/kw_aes.c
@@ -200,7 +200,7 @@ xmlSecMSCngKWAesSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecMSCngKWAesExecute(xmlSecTransformPtr transform, int last,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngKWAesCtxPtr ctx;
     int ret;
 

--- a/src/mscng/kw_des.c
+++ b/src/mscng/kw_des.c
@@ -48,7 +48,7 @@ XMLSEC_TRANSFORM_DECLARE(MSCngKWDes3, xmlSecMSCngKWDes3Ctx)
 #define xmlSecMSCngKWDes3Size XMLSEC_TRANSFORM_SIZE(MSCngKWDes3)
 
 static int
-xmlSecMSCngKWDes3GenerateRandom(xmlSecTransformPtr transform ATTRIBUTE_UNUSED, xmlSecByte * out,
+xmlSecMSCngKWDes3GenerateRandom(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED, xmlSecByte * out,
         xmlSecSize outSize, xmlSecSize* outWritten)
 {
     NTSTATUS status;
@@ -638,7 +638,7 @@ xmlSecMSCngKWDes3SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecMSCngKWDes3Execute(xmlSecTransformPtr transform, int last,
-                         xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                         xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngKWDes3CtxPtr ctx;
     int ret;
 

--- a/src/mscng/pbkdf2.c
+++ b/src/mscng/pbkdf2.c
@@ -26,8 +26,8 @@
 #include <xmlsec/base64.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
-#include <xmlsec/private.h>
 #include <xmlsec/xmltree.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscng/crypto.h>
 
@@ -211,7 +211,7 @@ xmlSecMSCngPbkdf2GetMacFromHref(const xmlChar* href) {
 
 static int
 xmlSecMSCngPbkdf2NodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngPbkdf2CtxPtr ctx;
     xmlNodePtr cur;
     int ret;

--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -1306,7 +1306,7 @@ PCCERT_CONTEXT
 xmlSecMSCngX509StoreFindCert_ex(xmlSecKeyDataStorePtr store, xmlChar* subjectName,
                                 xmlChar* issuerName, xmlChar* issuerSerial,
                                 xmlSecByte* ski, xmlSecSize skiSize,
-                                xmlSecKeyInfoCtx* keyInfoCtx ATTRIBUTE_UNUSED) {
+                                xmlSecKeyInfoCtx* keyInfoCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCngX509FindCertCtx findCertCtx;
     xmlSecMSCngX509StoreCtxPtr ctx;
     PCCERT_CONTEXT cert = NULL;

--- a/src/mscrypto/app.c
+++ b/src/mscrypto/app.c
@@ -24,9 +24,9 @@
 #include <xmlsec/keys.h>
 #include <xmlsec/errors.h>
 #include <xmlsec/keysdata.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/xmltree.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscrypto/app.h>
 #include <xmlsec/mscrypto/crypto.h>
@@ -133,7 +133,7 @@ xmlSecMSCryptoAppGetCertStoreName(void) {
  * Returns: pointer to the key or NULL if an error occurs.
  */
 xmlSecKeyPtr
-xmlSecMSCryptoAppKeyLoadEx(const char *filename, xmlSecKeyDataType type ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
+xmlSecMSCryptoAppKeyLoadEx(const char *filename, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
     const char *pwd, void* pwdCallback, void* pwdCallbackCtx
 ) {
     xmlSecBuffer buffer;
@@ -447,8 +447,8 @@ xmlSecMSCryptoAppKeyCertLoadMemory(xmlSecKeyPtr key, const xmlSecByte* data, xml
 xmlSecKeyPtr
 xmlSecMSCryptoAppPkcs12Load(const char *filename,
                             const char *pwd,
-                            void* pwdCallback ATTRIBUTE_UNUSED,
-                            void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                            void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                            void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBuffer buffer;
     xmlSecKeyPtr key;
     int ret;
@@ -504,8 +504,8 @@ xmlSecKeyPtr
 xmlSecMSCryptoAppPkcs12LoadMemory(const xmlSecByte* data,
                                   xmlSecSize dataSize,
                                   const char *pwd,
-                                  void* pwdCallback ATTRIBUTE_UNUSED,
-                                  void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                                  void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                                  void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     CRYPT_DATA_BLOB pfx;
     HCERTSTORE hCertStore = NULL;
     PCCERT_CONTEXT tmpcert = NULL;
@@ -688,7 +688,7 @@ done:
 int
 xmlSecMSCryptoAppKeysMngrCertLoad(xmlSecKeysMngrPtr mngr, const char *filename,
                                 xmlSecKeyDataFormat format,
-                                xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+                                xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBuffer buffer;
     int ret;
 

--- a/src/mscrypto/certkeys.c
+++ b/src/mscrypto/certkeys.c
@@ -1135,7 +1135,7 @@ xmlSecMSCryptoKeyDataRsaXmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 
 static int
 xmlSecMSCryptoKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits,
-                                xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+                                xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoKeyDataCtxPtr ctx;
     HCRYPTPROV hProv = 0;
     HCRYPTKEY hKey = 0;
@@ -1376,7 +1376,7 @@ done:
 
 static int
 xmlSecMSCryptoKeyDataRsaWrite(xmlSecKeyDataId id, xmlSecKeyDataPtr data,
-    xmlSecKeyValueRsaPtr rsaValue, int writePrivateKey ATTRIBUTE_UNUSED) {
+    xmlSecKeyValueRsaPtr rsaValue, int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED) {
 
     xmlSecMSCryptoKeyDataCtxPtr ctx;
     xmlSecBuffer buf;
@@ -1725,7 +1725,7 @@ xmlSecMSCryptoKeyDataDsaXmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecMSCryptoKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecMSCryptoKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoKeyDataCtxPtr ctx;
     HCRYPTPROV hProv = 0;
     HCRYPTKEY hKey = 0;
@@ -2006,7 +2006,7 @@ done:
 static int
 xmlSecMSCryptoKeyDataDsaWrite(xmlSecKeyDataId id, xmlSecKeyDataPtr data,
                               xmlSecKeyValueDsaPtr dsaValue,
-                              int writePrivateKey ATTRIBUTE_UNUSED)  {
+                              int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED)  {
     xmlSecMSCryptoKeyDataCtxPtr ctx;
     xmlSecBuffer buf;
     int bufInitialized = 0;

--- a/src/mscrypto/hmac.c
+++ b/src/mscrypto/hmac.c
@@ -24,8 +24,8 @@
 #include <xmlsec/base64.h>
 #include <xmlsec/errors.h>
 #include <xmlsec/keys.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscrypto/crypto.h>
 
@@ -250,7 +250,7 @@ xmlSecMSCryptoHmacFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecMSCryptoHmacNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                           xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                           xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoHmacCtxPtr ctx;
     int ret;
 
@@ -378,7 +378,7 @@ xmlSecMSCryptoHmacSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 static int
 xmlSecMSCryptoHmacVerify(xmlSecTransformPtr transform,
                         const xmlSecByte* data, xmlSecSize dataSize,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoHmacCtxPtr ctx;
     int ret;
 

--- a/src/mscrypto/kt_rsa.c
+++ b/src/mscrypto/kt_rsa.c
@@ -26,8 +26,8 @@
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/strings.h>
-#include <xmlsec/private.h>
 #include <xmlsec/transforms.h>
+#include <xmlsec/private.h>
 
 #include <xmlsec/mscrypto/crypto.h>
 #include <xmlsec/mscrypto/certkeys.h>
@@ -202,7 +202,7 @@ xmlSecMSCryptoRsaPkcs1OaepSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key)
 
 static int
 xmlSecMSCryptoRsaPkcs1OaepExecute(xmlSecTransformPtr transform, int last,
-                                  xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                                  xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoRsaPkcs1OaepCtxPtr ctx;
     int ret;
 
@@ -512,7 +512,7 @@ xmlSecMSCryptoTransformRsaOaepGetKlass(void) {
 
 static int
 xmlSecMSCryptoRsaOaepNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                              xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                              xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoRsaPkcs1OaepCtxPtr ctx;
     xmlSecTransformRsaOaepParams oaepParams;
     int ret;

--- a/src/mscrypto/kw_aes.c
+++ b/src/mscrypto/kw_aes.c
@@ -245,7 +245,7 @@ xmlSecMSCryptoKWAesSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecMSCryptoKWAesExecute(xmlSecTransformPtr transform, int last,
-                           xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                           xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoKWAesCtxPtr ctx;
     int ret;
 

--- a/src/mscrypto/kw_des.c
+++ b/src/mscrypto/kw_des.c
@@ -288,7 +288,7 @@ xmlSecMSCryptoKWDes3SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecMSCryptoKWDes3Execute(xmlSecTransformPtr transform, int last,
-                            xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                            xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoKWDes3CtxPtr ctx;
     int ret;
 

--- a/src/mscrypto/symkeys.c
+++ b/src/mscrypto/symkeys.c
@@ -137,7 +137,7 @@ xmlSecMSCryptoSymKeyDataBinWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecMSCryptoSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecMSCryptoSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBufferPtr buffer;
 
     xmlSecAssert2(xmlSecMSCryptoSymKeyDataCheckId(data), -1);

--- a/src/mscrypto/x509vfy.c
+++ b/src/mscrypto/x509vfy.c
@@ -157,7 +157,7 @@ PCCERT_CONTEXT
 xmlSecMSCryptoX509StoreFindCert_ex(xmlSecKeyDataStorePtr store, xmlChar* subjectName,
                                    xmlChar* issuerName, xmlChar* issuerSerial,
                                    xmlSecByte* ski, xmlSecSize skiSize,
-                                   xmlSecKeyInfoCtx* keyInfoCtx ATTRIBUTE_UNUSED) {
+                                   xmlSecKeyInfoCtx* keyInfoCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecMSCryptoX509StoreCtxPtr ctx;
     PCCERT_CONTEXT pCert = NULL;
 

--- a/src/nodeset.c
+++ b/src/nodeset.c
@@ -494,7 +494,7 @@ xmlSecNodeSetGetChildren(xmlDocPtr doc, const xmlNodePtr parent, int withComment
 
 static int
 xmlSecNodeSetDumpTextNodesWalkCallback(xmlSecNodeSetPtr nset, xmlNodePtr cur,
-                                   xmlNodePtr parent ATTRIBUTE_UNUSED,
+                                   xmlNodePtr parent XMLSEC_ATTRIBUTE_UNUSED,
                                    void* data) {
     int ret;
     xmlSecAssert2(nset != NULL, -1);

--- a/src/nss/app.c
+++ b/src/nss/app.c
@@ -221,7 +221,7 @@ xmlSecNssAppAscii2UCS2Conv(PRBool toUnicode,
                            unsigned char *outBuf,
                            unsigned int   maxOutBufLen,
                            unsigned int  *outBufLen,
-                           PRBool         swapBytes ATTRIBUTE_UNUSED)
+                           PRBool         swapBytes XMLSEC_ATTRIBUTE_UNUSED)
 {
     SECItem it = { siBuffer, NULL, 0 };
 
@@ -240,8 +240,8 @@ xmlSecNssAppAscii2UCS2Conv(PRBool toUnicode,
 #ifndef XMLSEC_NO_X509
 /* rename certificate if needed */
 static SECItem *
-xmlSecNssAppNicknameCollisionCallback(SECItem *old_nick ATTRIBUTE_UNUSED,
-    PRBool *cancel, void *wincx ATTRIBUTE_UNUSED
+xmlSecNssAppNicknameCollisionCallback(SECItem *old_nick XMLSEC_ATTRIBUTE_UNUSED,
+    PRBool *cancel, void *wincx XMLSEC_ATTRIBUTE_UNUSED
 ) {
     CERTCertificate *cert = (CERTCertificate *)wincx;
     char *nick = NULL;
@@ -286,7 +286,7 @@ xmlSecNssAppNicknameCollisionCallback(SECItem *old_nick ATTRIBUTE_UNUSED,
  * Returns: pointer to the key or NULL if an error occurs.
  */
 xmlSecKeyPtr
-xmlSecNssAppKeyLoadEx(const char *filename, xmlSecKeyDataType type ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
+xmlSecNssAppKeyLoadEx(const char *filename, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED, xmlSecKeyDataFormat format,
     const char *pwd, void* pwdCallback, void* pwdCallbackCtx
 ) {
     SECItem secItem = { siBuffer, NULL, 0 };
@@ -764,8 +764,8 @@ done:
  */
 xmlSecKeyPtr
 xmlSecNssAppPkcs12Load(const char *filename, const char *pwd,
-                       void *pwdCallback ATTRIBUTE_UNUSED,
-                       void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                       void *pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                       void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     SECItem secItem = { siBuffer, NULL, 0 };
     xmlSecKeyPtr res;
     int ret;
@@ -807,8 +807,8 @@ xmlSecNssAppPkcs12Load(const char *filename, const char *pwd,
  */
 xmlSecKeyPtr
 xmlSecNssAppPkcs12LoadMemory(const xmlSecByte* data, xmlSecSize dataSize, const char *pwd,
-                       void *pwdCallback ATTRIBUTE_UNUSED,
-                       void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                       void *pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                       void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     SECItem secItem = { siBuffer, NULL, 0 };
     xmlSecKeyPtr res;
     int ret;
@@ -849,8 +849,8 @@ xmlSecNssAppPkcs12LoadMemory(const xmlSecByte* data, xmlSecSize dataSize, const 
  */
 xmlSecKeyPtr
 xmlSecNssAppPkcs12LoadSECItem(SECItem* secItem, const char *pwd,
-                       void *pwdCallback ATTRIBUTE_UNUSED,
-                       void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                       void *pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                       void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecKeyPtr key = NULL;
     xmlSecKeyDataPtr keyValueData = NULL;
     xmlSecKeyDataPtr x509Data = NULL;

--- a/src/nss/hmac.c
+++ b/src/nss/hmac.c
@@ -212,7 +212,7 @@ xmlSecNssHmacFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecNssHmacNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                      xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                      xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssHmacCtxPtr ctx;
     int ret;
 
@@ -327,7 +327,7 @@ xmlSecNssHmacSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 static int
 xmlSecNssHmacVerify(xmlSecTransformPtr transform,
                         const xmlSecByte* data, xmlSecSize dataSize,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssHmacCtxPtr ctx;
     int ret;
 

--- a/src/nss/keysstore.c
+++ b/src/nss/keysstore.c
@@ -131,7 +131,7 @@ xmlSecNssKeysStoreAdoptKey(xmlSecKeyStorePtr store, xmlSecKeyPtr key) {
  */
 int
 xmlSecNssKeysStoreLoad(xmlSecKeyStorePtr store, const char *uri,
-                            xmlSecKeysMngrPtr keysMngr ATTRIBUTE_UNUSED) {
+                            xmlSecKeysMngrPtr keysMngr XMLSEC_ATTRIBUTE_UNUSED) {
     return(xmlSecSimpleKeysStoreLoad_ex(store, uri, keysMngr,
         xmlSecNssKeysStoreAdoptKey));
 }

--- a/src/nss/keytrans.c
+++ b/src/nss/keytrans.c
@@ -805,7 +805,7 @@ xmlSecNssTransformRsaOaepEnc11GetKlass(void) {
 
 static int
 xmlSecNssRsaOaepNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                         xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                         xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssKeyTransportCtxPtr ctx;
     xmlSecTransformRsaOaepParams oaepParams;
     int ret;

--- a/src/nss/kw_aes.c
+++ b/src/nss/kw_aes.c
@@ -328,7 +328,7 @@ xmlSecNssKWAesSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecNssKWAesExecute(xmlSecTransformPtr transform, int last,
-                      xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                      xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssKWAesCtxPtr ctx;
     int ret;
 

--- a/src/nss/kw_des.c
+++ b/src/nss/kw_des.c
@@ -231,7 +231,7 @@ xmlSecNssKWDes3SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecNssKWDes3Execute(xmlSecTransformPtr transform, int last,
-                       xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                       xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssKWDes3CtxPtr ctx;
     int ret;
 
@@ -255,7 +255,7 @@ xmlSecNssKWDes3Execute(xmlSecTransformPtr transform, int last,
  *
  *********************************************************************/
 static int
-xmlSecNssKWDes3Sha1(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
+xmlSecNssKWDes3Sha1(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED,
                     const xmlSecByte * in, xmlSecSize inSize,
                     xmlSecByte * out, xmlSecSize outSize,
                     xmlSecSize * outWritten) {
@@ -310,7 +310,7 @@ xmlSecNssKWDes3Sha1(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
 }
 
 static int
-xmlSecNssKWDes3GenerateRandom(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
+xmlSecNssKWDes3GenerateRandom(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED,
                               xmlSecByte * out, xmlSecSize outSize,
                               xmlSecSize * outWritten) {
     SECStatus status;

--- a/src/nss/pbkdf2.c
+++ b/src/nss/pbkdf2.c
@@ -210,7 +210,7 @@ xmlSecNssPbkdf2GetMacFromHref(const xmlChar* href) {
 
 static int
 xmlSecNssPbkdf2NodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssPbkdf2CtxPtr ctx;
     xmlNodePtr cur;
     int ret;

--- a/src/nss/pkikeys.c
+++ b/src/nss/pkikeys.c
@@ -855,7 +855,7 @@ xmlSecNssKeyDataDsaXmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecNssKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecNssKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     PQGParams    *pqgParams = NULL;
     PQGVerify    *pqgVerify = NULL;
     SECStatus     rv;
@@ -1110,7 +1110,7 @@ done:
 static int
 xmlSecNssKeyDataDsaWrite(xmlSecKeyDataId id, xmlSecKeyDataPtr data,
                          xmlSecKeyValueDsaPtr dsaValue,
-                         int writePrivateKey ATTRIBUTE_UNUSED) {
+                         int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssPKIKeyDataCtxPtr ctx;
     int ret;
 
@@ -1469,7 +1469,7 @@ done:
 static int
 xmlSecNssKeyDataRsaWrite(xmlSecKeyDataId id,xmlSecKeyDataPtr data,
                          xmlSecKeyValueRsaPtr rsaValue,
-                         int writePrivateKey ATTRIBUTE_UNUSED) {
+                         int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssPKIKeyDataCtxPtr ctx;
     int ret;
 
@@ -1506,7 +1506,7 @@ xmlSecNssKeyDataRsaWrite(xmlSecKeyDataId id,xmlSecKeyDataPtr data,
 }
 
 static int
-xmlSecNssKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecNssKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     PK11RSAGenParams  params;
     PK11SlotInfo *slot = NULL;
     SECKEYPrivateKey *privkey = NULL;

--- a/src/nss/symkeys.c
+++ b/src/nss/symkeys.c
@@ -130,7 +130,7 @@ xmlSecNssSymKeyDataBinWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecNssSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecNssSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBufferPtr buffer;
 
     xmlSecAssert2(xmlSecNssSymKeyDataCheckId(data), -1);

--- a/src/nss/x509vfy.c
+++ b/src/nss/x509vfy.c
@@ -179,7 +179,7 @@ CERTCertificate *
 xmlSecNssX509StoreFindCert_ex(xmlSecKeyDataStorePtr store, xmlChar *subjectName,
                                 xmlChar *issuerName, xmlChar *issuerSerial,
                                  xmlSecByte * ski, xmlSecSize skiSize,
-                                 xmlSecKeyInfoCtx* keyInfoCtx ATTRIBUTE_UNUSED) {
+                                 xmlSecKeyInfoCtx* keyInfoCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecNssX509StoreCtxPtr ctx;
     xmlSecNssX509FindCertCtx findCertCtx;
     CERTCertificate * cert;

--- a/src/openssl/README.md
+++ b/src/openssl/README.md
@@ -3,7 +3,7 @@
 ## What version of OpenSSL?
 OpenSSL 3.0.0 or later is strongly recommended.
 
-Also LibreSSL (>= 3.5.0) and Boring SSL (>= 1.1.0) should work but those are
+Also LibreSSL (>= 3.5.0) and Boring SSL (>= 1.1.0) should work but those libraries
 have less stable API/ABI and are not tested as frequently as OpenSSL.
 
 ## Keys manager

--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -1256,8 +1256,8 @@ xmlSecOpenSSLAppPkcs12LoadMemory(const xmlSecByte* data, xmlSecSize dataSize,
  */
 xmlSecKeyPtr
 xmlSecOpenSSLAppPkcs12LoadBIO(BIO* bio, const char *pwd,
-                           void* pwdCallback ATTRIBUTE_UNUSED,
-                           void* pwdCallbackCtx ATTRIBUTE_UNUSED) {
+                           void* pwdCallback XMLSEC_ATTRIBUTE_UNUSED,
+                           void* pwdCallbackCtx XMLSEC_ATTRIBUTE_UNUSED) {
 
     PKCS12 *p12 = NULL;
     EVP_PKEY * pKey = NULL;
@@ -2017,7 +2017,7 @@ xmlSecOpenSSLDefaultPasswordCallback(char *buf, int buflen, int verify, void *us
 
 static int
 xmlSecOpenSSLDummyPasswordCallback(char *buf, int bufLen,
-                                   int verify ATTRIBUTE_UNUSED,
+                                   int verify XMLSEC_ATTRIBUTE_UNUSED,
                                    void *userdata) {
 #if defined(_MSC_VER)
     xmlSecSize bufSize;

--- a/src/openssl/ciphers.c
+++ b/src/openssl/ciphers.c
@@ -387,7 +387,7 @@ xmlSecOpenSSLEvpBlockCipherCBCCtxFinal(xmlSecOpenSSLEvpBlockCipherCtxPtr ctx,
         xmlSecBufferPtr in,
         xmlSecBufferPtr out,
         const xmlChar* cipherName,
-        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED)
+        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED)
 {
     xmlSecSize size, inSize, outSize;
     xmlSecOpenSSLUInt inLen, outLen, padLen, blockLen;

--- a/src/openssl/evp.c
+++ b/src/openssl/evp.c
@@ -1065,7 +1065,7 @@ done:
 }
 
 static int
-xmlSecOpenSSLKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     DSA* dsa = NULL;
     int counter_ret, bitsLen;
     unsigned long h_ret;
@@ -1298,7 +1298,7 @@ done:
 }
 
 static int
-xmlSecOpenSSLKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataDsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     EVP_PKEY_CTX* pctx = NULL;
     OSSL_PARAM_BLD* param_bld = NULL;
     OSSL_PARAM* params = NULL;
@@ -1957,7 +1957,7 @@ done:
 }
 
 static int
-xmlSecOpenSSLKeyDataDhGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataDhGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     DH* dh = NULL;
     int bitsLen;
     int ret;
@@ -2210,7 +2210,7 @@ done:
 }
 
 static int
-xmlSecOpenSSLKeyDataDhGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataDhGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     EVP_PKEY_CTX* pctx = NULL;
     OSSL_PARAM_BLD* param_bld = NULL;
     OSSL_PARAM* params = NULL;
@@ -2419,7 +2419,7 @@ done:
 
 static int
 xmlSecOpenSSLKeyDataDhWrite(xmlSecKeyDataId id, xmlSecKeyDataPtr data, xmlSecKeyValueDhPtr dhValue,
-    int writePrivateKey ATTRIBUTE_UNUSED
+    int writePrivateKey XMLSEC_ATTRIBUTE_UNUSED
 ) {
     xmlSecOpenSSLKeyValueDh dhKeyValue;
     int ret;
@@ -2664,7 +2664,7 @@ xmlSecOpenSSLKeyDataEcFinalize(xmlSecKeyDataPtr data) {
 }
 
 static xmlSecKeyDataType
-xmlSecOpenSSLKeyDataEcGetType(xmlSecKeyDataPtr data ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataEcGetType(xmlSecKeyDataPtr data XMLSEC_ATTRIBUTE_UNUSED) {
     UNREFERENCED_PARAMETER(data);
     /* XXX-MAK: Fix this. */
     return(xmlSecKeyDataTypePublic | xmlSecKeyDataTypePrivate);
@@ -3541,7 +3541,7 @@ xmlSecOpenSSLKeyDataRsaGetRsa(xmlSecKeyDataPtr data) {
 }
 
 static int
-xmlSecOpenSSLKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     RSA* rsa = NULL;
     int lenBits;
     BIGNUM* publicExponent = NULL;
@@ -3723,7 +3723,7 @@ done:
 #else /* XMLSEC_OPENSSL_API_300 */
 
 static int
-xmlSecOpenSSLKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataRsaGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     EVP_PKEY_CTX* pctx = NULL;
     OSSL_PARAM_BLD* param_bld = NULL;
     OSSL_PARAM* params = NULL;
@@ -4237,7 +4237,7 @@ xmlSecOpenSSLKeyDataGost2001Finalize(xmlSecKeyDataPtr data) {
 }
 
 static xmlSecKeyDataType
-xmlSecOpenSSLKeyDataGost2001GetType(xmlSecKeyDataPtr data ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataGost2001GetType(xmlSecKeyDataPtr data XMLSEC_ATTRIBUTE_UNUSED) {
     UNREFERENCED_PARAMETER(data);
 
     /* Now I don't know how to find whether we have both private and public key
@@ -4365,7 +4365,7 @@ xmlSecOpenSSLKeyDataGostR3410_2012_256Finalize(xmlSecKeyDataPtr data) {
 }
 
 static xmlSecKeyDataType
-xmlSecOpenSSLKeyDataGostR3410_2012_256GetType(xmlSecKeyDataPtr data ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataGostR3410_2012_256GetType(xmlSecKeyDataPtr data XMLSEC_ATTRIBUTE_UNUSED) {
     UNREFERENCED_PARAMETER(data);
 
     /* I don't know how to find whether we have both private and public key
@@ -4493,7 +4493,7 @@ xmlSecOpenSSLKeyDataGostR3410_2012_512Finalize(xmlSecKeyDataPtr data) {
 }
 
 static xmlSecKeyDataType
-xmlSecOpenSSLKeyDataGostR3410_2012_512GetType(xmlSecKeyDataPtr data ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLKeyDataGostR3410_2012_512GetType(xmlSecKeyDataPtr data XMLSEC_ATTRIBUTE_UNUSED) {
     UNREFERENCED_PARAMETER(data);
 
     /* I don't know how to find whether we have both private and public key

--- a/src/openssl/hmac.c
+++ b/src/openssl/hmac.c
@@ -282,7 +282,7 @@ xmlSecOpenSSLHmacFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecOpenSSLHmacNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLHmacCtxPtr ctx;
     int ret;
 
@@ -444,7 +444,7 @@ xmlSecOpenSSLHmacSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 static int
 xmlSecOpenSSLHmacVerify(xmlSecTransformPtr transform,
                         const xmlSecByte* data, xmlSecSize dataSize,
-                        xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                        xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLHmacCtxPtr ctx;
     int ret;
 

--- a/src/openssl/kdf.c
+++ b/src/openssl/kdf.c
@@ -439,7 +439,7 @@ xmlSecOpenSSLConcatKdfSetDigestNameFromHref(xmlSecOpenSSLKdfCtxPtr ctx, const xm
 
 static int
 xmlSecOpenSSLConcatKdfNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLKdfCtxPtr ctx;
     xmlSecTransformConcatKdfParams params;
     int paramsInitialized = 0;
@@ -644,7 +644,7 @@ xmlSecOpenSSLPbkdf2SetDigestNameFromHref(xmlSecOpenSSLKdfCtxPtr ctx, const xmlCh
 
 static int
 xmlSecOpenSSLPbkdf2NodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLKdfCtxPtr ctx;
     xmlSecTransformPbkdf2Params params;
     int paramsInitialized = 0;

--- a/src/openssl/keysstore.c
+++ b/src/openssl/keysstore.c
@@ -209,7 +209,7 @@ xmlSecOpenSSLKeysStoreAdoptKey(xmlSecKeyStorePtr store, xmlSecKeyPtr key) {
  */
 int
 xmlSecOpenSSLKeysStoreLoad(xmlSecKeyStorePtr store, const char *uri,
-                            xmlSecKeysMngrPtr keysMngr ATTRIBUTE_UNUSED) {
+                            xmlSecKeysMngrPtr keysMngr XMLSEC_ATTRIBUTE_UNUSED) {
     return(xmlSecSimpleKeysStoreLoad_ex(store, uri, keysMngr,
         xmlSecOpenSSLKeysStoreAdoptKey));
 }

--- a/src/openssl/kt_rsa.c
+++ b/src/openssl/kt_rsa.c
@@ -124,7 +124,7 @@ xmlSecOpenSSLTransformRsaPkcs1GetKlass(void) {
 
 static int
 xmlSecOpenSSLRsaPkcs1SetKeyImpl(xmlSecOpenSSLRsaPkcs1CtxPtr ctx, EVP_PKEY* pKey,
-                                int encrypt ATTRIBUTE_UNUSED) {
+                                int encrypt XMLSEC_ATTRIBUTE_UNUSED) {
     RSA *rsa = NULL;
     xmlSecOpenSSLSizeT keyLen;
 
@@ -391,7 +391,7 @@ xmlSecOpenSSLRsaPkcs1SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecOpenSSLRsaPkcs1Execute(xmlSecTransformPtr transform, int last,
-                             xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                             xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLRsaPkcs1CtxPtr ctx;
     int ret;
 
@@ -653,7 +653,7 @@ xmlSecOpenSSLRsaOaepCheckId(xmlSecTransformPtr transform) {
 
 static int
 xmlSecOpenSSLRsaOaepSetKeyImpl(xmlSecOpenSSLRsaOaepCtxPtr ctx, EVP_PKEY* pKey,
-                            int encrypt ATTRIBUTE_UNUSED) {
+                            int encrypt XMLSEC_ATTRIBUTE_UNUSED) {
     RSA *rsa = NULL;
     int keyLen;
 
@@ -1020,7 +1020,7 @@ xmlSecOpenSSLRsaOaepFinalize(xmlSecTransformPtr transform) {
 
 static int
 xmlSecOpenSSLRsaOaepNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
-                             xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                             xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLRsaOaepCtxPtr ctx;
     xmlSecTransformRsaOaepParams oaepParams;
     int ret;
@@ -1250,7 +1250,7 @@ xmlSecOpenSSLRsaOaepSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecOpenSSLRsaOaepExecute(xmlSecTransformPtr transform, int last,
-                            xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                            xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLRsaOaepCtxPtr ctx;
     int ret;
 

--- a/src/openssl/kw_aes.c
+++ b/src/openssl/kw_aes.c
@@ -221,7 +221,7 @@ xmlSecOpenSSLKWAesSetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecOpenSSLKWAesExecute(xmlSecTransformPtr transform, int last,
-                          xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                          xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLKWAesCtxPtr ctx;
     int ret;
 

--- a/src/openssl/kw_des.c
+++ b/src/openssl/kw_des.c
@@ -235,7 +235,7 @@ xmlSecOpenSSLKWDes3SetKey(xmlSecTransformPtr transform, xmlSecKeyPtr key) {
 
 static int
 xmlSecOpenSSLKWDes3Execute(xmlSecTransformPtr transform, int last,
-                           xmlSecTransformCtxPtr transformCtx ATTRIBUTE_UNUSED) {
+                           xmlSecTransformCtxPtr transformCtx XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecOpenSSLKWDes3CtxPtr ctx;
     int ret;
 
@@ -262,7 +262,7 @@ xmlSecOpenSSLKWDes3Execute(xmlSecTransformPtr transform, int last,
 #ifndef XMLSEC_OPENSSL_API_300
 
 static int
-xmlSecOpenSSLKWDes3Sha1(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
+xmlSecOpenSSLKWDes3Sha1(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED,
                        const xmlSecByte * in, xmlSecSize inSize,
                        xmlSecByte * out, xmlSecSize outSize,
                        xmlSecSize * outWritten) {
@@ -286,7 +286,7 @@ xmlSecOpenSSLKWDes3Sha1(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
 #else /* XMLSEC_OPENSSL_API_300 */
 
 static int
-xmlSecOpenSSLKWDes3Sha1(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
+xmlSecOpenSSLKWDes3Sha1(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED,
                        const xmlSecByte * in, xmlSecSize inSize,
                        xmlSecByte * out, xmlSecSize outSize,
                        xmlSecSize * outWritten) {
@@ -317,7 +317,7 @@ xmlSecOpenSSLKWDes3Sha1(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
 
 
 static int
-xmlSecOpenSSLKWDes3GenerateRandom(xmlSecTransformPtr transform ATTRIBUTE_UNUSED,
+xmlSecOpenSSLKWDes3GenerateRandom(xmlSecTransformPtr transform XMLSEC_ATTRIBUTE_UNUSED,
                                  xmlSecByte * out, xmlSecSize outSize,
                                  xmlSecSize * outWritten) {
     int ret;

--- a/src/openssl/symkeys.c
+++ b/src/openssl/symkeys.c
@@ -132,7 +132,7 @@ xmlSecOpenSSLSymKeyDataBinWrite(xmlSecKeyDataId id, xmlSecKeyPtr key,
 }
 
 static int
-xmlSecOpenSSLSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type ATTRIBUTE_UNUSED) {
+xmlSecOpenSSLSymKeyDataGenerate(xmlSecKeyDataPtr data, xmlSecSize sizeBits, xmlSecKeyDataType type XMLSEC_ATTRIBUTE_UNUSED) {
     xmlSecBufferPtr buffer;
 
     xmlSecAssert2(xmlSecOpenSSLSymKeyDataCheckId(data), -1);

--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -182,7 +182,7 @@ xmlSecOpenSSLX509StoreFindCert_ex(xmlSecKeyDataStorePtr store,
     xmlChar *subjectName,
     xmlChar *issuerName, xmlChar *issuerSerial,
     xmlSecByte * ski, xmlSecSize skiSize,
-    xmlSecKeyInfoCtx* keyInfoCtx ATTRIBUTE_UNUSED
+    xmlSecKeyInfoCtx* keyInfoCtx XMLSEC_ATTRIBUTE_UNUSED
 ) {
     xmlSecOpenSSLX509StoreCtxPtr ctx;
     xmlSecOpenSSLX509FindCertCtx findCertCtx;


### PR DESCRIPTION
See issue #904 