### PR TITLE
(xmlsec-openssl) Support invalid ECDSA signature values in ASN1 format

### DIFF
--- a/src/openssl/x509vfy.c
+++ b/src/openssl/x509vfy.c
@@ -1851,6 +1851,7 @@ xmlSecOpenSSLX509NameReadCallback(
 /* OpenSSL doesn't accept "E" so we need to replace it */
 static xmlSecx509NameReplacements xmlSecOpenSSLX509NameReplacements[]  = {
     { BAD_CAST "E", BAD_CAST  "emailAddress"},
+    { BAD_CAST "SERIALNUMBER", BAD_CAST  "serialNumber"},
     { NULL, NULL }
 };
 


### PR DESCRIPTION
See https://github.com/lsh123/xmlsec/issues/995