### PR TITLE
Fix const qualifier mismatch with libxml2 >= 2.15.0 (xmlDoc.encoding)

### DIFF
--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -718,7 +718,7 @@ xmlSecReplaceNodeBufferAndReturn(xmlNodePtr node, const xmlSecByte *buffer, xmlS
     node->doc->encoding = NULL;
     ret = xmlParseInNodeContext(node->parent, (const char*)buffer, len,
             xmlSecParserGetDefaultOptions(), &results);
-    node->doc->encoding = oldenc;
+    node->doc->encoding = (xmlChar*)oldenc;
     if(ret != XML_ERR_OK) {
         xmlSecXmlError("xmlParseInNodeContext", NULL);
         return(-1);


### PR DESCRIPTION
libxml2 2.15.0 changed xmlDoc.encoding from `const xmlChar*` to `xmlChar*`. This causes a compiler warning/error in xmlsec.

To maintain compatibility with both libxml2 <= 2.14.x and >= 2.15.0, explicitly cast the saved `const xmlChar*` back to `xmlChar*` when assigning it to node->doc->encoding.

This ensures clean builds across libxml2 versions without introducing conditional compilation or breaking backwards compatibility.

Fixes https://github.com/lsh123/xmlsec/issues/948
libxml2 change: https://github.com/GNOME/libxml2/commit/7c91385040ffab197f92135f7240e4d86b8f0cbb 