### PR TITLE
compare des3 key wrap checksum in constant time in xmlSecKWDes3Decode

### DIFF
--- a/src/kw_helpers.c
+++ b/src/kw_helpers.c
@@ -446,11 +446,21 @@ xmlSecKWDes3Decode(xmlSecKWDes3Id kwDes3Id, xmlSecTransformPtr transform,
         goto done;
     }
 
-    /* check sha1 */
+    /* check sha1 in constant time: the checksum is derived from the unwrapped
+     * key, so the number of matching leading bytes must not leak through timing */
     xmlSecAssert2(XMLSEC_KW_DES3_BLOCK_LENGTH <= sizeof(sha1), -1);
-    if(memcmp(sha1, out + outSz, XMLSEC_KW_DES3_BLOCK_LENGTH) != 0) {
-        xmlSecInvalidDataError("SHA1 does not match", NULL);
-        goto done;
+    {
+        const xmlSecByte* cks = out + outSz;
+        xmlSecByte diff = 0;
+        xmlSecSize ii;
+
+        for(ii = 0; ii < XMLSEC_KW_DES3_BLOCK_LENGTH; ++ii) {
+            diff |= (xmlSecByte)(sha1[ii] ^ cks[ii]);
+        }
+        if(diff != 0) {
+            xmlSecInvalidDataError("SHA1 does not match", NULL);
+            goto done;
+        }
     }
 
     /* success */


### PR DESCRIPTION
xmlSecKWDes3Decode at src/kw_helpers.c:451 checks the Triple-DES key-unwrap integrity checksum with memcmp, whose early exit leaks the matching-prefix length of a value derived from the unwrapped key. Compare it in constant time, like xmlSecTransformHmacVerify.
