### PR TITLE
Return positive value in xmlSecBnCompare when bn is greater than data

### DIFF
--- a/src/bn.c
+++ b/src/bn.c
@@ -632,7 +632,7 @@ xmlSecBnCompare(xmlSecBnPtr bn, const xmlSecByte* data, xmlSecSize dataSize) {
     } else if(bnSize < dataSize) {
         return(-1);
     } else if(bnSize > dataSize) {
-        return(-1);
+        return(1);
     }
 
     xmlSecAssert2(bnData != NULL, -1);
@@ -679,7 +679,7 @@ xmlSecBnCompareReverse(xmlSecBnPtr bn, const xmlSecByte* data, xmlSecSize dataSi
     } else if(bnSize < dataSize) {
         return(-1);
     } else if(bnSize > dataSize) {
-        return(-1);
+        return(1);
     }
 
     xmlSecAssert2(bnData != NULL, -1);


### PR DESCRIPTION
### Bug

`xmlSecBnCompare` (and `xmlSecBnCompareReverse`) are documented in `include/xmlsec/bn.h` to return a negative value when `bn` is less than `data`, zero when they are equal, and a *positive* value when `bn` is greater than `data`. After stripping leading zeros from both operands, the size-comparison branch returns `-1` in both directions (see `src/bn.c:632-636` and `src/bn.c:679-683`):

```c
} else if(bnSize < dataSize) {
    return(-1);
} else if(bnSize > dataSize) {
    return(-1);   /* should be +1 */
}
```

So `bn > data` (because `bn` has more leading non-zero bytes) is reported as `bn < data`, which is the opposite of the documented contract.

### How to reproduce

After stripping leading zeros from both sides, any case where `bn` has more bytes than `data` triggers the bug. Concrete cases (using `xmlSecBnSetData` + `xmlSecBnCompare`):

| bn (bytes) | data (bytes) | numeric | expected sign | observed (before fix) |
|---|---|---|---|---|
| `00 01 00` (256) | `02` (2) | bn > data | positive | `-1` |
| `01 00 00` (65536) | `FF` (255) | bn > data | positive | `-1` |
| `01 2C` (300) | `02` (2) | bn > data | positive | `-1` |

All three return `-1` instead of a positive value on master; after this patch they return `1`. Equal and `bn < data` cases were already correct and still pass.

### Impact

The only in-tree caller is `xmlSecMSCngDhValidatePublicValueRange` in `src/mscng/certkeys.c:1844`, which performs the standard DH public-value range check `2 <= y <= p - 2` by computing `pMinusTwo = p - 2` and then:

```c
cmp = xmlSecBnCompare(&pMinusTwo, publicValue, publicValueSize);
if (cmp < 0) {
    xmlSecInvalidDataError(\"DH public key is greater than p - 2\", NULL);
    ...
}
```

Whenever the supplied DH public value has fewer leading non-zero bytes than `p - 2` (the normal case for any small/short `y`), `xmlSecBnCompare` returns `-1` and the validation falsely rejects the public value as 'greater than p - 2', even though numerically it is far smaller. `xmlSecBnCompareReverse` is exported from the public API in `include/xmlsec/bn.h` and has the same defect.

### Fix

Return `1` instead of `-1` in the `bnSize > dataSize` branch of both `xmlSecBnCompare` and `xmlSecBnCompareReverse` in `src/bn.c`. Two-character change, no behaviour change in the equal or `bn < data` branches, no API change.

### Verification

* Built `src/libxmlsec1.la` after the change.
* `apps/xmlsec_unit_tests` runs all suites with `FAILURE=0`.
* External round-trip program that calls `xmlSecBnSetData` + `xmlSecBnCompare` on the table above goes from 3 failing cases to 0 after the patch.