### PR TITLE
Fix a Y2038 bug by replacing `Int32x32To64` with multiplication

### DIFF
--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -750,7 +750,7 @@ xmlSecMSCngUnixTimeToFileTime(time_t in, LPFILETIME out) {
 
     /* seconds -> 100 nanoseconds */
     /* 1970-01-01 epoch -> 1601-01-01 epoch */
-    ll = Int32x32To64(in, 10000000) + 116444736000000000;
+    ll = Int32x32To64(in * 10000000LL) + 116444736000000000LL;
     out->dwLowDateTime  = (DWORD)ll;
     out->dwHighDateTime = (DWORD)(ll >> 32);
 

--- a/src/mscrypto/x509vfy.c
+++ b/src/mscrypto/x509vfy.c
@@ -190,11 +190,7 @@ xmlSecMSCryptoUnixTimeToFileTime(time_t t, LPFILETIME pft) {
 
     xmlSecAssert(pft != NULL);
 
-#if defined( __MINGW32__)
-    ll = Int32x32To64(t, 10000000) + 116444736000000000LL;
-#else
-    ll = Int32x32To64(t, 10000000) + 116444736000000000;
-#endif
+    ll = Int32x32To64(t * 10000000LL) + 116444736000000000LL;
     pft->dwLowDateTime  = (DWORD)ll;
     pft->dwHighDateTime = (DWORD)(ll >> 32);
 }


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>