### PR TITLE
Free DerivedKeyName/MasterKeyName when master key lookup fails

### DIFF
--- a/src/xmlenc.c
+++ b/src/xmlenc.c
@@ -1310,12 +1310,12 @@ xmlSecEncCtxDerivedKeyGenerate(xmlSecEncCtxPtr encCtx, xmlSecKeyDataId keyId, xm
         xmlSecOtherError2(XMLSEC_ERRORS_R_KEY_NOT_FOUND, NULL,
             "encMethod=%s", xmlSecErrorsSafeString(xmlSecTransformGetName(encCtx->encMethod)));
         xmlSecEncCtxMarkAsFailed(encCtx, xmlSecEncFailureReasonKeyNotFound);
-        return(NULL);
+        goto done;
     }
     ret = xmlSecTransformSetKey(encCtx->encMethod, encCtx->encKey);
     if(ret < 0) {
         xmlSecInternalError("xmlSecTransformSetKey", xmlSecTransformGetName(encCtx->encMethod));
-        return(NULL);
+        goto done;
     }
 
     /* let's get the derive key! */


### PR DESCRIPTION
xmlSecEncCtxDerivedKeyGenerate in src/xmlenc.c reads DerivedKeyName and
MasterKeyName via xmlSecGetNodeContentAndTrim into local strings that are
only freed via the trailing `done:` cleanup. Two error branches (key not
found, xmlSecTransformSetKey failure) returned NULL directly and skipped
that cleanup. Run under macOS `leaks` against a DerivedKey doc whose
MasterKeyName points at a missing key: 2 leaks / 160 bytes before, 0
after. Switched both early returns to `goto done;`.