### PR TITLE
fix use-after-free in xmlSecQName2BitMaskNodesRead

### DIFF
--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -1750,14 +1750,14 @@ xmlSecQName2BitMaskNodesRead(xmlSecQName2BitMaskInfoConstPtr info, xmlNodePtr* n
             xmlFree(content);
             return(-1);
         }
-        xmlFree(content);
-
         if((stopOnUnknown != 0) && (tmp == 0)) {
             /* todo: better error */
             xmlSecInternalError2("xmlSecQName2BitMaskGetBitMaskFromString", NULL,
                                  "value=%s", xmlSecErrorsSafeString(content));
+            xmlFree(content);
             return(-1);
         }
+        xmlFree(content);
 
         (*mask) |= tmp;
         cur = xmlSecGetNextElementNode(cur->next);


### PR DESCRIPTION
xmlSecQName2BitMaskNodesRead frees content, then reads it via xmlSecErrorsSafeString in the stopOnUnknown branch at src/xmltree.c:1758. Move the free below that check so the error path doesn't touch freed memory.