### PR TITLE
Fix memory leak in xmlSecTransformRsaOaepParamsRead on duplicate child nodes

### DIFF
--- a/src/transform_helpers.c
+++ b/src/transform_helpers.c
@@ -1897,14 +1897,24 @@ xmlSecTransformRsaOaepParamsRead(xmlSecTransformRsaOaepParamsPtr oaepParams, xml
                 return(-1);
             }
         } else if (xmlSecCheckNodeName(cur, xmlSecNodeDigestMethod, xmlSecDSigNs)) {
-            /* digest algorithm attribute is required */
+            /* digest algorithm attribute is required; free any previously
+             * stored value to avoid a leak if the node appears more than once */
+            if (oaepParams->digestAlgorithm != NULL) {
+                xmlFree(oaepParams->digestAlgorithm);
+                oaepParams->digestAlgorithm = NULL;
+            }
             oaepParams->digestAlgorithm = xmlGetProp(cur, xmlSecAttrAlgorithm);
             if (oaepParams->digestAlgorithm == NULL) {
                 xmlSecInvalidNodeAttributeError(cur, xmlSecAttrAlgorithm, NULL, "empty");
                 return(-1);
             }
         } else if (xmlSecCheckNodeName(cur, xmlSecNodeRsaMGF, xmlSecEnc11Ns)) {
-            /* mgf1 digest algorithm attribute is required */
+            /* mgf1 digest algorithm attribute is required; free any previously
+             * stored value to avoid a leak if the node appears more than once */
+            if (oaepParams->mgf1DigestAlgorithm != NULL) {
+                xmlFree(oaepParams->mgf1DigestAlgorithm);
+                oaepParams->mgf1DigestAlgorithm = NULL;
+            }
             oaepParams->mgf1DigestAlgorithm = xmlGetProp(cur, xmlSecAttrAlgorithm);
             if (oaepParams->mgf1DigestAlgorithm == NULL) {
                 xmlSecInvalidNodeAttributeError(cur, xmlSecAttrAlgorithm, NULL, "empty");


### PR DESCRIPTION
## Bug

`xmlSecTransformRsaOaepParamsRead` in `src/transform_helpers.c` iterates over
every child element of the `<EncryptionMethod>` node and stores the
`Algorithm` attribute of `<ds:DigestMethod>` and `<xenc11:MGF>` into
`oaepParams->digestAlgorithm` / `->mgf1DigestAlgorithm` via `xmlGetProp()`:

```c
} else if (xmlSecCheckNodeName(cur, xmlSecNodeDigestMethod, xmlSecDSigNs)) {
    /* digest algorithm attribute is required */
    oaepParams->digestAlgorithm = xmlGetProp(cur, xmlSecAttrAlgorithm);
    ...
} else if (xmlSecCheckNodeName(cur, xmlSecNodeRsaMGF, xmlSecEnc11Ns)) {
    /* mgf1 digest algorithm attribute is required */
    oaepParams->mgf1DigestAlgorithm = xmlGetProp(cur, xmlSecAttrAlgorithm);
    ...
}
```

There is nothing in the loop that rejects a duplicate `<ds:DigestMethod>` or
`<xenc11:MGF>` child, so if either appears more than once the second
`xmlGetProp()` result silently overwrites the first without freeing it.
`xmlSecTransformRsaOaepParamsFinalize` then frees only the last-stored value,
and every previous occurrence is leaked.

## Reproducer / evidence

Feed the parser an EncryptionMethod with duplicate DigestMethod / MGF children:

```xml
<EncryptionMethod xmlns="http://www.w3.org/2001/04/xmlenc#"
                  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
                  xmlns:xenc11="http://www.w3.org/2009/xmlenc11#"
                  Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep">
    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384"/>
    <xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
    <xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha384"/>
</EncryptionMethod>
```

Running the resulting binary with the macOS `leaks --atExit` tool (libxml2's
default malloc-backed allocator) reports, with the unmodified library:

```
Process N: 2 leaks for 112 total leaked bytes.
STACK OF 1 INSTANCE OF 'ROOT LEAK: <malloc in xmlStrndup>':
... main + 208  repro.c:51   (xmlSecTransformRsaOaepParamsRead)
```

The two leaks correspond to the first `digestAlgorithm` and first
`mgf1DigestAlgorithm` strings, both allocated through `xmlGetProp` ->
`xmlStrndup`.

## Fix

Free any value already stored in `oaepParams->digestAlgorithm` /
`->mgf1DigestAlgorithm` before assigning the new `xmlGetProp()` result. This
keeps the existing "last value wins" semantics that the loop already
implemented and only fixes the leak; it does not change behavior for
well-formed input where each child appears at most once. The fix is local to
the callee and is a few lines per branch.

After the patch the same reproducer reports `0 leaks for 0 total leaked
bytes`, and `apps/xmlsec_unit_tests` still passes (`Checking xmlsec-core: SUCCESS`).