### PR TITLE
free docIn/docOut on output close error in xmlSecXslProcess

### DIFF
--- a/src/xslt.c
+++ b/src/xslt.c
@@ -490,7 +490,7 @@ xmlSecXslProcess(xmlSecXsltCtxPtr ctx, xmlSecBufferPtr in, xmlSecBufferPtr out) 
     output = NULL;
     if(ret < 0) {
         xmlSecXmlError("xmlOutputBufferClose", NULL);
-        return(-1);
+        goto done;
     }
 
     res = 0;


### PR DESCRIPTION
`xmlSecXslProcess` returns directly at src/xslt.c:493 when `xmlOutputBufferClose` fails, skipping the `done:` cleanup that frees `docIn` and `docOut`. Every other branch in the function uses `goto done`; switch this one too so both documents are freed on that path.