### PR TITLE
cast to unsigned char before isspace in xmlSecGetNodeContentAsSize

### DIFF
--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -190,7 +190,7 @@ xmlSecGetNodeContentAsSize(const xmlNodePtr cur, xmlSecSize defValue, xmlSecSize
     }
 
     /* skip spaces at the end */
-    while(isspace((int)(*endptr))) {
+    while(isspace((unsigned char)(*endptr))) {
         ++endptr;
     }
     if((content + xmlStrlen(content)) != BAD_CAST endptr) {


### PR DESCRIPTION
endptr in xmlSecGetNodeContentAsSize comes from strtol, so *endptr is a plain char; node content bytes >= 0x80 (any non-ASCII byte) sign-extend to a negative int, and isspace() is undefined for negative values other than EOF. Cast through unsigned char to match every other ctype call site in the tree.