### PR TITLE
Fix bug signing with ML-DSA keys using pkcs11-provider

### DIFF
--- a/src/openssl/signatures.c
+++ b/src/openssl/signatures.c
@@ -31,6 +31,7 @@
 
 #ifdef XMLSEC_OPENSSL_API_300
 #include <openssl/core_names.h>
+#include <openssl/provider.h>
 #endif /* XMLSEC_OPENSSL_API_300 */
 
 #include "../cast_helpers.h"
@@ -1084,6 +1085,11 @@ xmlSecOpenSSLEvpSignatureCreatePkeyCtx(xmlSecTransformPtr transform, xmlSecOpenS
         OSSL_PARAM params[2];
         int paramsPos = 0;
         EVP_SIGNATURE *sigAlg;
+        EVP_PKEY *pKey;
+        const OSSL_PROVIDER *keyProv;
+        const char *provName;
+        const char *propQueryPtr = NULL;
+        xmlChar propQuery[128];
 
         /* setup params */
         if ((ctx->contextString != NULL) && (xmlSecBufferGetData(ctx->contextString) != NULL)) {
@@ -1095,7 +1101,26 @@ xmlSecOpenSSLEvpSignatureCreatePkeyCtx(xmlSecTransformPtr transform, xmlSecOpenS
         }
         params[paramsPos++] = OSSL_PARAM_construct_end();
 
-        sigAlg = EVP_SIGNATURE_fetch(xmlSecOpenSSLGetLibCtx(), ctx->signatureName, NULL);
+        /* Fetch the signature implementation from the key's owning provider.
+         * Otherwise, pass NULL to EVP_Signature_fetch to use the default provider. */
+        pKey = EVP_PKEY_CTX_get0_pkey(pKeyCtx);
+        if (pKey != NULL) {
+            keyProv = EVP_PKEY_get0_provider(pKey);
+            if (keyProv != NULL) {
+                provName = OSSL_PROVIDER_get0_name(keyProv);
+                if (provName != NULL) {
+                    ret = xmlStrPrintf(propQuery, sizeof(propQuery),
+                                       "provider=%s", provName);
+                    if (ret < 0) {
+                        xmlSecXmlError("xmlStrPrintf", xmlSecTransformGetName(transform));
+                        goto error;
+                    }
+                    propQueryPtr = (const char *)propQuery;
+                }
+            }
+        }
+        sigAlg = EVP_SIGNATURE_fetch(xmlSecOpenSSLGetLibCtx(),
+                                     ctx->signatureName, propQueryPtr);
         if(sigAlg == NULL) {
             xmlSecOpenSSLError2("EVP_SIGNATURE_fetch", xmlSecTransformGetName(transform),
                 "name=%s", xmlSecErrorsSafeString(ctx->signatureName));


### PR DESCRIPTION
This bug was discovered when using ML-DSA-87 keys held in a PKCS#11 token (Kryoptic) accessed via OpenSSL 3.5.6 through pkcs11-provider, with the key referenced through xmlsec1 –privkey-openssl-store.

This failed with:
`func=xmlSecOpenSSLEvpSignatureCreatePkeyCtx:file=signatures.c:line=1107:obj=ml-dsa-87:subj=EVP_PKEY_sign_message_init:error=4:crypto library function failed:ret=0; openssl error: error:00000000:lib(0)::reason(0) func=xmlSecOpenSSLEvpSignatureSign:file=signatures.c:line=1308:obj=ml-dsa-87:subj=xmlSecOpenSSLEvpSignatureCreatePkeyCtx:error=1:xmlsec library function failed: func=xmlSecOpenSSLEvpSignatureExecute:file=signatures.c:line=1568:obj=ml-dsa-87:subj=xmlSecOpenSSLEvpSignatureSign:error=1:xmlsec library function failed: func=xmlSecTransformDefaultPushBin:file=transforms.c:line=2073:obj=ml-dsa-87:subj=xmlSecTransformExecute:error=1:xmlsec library function failed:final=1 func=xmlSecTransformIOBufferClose:file=transforms.c:line=2689:obj=ml-dsa-87:subj=xmlSecTransformPushBin:error=1:xmlsec library function failed: func=xmlSecTransformC14NPushXml:file=c14n.c:line=239:obj=c14n:subj=xmlOutputBufferClose:error=5:libxml2 library function failed:xml error: 0: NULL func=xmlSecTransformCtxXmlExecute:file=transforms.c:line=1209:obj=c14n:subj=xmlSecTransformPushXml:error=1:xmlsec library function failed: func=xmlSecDSigCtxProcessSignatureNode:file=xmldsig.c:line=576:obj=unknown:subj=xmlSecTransformCtxXmlExecute:error=1:xmlsec library function failed: func=xmlSecDSigCtxSign:file=xmldsig.c:line=286:obj=unknown:subj=xmlSecDSigCtxProcessSignatureNode:error=1:xmlsec library function failed: Signature status: ERROR
Error: failed to sign file "manifest-template-mldsa.xml" exit code: 1`


Indicating a successful key load and parameter query, but no C_SignInit ever reaching the HSM.

Tracing through the code path revealed that the EVP_SIGNATURE_fetch call in xmlSecOpenSSLEvpSignatureCreatePkeyCtx for OpenSSL API >= 3.5.0 in src/openssl/signatures.c was passing NULL as the property query, causing OpenSSL to return the default provider's implementation.

The subsequent EVP_PKEY_sign_message_init then attempted to export the HSM-resident key to the default provider's keymgmt, which silently failed because pkcs11-provider doesn't expose private-key export. The fix determines the key's owning provider via EVP_PKEY_get0_provider and constructs a property query 'provider=<name>' that explicitly targets that provider's signature implementation. Otherwise, it falls back to passing NULL in the property query to use the default provider.

Tested with:
- OpenSSL 3.5.6 + pkcs11-provider main + Kryoptic v1.5.0
- ML-DSA-87 key in PKCS#11 token, referenced via --privkey-openssl-store
- xmlsec1 sign + verify of an ML-DSA manifest