### PR TITLE
use constant-time compare in xmlSecTransformHmacVerify

### DIFF
--- a/src/transform_helpers.c
+++ b/src/transform_helpers.c
@@ -1044,8 +1044,9 @@ int
 xmlSecTransformHmacVerify(const xmlSecByte* data, xmlSecSize dataSize,
     const xmlSecByte * hmac, xmlSecSize hmacSizeInBits, xmlSecSize hmacMaxSizeInBytes)
 {
-    xmlSecSize hmacSize;
+    xmlSecSize hmacSize, ii;
     xmlSecByte lastByteMask;
+    xmlSecByte diff;
 
     xmlSecAssert2(data != NULL, -1);
     xmlSecAssert2(dataSize > 0, -1);
@@ -1061,15 +1062,15 @@ xmlSecTransformHmacVerify(const xmlSecByte* data, xmlSecSize dataSize,
         return(0);
     }
 
-    /* we check the last byte separately */
+    /* compare in constant time so the number of matching leading bytes is not
+     * leaked through timing; the last byte is masked for truncated HMAC output */
     lastByteMask = g_hmac_last_byte_masks[hmacSizeInBits % 8];
-    if((hmac[hmacSize - 1] & lastByteMask) != (data[dataSize - 1] & lastByteMask)) {
-        xmlSecOtherError(XMLSEC_ERRORS_R_DATA_NOT_MATCH, NULL, "data and digest do not match (last byte)");
-        return(0);
+    diff = 0;
+    for(ii = 0; (ii + 1) < hmacSize; ++ii) {
+        diff |= (xmlSecByte)(hmac[ii] ^ data[ii]);
     }
-
-    /* now check the rest of the digest */
-    if((hmacSize > 1) && (memcmp(hmac, data, hmacSize - 1) != 0)) {
+    diff |= (xmlSecByte)((hmac[hmacSize - 1] & lastByteMask) ^ (data[dataSize - 1] & lastByteMask));
+    if(diff != 0) {
         xmlSecOtherError(XMLSEC_ERRORS_R_DATA_NOT_MATCH, NULL, "data and digest do not match");
         return(0);
     }


### PR DESCRIPTION
xmlSecTransformHmacVerify compared the expected HMAC with memcmp, whose early exit leaks the digest byte-by-byte through verification timing; all crypto backends call this one helper.