### PR TITLE
Remove manual autogen.sh

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,7 +89,8 @@ jobs:
       shell: bash
       run: |
         mkdir install.dir
-        ./autogen.sh --prefix=${GITHUB_WORKSPACE}/install.dir --enable-werror --enable-pedantic --enable-legacy-features --enable-ftp --enable-http
+        autoreconf -i -f
+        ./configure --prefix=${GITHUB_WORKSPACE}/install.dir --enable-werror --enable-pedantic --enable-legacy-features --enable-ftp --enable-http
         make
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -40,7 +40,8 @@ jobs:
     - name: configure
       working-directory: build.dir
       run: |
-          ../autogen.sh --prefix=${GITHUB_WORKSPACE}/install.dir --enable-werror --enable-pedantic ${{ matrix.config_flags }}
+          autoreconf -i -f ..
+          ../configure --prefix=${GITHUB_WORKSPACE}/install.dir --enable-werror --enable-pedantic ${{ matrix.config_flags }}
     - name: make
       working-directory: build.dir
       run: |
@@ -92,7 +93,8 @@ jobs:
     - name: configure
       working-directory: build.dir
       run: |
-          ../autogen.sh --prefix=${GITHUB_WORKSPACE}/install.dir ${{ matrix.config_flags }} \
+          autoreconf -i -f ..
+          ../configure --prefix=${GITHUB_WORKSPACE}/install.dir ${{ matrix.config_flags }} \
             --enable-werror --enable-pedantic \
             --with-openssl=${GITHUB_WORKSPACE}/../aws-lc/install \
             --without-gnutls --without-nss --without-gcrypt
@@ -143,7 +145,8 @@ jobs:
       #  --with-nspr=`brew --prefix nspr` \
       #  --with-nss=`brew --prefix nss` \
       run: |
-          ../autogen.sh --prefix=${GITHUB_WORKSPACE}/install.dir  --enable-werror --enable-pedantic \
+          autoreconf -i -f ..
+          ../configure --prefix=${GITHUB_WORKSPACE}/install.dir  --enable-werror --enable-pedantic \
             --with-openssl=`brew --prefix openssl` \
             --without-nss \
             --with-gnutls=`brew --prefix gnutls` \
@@ -222,7 +225,8 @@ jobs:
     - name: configure
       working-directory: build.dir
       run: |
-          ../autogen.sh --prefix=`cygpath -u "${GITHUB_WORKSPACE}/install.dir"` --enable-werror  --enable-pedantic \
+          autoreconf -i -f ..
+          ../configure --prefix=`cygpath -u "${GITHUB_WORKSPACE}/install.dir"` --enable-werror  --enable-pedantic \
               --enable-mscrypto --enable-mscng ${{ matrix.config_flags }} \
               --build="${{ matrix.arch }}-w64-mingw32" \
               --host="${{ matrix.arch }}-w64-mingw32"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ To build from GitHub, run the following commands:
 ```
 git clone https://github.com/lsh123/xmlsec.git
 cd xmlsec
-./autogen.sh [possible configure options]
+autoreconf -i -f
+./configure [possible configure options]
 make
 make check
 make install

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,99 +1,21 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+# This is just a trivial wrapper around autoreconf and configure.
 
 srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.
 
-THEDIR=`pwd`
-cd $srcdir
-DIE=0
-
-(autoconf --version) < /dev/null > /dev/null 2>&1 || {
-	echo
-	echo "You must have autoconf installed to compile xmlsec."
-	DIE=1
-}
-
-LIBTOOL="libtool"
-if [ "`uname`" = "Darwin" -a -n "`type -p glibtool`" ]; then
-	LIBTOOL=glibtool
-fi
-
-($LIBTOOL --version) < /dev/null > /dev/null 2>&1 || {
-	echo
-	echo "You must have $LIBTOOL installed to compile xmlsec."
-	DIE=1
-}
-
-(autoheader --version) < /dev/null > /dev/null 2>&1 || {
-	echo
-	echo "You must have autoheader installed to compile xmlsec."
-	DIE=1
-}
-
-(autoconf --version) < /dev/null > /dev/null 2>&1 || {
-	echo
-	echo "You must have autoconf installed to compile xmlsec."
-	DIE=1
-}
-(autoreconf --version) < /dev/null > /dev/null 2>&1 || {
-        echo
-        echo "You must have autoreconf installed to compile xmlsec."
-        DIE=1
-}
-(automake --version) < /dev/null > /dev/null 2>&1 || {
-	echo
-	echo "You must have automake installed to compile xmlsec."
-	DIE=1
-}
-
-if test "$DIE" -eq 1; then
-	exit 1
-fi
-
-test -f include/xmlsec/xmldsig.h  || {
-	echo "You must run this script in the top-level xmlsec directory."
-	exit 1
-}
-
-if test -z "$*"; then
-	echo "I am going to run ./configure with no arguments."
-	echo "If you want to pass any, specify them on the $0 command line."
-fi
-
-LIBTOOLIZE="libtoolize"
-if [ "`uname`" = "Darwin" -a -n "`type -p glibtoolize`" ]; then
-	LIBTOOLIZE=glibtoolize
-fi
-echo "Running $LIBTOOLIZE..."
-$LIBTOOLIZE --copy --force
-echo "Running aclocal..."
-if [ -d /usr/local/share/aclocal ]; then
-	aclocal --force -I m4 -I /usr/local/share/aclocal
-else
-	aclocal --force -I m4
-fi
-echo "Running autoheader..."
-autoheader --force
-echo "Running autoconf..."
-autoconf --force
-echo "Running automake..."
-automake --gnu --add-missing
-echo "Running autoconf..."
-autoconf
-echo "Running autoreconf..."
-autoreconf -i
-
-cd $THEDIR
+echo Running autoreconf...
+autoreconf -i -f $srcdir
 
 if test x$OBJ_DIR != x; then
     mkdir -p "$OBJ_DIR"
     cd "$OBJ_DIR"
 fi
 
-conf_flags="--enable-maintainer-mode" #--enable-iso-c
-echo Running configure $conf_flags "$@" ...
-$srcdir/configure $conf_flags "$@"
+echo
+echo Running configure "$@" ...
+$srcdir/configure "$@"
 
 echo
 echo "Now type 'make' to compile xmlsec."

--- a/config.h.in
+++ b/config.h.in
@@ -1,6 +1,6 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* Define to 1 if you have the <dirent.h> header file, and it defines 'DIR'.
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
    */
 #undef HAVE_DIRENT_H
 
@@ -10,7 +10,7 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
 /* Define to 1 if you have the <stdint.h> header file. */
@@ -28,11 +28,11 @@
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
-/* Define to 1 if you have the <sys/dir.h> header file, and it defines 'DIR'.
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
    */
 #undef HAVE_SYS_DIR_H
 
-/* Define to 1 if you have the <sys/ndir.h> header file, and it defines 'DIR'.
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
    */
 #undef HAVE_SYS_NDIR_H
 
@@ -69,7 +69,7 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if all of the C89 standard headers exist (not just the ones
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
    backward compatibility; new code need not use it. */
 #undef STDC_HEADERS

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -10,7 +10,8 @@ today=`date +%F-%H-%M-%S`
 
 echo "============= Building xmlsec"
 make distclean
-./autogen.sh $configure_options
+autoreconf -if
+./configure $configure_options
 make -j12
 make -C docs docs
 

--- a/scripts/build_memcheck.sh
+++ b/scripts/build_memcheck.sh
@@ -19,6 +19,7 @@ fi
 echo "============== Starting memcheck for ${crypto} using source root '${top_dir}'"
 rm -rf /tmp/xmlsec-test*
 make distclean
-${top_dir}/autogen.sh --enable-development --enable-legacy-features --with-default-crypto=${crypto} "$@"
+autoreconf -i -f ${top_dir}
+${top_dir}/configure --enable-development --enable-legacy-features --with-default-crypto=${crypto} "$@"
 make -j12
 make memcheck-crypto-${crypto}

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -42,7 +42,8 @@ cd xmlsec
 find . -name ".git" | xargs rm -r
 
 echo "============== Building xmlsec1-${full_version}"
-./autogen.sh --prefix=/usr --sysconfdir=/etc
+autoreconf -i -f
+./configure --prefix=/usr --sysconfdir=/etc
 make tar-release
 # Cannot build RPM on Ubuntu.
 # make rpm-release


### PR DESCRIPTION
The modern replacement for a hand-coded autogen.sh is just autoreconf, which will call the required commands and is more flexible than this autogen.sh.

Interestingly, autogen.sh calls libtoolize/automake/autoconf and then calls autoreconf which will run all of those commands again, so moving to just autoreconf will half the time needed to bootstrap.