### PR TITLE
Fix double-free in xmlSecKeyUseWithDuplicate on copy failure

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -149,7 +149,7 @@ xmlSecKeyUseWithDuplicate(xmlSecKeyUseWithPtr keyUseWith) {
     ret = xmlSecKeyUseWithCopy(newKeyUseWith, keyUseWith);
     if(ret < 0) {
         xmlSecInternalError("xmlSecKeyUseWithCopy", NULL);
-        xmlSecKeyUseWithDestroy(keyUseWith);
+        xmlSecKeyUseWithDestroy(newKeyUseWith);
         return(NULL);
     }
 


### PR DESCRIPTION
On copy failure the error branch destroys the source argument instead of the new copy, double-freeing the list-owned item when that list is later released.