### PR TITLE
adopt duplicated cert in xmlSecMSCngKeysStoreSetKeyValueFromCert

### DIFF
--- a/src/mscng/keysstore.c
+++ b/src/mscng/keysstore.c
@@ -239,7 +239,7 @@ xmlSecMSCngKeysStoreSetKeyValueFromCert(xmlSecKeyPtr key, PCCERT_CONTEXT cert, x
         return(-1);
     }
 
-    keyValue = xmlSecMSCngCertAdopt(cert, keyReq->keyType);
+    keyValue = xmlSecMSCngCertAdopt(certTmp, keyReq->keyType);
     if (keyValue == NULL) {
         xmlSecInternalError("xmlSecMSCngCertAdopt", NULL);
         CertFreeCertificateContext(certTmp);


### PR DESCRIPTION
xmlSecMSCngKeysStoreSetKeyValueFromCert duplicates the cert into certTmp but then calls xmlSecMSCngCertAdopt on the borrowed `cert`, so on success certTmp is never released and the caller's reference (freed again in xmlSecMSCngKeysStoreFindKey) is over-freed. Adopt certTmp instead, like the sibling xmlSecMSCngKeysStoreAddCertDataToKey already does.