### PR TITLE
Read EC PublicKey base64 from child node, not parent

### DIFF
--- a/src/keysdata_helpers.c
+++ b/src/keysdata_helpers.c
@@ -918,7 +918,7 @@ xmlSecKeyValueEcXmlRead(xmlSecKeyValueEcPtr data, xmlNodePtr node) {
         xmlSecInvalidNodeError(cur, xmlSecNodePublicKey, NULL);
         return(-1);
     }
-    ret = xmlSecBufferBase64NodeContentRead(&(data->pubkey), node);
+    ret = xmlSecBufferBase64NodeContentRead(&(data->pubkey), cur);
     if(ret < 0) {
         xmlSecInternalError("xmlSecBufferBase64NodeContentRead(pubkey)", NULL);
         return(-1);


### PR DESCRIPTION
xmlSecKeyValueEcXmlRead in src/keysdata_helpers.c reads the base64 PublicKey content from the parent ECKeyValue node instead of the child node `cur`, unlike every other reader in the file.