### PR TITLE
(xmlsec-openssl) Fix AWS-LC support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -819,6 +819,26 @@ if test "z$OPENSSL_FOUND" = "zyes" ; then
             OPENSSL_VERSION=""
         ])
     fi
+    
+    if test "z$OPENSSL_VERSION" = "z" ; then
+        AC_EGREP_CPP(greater-than-minvers, [
+            #include <openssl/opensslv.h>
+            #include <openssl/crypto.h>
+            #if OPENSSL_VERSION_NUMBER >= 0x10100010L
+            #ifdef OPENSSL_IS_AWSLC
+            greater-than-minvers
+            #endif
+            #endif
+        ],[
+            OPENSSL_VERSION="AWSLC >= 1.1.1"
+            enable_ripemd160=no
+            enable_dsa=no
+            enable_dh=no
+            enable_sha3=no
+        ],[
+            OPENSSL_VERSION=""
+        ])
+    fi
 
     if test "z$OPENSSL_VERSION" = "z" ; then
         AC_EGREP_CPP(greater-than-minvers, [

--- a/include/xmlsec/openssl/crypto.h
+++ b/include/xmlsec/openssl/crypto.h
@@ -17,7 +17,7 @@
 
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #include <openssl/opensslconf.h>
 #endif /* OPENSSL_IS_BORINGSSL */
 

--- a/src/openssl/app.c
+++ b/src/openssl/app.c
@@ -50,7 +50,7 @@
 #include <openssl/engine.h>
 #endif /* !defined(OPENSSL_NO_ENGINE) && (!defined(XMLSEC_OPENSSL_API_300) || defined(XMLSEC_OPENSSL3_ENGINES)) */
 
-#ifndef OPENSSL_IS_BORINGSSL
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #include <openssl/ui.h>
 #endif /* OPENSSL_IS_BORINGSSL */
 
@@ -150,11 +150,11 @@ xmlSecOpenSSLAppInit(const char* config) {
     opts |= OPENSSL_INIT_ADD_ALL_DIGESTS;
     opts |= OPENSSL_INIT_LOAD_CONFIG;
 
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     opts |= OPENSSL_INIT_ASYNC;
 #endif /* !defined(OPENSSL_IS_BORINGSSL) */
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(XMLSEC_OPENSSL_API_300)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_AWSLC)
     opts |= OPENSSL_INIT_ENGINE_ALL_BUILTIN;
 #endif /* !defined(OPENSSL_IS_BORINGSSL) && !defined(XMLSEC_OPENSSL_API_300) */
 

--- a/src/openssl/crypto.c
+++ b/src/openssl/crypto.c
@@ -46,7 +46,7 @@ static void             xmlSecOpenSSLErrorsShutdown             (void);
 static xmlSecCryptoDLFunctionsPtr gXmlSecOpenSSLFunctions = NULL;
 static xmlChar* gXmlSecOpenSSLTrustedCertsFolder = NULL;
 
-#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ERR)
+#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ERR)
 
 #define XMLSEC_OPENSSL_ERRORS_FUNCTION                  0
 
@@ -566,7 +566,7 @@ void
 xmlSecOpenSSLErrorsDefaultCallback(const char* file, int line, const char* func,
                                 const char* errorObject, const char* errorSubject,
                                 int reason, const char* msg) {
-#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ERR)
+#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ERR)
     ERR_put_error(gXmlSecOpenSSLErrorsLib,
                 XMLSEC_OPENSSL_ERRORS_FUNCTION,
                 reason, file, line);
@@ -579,7 +579,7 @@ xmlSecOpenSSLErrorsDefaultCallback(const char* file, int line, const char* func,
 
 static int
 xmlSecOpenSSLErrorsInit(void) {
-#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ERR)
+#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ERR)
     xmlSecSize pos;
 
     /* get XMLSec library id */
@@ -620,7 +620,7 @@ xmlSecOpenSSLErrorsShutdown(void) {
     /* remove callback */
     xmlSecErrorsSetCallback(NULL);
 
-#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ERR)
+#if !defined(XMLSEC_OPENSSL_API_300) && !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ERR)
     /* unload xmlsec strings from OpenSSL */
     ERR_unload_strings(gXmlSecOpenSSLErrorsLib, xmlSecOpenSSLStrLib);
     ERR_unload_strings(gXmlSecOpenSSLErrorsLib, xmlSecOpenSSLStrDefReason);

--- a/src/openssl/openssl_compat.h
+++ b/src/openssl/openssl_compat.h
@@ -15,24 +15,10 @@
 
 /******************************************************************************
  *
- * AWS LC compatibility (based on BoringSSL)
+ * boringssl and aws-lc compatibility
  *
  *****************************************************************************/
-#ifdef OPENSSL_IS_AWSLC
-
-#ifndef OPENSSL_IS_BORINGSSL
-#define OPENSSL_IS_BORINGSSL
-#endif /* OPENSSL_IS_BORINGSSL */
-
-#endif /* ! OPENSSL_IS_AWSLC */
-
-
-/******************************************************************************
- *
- * boringssl compatibility
- *
- *****************************************************************************/
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 /* Not implemented by LibreSSL (yet?) */
 #define XMLSEC_OPENSSL_NO_ASN1_TIME_TO_TM   1
@@ -66,7 +52,7 @@
 
 
 /* BoringSSL redefines int->size_t or int->unsigned */
-#if defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 
 /* when BoringSSL replaced int with unisgned */
 typedef unsigned xmlSecOpenSSLUInt;

--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -50,7 +50,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/asn1.h>
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
 #include <openssl/mem.h>
 #endif /* OPENSSL_IS_BORINGSSL */
 


### PR DESCRIPTION
This PR explicitly ifdef's xmlsec code with the macro OPENSSL_IS_AWSLC as discussed in issue #908 