### PR TITLE
Fix incorrect borrow propagation in xmlSecBnAdd subtraction

### DIFF
--- a/src/bn.c
+++ b/src/bn.c
@@ -571,14 +571,17 @@ xmlSecBnAdd(xmlSecBnPtr bn, int delta) {
         }
     } else {
         for(over = -delta, ii = xmlSecBufferGetSize(bn); (ii > 0) && (over > 0);) {
+            int byteSub;
             xmlSecAssert2(data != NULL, -1);
             tmp = data[--ii];
-            if(tmp < over) {
-                data[ii] = 0;
-                over = (over - tmp) / 256;
+            byteSub = over & 0xFF;
+            if(tmp >= byteSub) {
+                data[ii] = (xmlSecByte)(tmp - byteSub);
+                over = over >> 8;
             } else {
-                data[ii] = (xmlSecByte)(tmp - over);
-                over = 0;
+                /* underflow: wrap and propagate a borrow to the next higher byte */
+                data[ii] = (xmlSecByte)(tmp + 256 - byteSub);
+                over = (over >> 8) + 1;
             }
         }
     }


### PR DESCRIPTION
## What

The negative-delta branch of `xmlSecBnAdd` in `src/bn.c` drops the borrow whenever
the current byte is smaller than the amount being subtracted. As a consequence,
subtracting from a big-endian value with a trailing zero byte returns the value
unchanged instead of the correctly-borrowed result.

The buggy code at `src/bn.c:572-584` (before the fix) is:

```c
} else {
    for(over = -delta, ii = xmlSecBufferGetSize(bn); (ii > 0) && (over > 0);) {
        xmlSecAssert2(data != NULL, -1);
        tmp = data[--ii];
        if(tmp < over) {
            data[ii] = 0;
            over = (over - tmp) / 256;   /* loses the borrow */
        } else {
            data[ii] = (xmlSecByte)(tmp - over);
            over = 0;
        }
    }
}
```

When `tmp < over` and the residual `(over - tmp)` is less than 256
(the common case for small deltas such as `-1` and `-2`), `(over - tmp) / 256`
evaluates to `0`, so the loop terminates without subtracting `1` from the next
higher byte. The current byte is also incorrectly set to `0` instead of
`tmp + 256 - over`.

## How to reproduce

The bug is reachable through the public BN API. Round-tripping any negative
value with a trailing zero byte through `xmlSecBnFromHexString` → `xmlSecBnAdd`
→ `xmlSecBnToHexString` exposes it:

| Initial (hex) | delta | Expected     | Got (current code) |
|---------------|-------|--------------|--------------------|
| `100`         | `-1`  | `FF`         | `100`              |
| `10000`       | `-1`  | `FFFF`       | `10000`            |
| `01000000`    | `-5`  | `00FFFFFB`   | `01000000`         |
| `FF00`        | `-1`  | `FEFF`       | `FF00`             |
| `010000`      | `-300`| `FED4`       | `010000`           |
| `100`         | `-2`  | `FE`         | `100`              |

The two real call sites are:

1. `src/bn.c:323` — `xmlSecBnAdd(&bn2, -1)` inside `xmlSecBnToString` while
   converting a 2's-complement-encoded negative BN to a decimal/hex string
   (used by `xmlSecBnSetNodeValue` and related node serialization paths). For
   any negative BN whose 2's-complement representation has a trailing zero
   byte (e.g. `-256`, `-32768`), the displayed magnitude is off and the
   resulting XML serializes a wrong number.
2. `src/mscng/certkeys.c:1838` — `xmlSecBnAdd(&pMinusTwo, -2)` while computing
   `p - 2` for DH key handling. Any prime `p` whose low byte is `0x01` would
   trip the same buggy path.

## The fix

Replace the inner loop with a standard subtract-with-borrow:

- subtract the low byte of the residual from the current byte,
- wrap (`tmp + 256 - byteSub`) when the current byte is smaller than the low
  byte of the residual,
- propagate a borrow of 1 into the next higher byte while shifting the
  residual right by 8 (so that an arbitrarily large `over` still terminates
  correctly).

The positive-delta branch is unchanged.

## Test plan

- [x] Build `libxmlsec1` against OpenSSL 3 (`./autogen.sh && make -C src`) — builds clean.
- [x] Existing `apps/xmlsec_unit_tests` suite passes against the patched library.
- [x] Standalone test program that exercises the public BN API (`xmlSecBnFromHexString` → `xmlSecBnAdd` → `xmlSecBnToHexString`) confirms all six previously-failing cases now return the expected value, and the trivial single-byte case as well as the positive-add path still match expectations.