### PR TITLE
fix cert leak in xmlSecNssX509StoreRemoveRevokedCerts

### DIFF
--- a/src/nss/x509vfy.c
+++ b/src/nss/x509vfy.c
@@ -379,6 +379,7 @@ xmlSecNssX509StoreRemoveRevokedCerts(xmlSecNssX509StoreCtxPtr x509StoreCtx, CERT
         rv = CERT_AddCertToListTail((*res),  cert);
         if(rv != SECSuccess) {
             xmlSecNssError("CERT_AddCertToListTail", NULL);
+            CERT_DestroyCertificate(cert);
             return(-1);
         }
     }


### PR DESCRIPTION
xmlSecNssX509StoreRemoveRevokedCerts duplicates each surviving cert with CERT_DupCertificate before appending it to the output list. If CERT_AddCertToListTail fails, the function returns without releasing that duplicate, and the caller only frees the list, so the orphaned reference leaks. Destroy it on the error path, like the OpenSSL backend already does for its temporary.