### PR TITLE
Update kt_rsa.c to resolve compilation issue.

### DIFF
--- a/src/openssl/kt_rsa.c
+++ b/src/openssl/kt_rsa.c
@@ -694,7 +694,7 @@ xmlSecOpenSSLRsaOaepProcessImpl(xmlSecOpenSSLRsaOaepCtxPtr ctx, const xmlSecByte
 
     xmlSecAssert2(ctx != NULL, -1);
     xmlSecAssert2(ctx->pKey != NULL, -1);
-    xmlSecAssert2(xmlSecOpenSSLKeyValueRsaCheckKeyType(pKey) == 0, -1);
+    xmlSecAssert2(xmlSecOpenSSLKeyValueRsaCheckKeyType(ctx->pKey) == 0, -1);
     xmlSecAssert2(inBuf != NULL, -1);
     xmlSecAssert2(inSize > 0, -1);
     xmlSecAssert2(outBuf != NULL, -1);


### PR DESCRIPTION
While running test cases for xmlsec, getting below compilation error.
**Error :**
kt_rsa.c: In function 'xmlSecOpenSSLRsaOaepProcessImpl':
kt_rsa.c:697:56: error: 'pKey' undeclared (first use in this function)
  697 |     xmlSecAssert2(xmlSecOpenSSLKeyValueRsaCheckKeyType(pKey) == 0, -1);
      |                                                        ^~~~
../../include/xmlsec/errors.h:550:15: note: in definition of macro 'xmlSecAssert2'
  550 |         if(!( p ) ) { \
      |               ^
kt_rsa.c:697:56: note: each undeclared identifier is reported only once for each function it appears in
  697 |     xmlSecAssert2(xmlSecOpenSSLKeyValueRsaCheckKeyType(pKey) == 0, -1);
**Reason** : pKey is part of ctx structure, should be used like ctx->pKey.
**Fix :** Changed pKey with ctx->pKey   xmlSecAssert2(xmlSecOpenSSLKeyValueRsaCheckKeyType(ctx->pKey) == 0, -1);
