### PR TITLE
Free node list when xmlListInsert fails in Relationship transform

### DIFF
--- a/src/relationship.c
+++ b/src/relationship.c
@@ -382,6 +382,7 @@ xmlSecTransformRelationshipProcessNodeList(xmlSecTransformPtr transform, xmlOutp
         if(xmlStrcmp(cur->name, xmlSecNodeRelationship) == 0) {
             if(xmlListInsert(list, cur) != 0) {
                 xmlSecXmlError("xmlListInsert", xmlSecTransformGetName(transform));
+                xmlListDelete(list);
                 return(-1);
             }
         } else {


### PR DESCRIPTION
## What the bug is

`xmlSecTransformRelationshipProcessNodeList` in `src/relationship.c` allocates a temporary `xmlListPtr list` to sort `Relationship` elements by `Id` before processing them. When iterating the input children, the function calls `xmlListInsert(list, cur)` for every `Relationship` element. If `xmlListInsert` returns non-zero, the function returns `-1` immediately without freeing the list it just created:

```c
for(; cur; cur = cur->next) {
    if(xmlStrcmp(cur->name, xmlSecNodeRelationship) == 0) {
        if(xmlListInsert(list, cur) != 0) {
            xmlSecXmlError("xmlListInsert", xmlSecTransformGetName(transform));
            return(-1);          // <-- leaks `list`
        }
    } else {
        ret = xmlSecTransformRelationshipProcessNode(transform, buf, cur, depth, transformCtx);
        if(ret < 0) {
            xmlSecInternalError("xmlSecTransformRelationshipProcessNode", ...);
            xmlListDelete(list); // <-- correct cleanup here
            return(-1);
        }
    }
}
```

Every other error and success path in this function calls `xmlListDelete(list)` before returning (see `src/relationship.c` lines 391, 405, 413). The `xmlListInsert` failure path is the only one that does not.

## How to observe it

`xmlListInsert` in libxml2 returns non-zero when it fails to allocate the new `xmlLink` node (out-of-memory). On that path, the `xmlList` head plus any links already added are not released. Static inspection makes the asymmetry clear: compare the new error branch at `src/relationship.c:383-386` with the structurally identical branch at lines 388-393 that already calls `xmlListDelete(list)`.

## What the fix does

Adds the single missing `xmlListDelete(list)` call before the early `return(-1)` so the error path matches the cleanup contract used by the rest of the function. The change is local to the callee (`xmlSecTransformRelationshipProcessNodeList`) and is one line.

## Build / test evidence

* Configured with `./autogen.sh --without-gnutls --without-gcrypt --without-nss --enable-static` and ran `make -j4` — clean build.
* `apps/xmlsec_unit_tests` passes after the change (no regressions in the existing unit suite covering base64, transform helpers, x509, nodeset, and templates).