### PR TITLE
fix secret buffer leak in xmlSecGnuTLSKeyAgreementExecute

### DIFF
--- a/src/gnutls/key_agrmnt.c
+++ b/src/gnutls/key_agrmnt.c
@@ -267,6 +267,7 @@ xmlSecGnuTLSKeyAgreementExecute(xmlSecTransformPtr transform, int last, xmlSecTr
         kamKeyData = xmlSecTransformCtxExtraKeyDataGet(transformCtx, xmlSecKeyDataKAMId);
         if(kamKeyData == NULL) {
             xmlSecInternalError("xmlSecTransformCtxExtraKeyDataGet", xmlSecTransformGetName(transform));
+            xmlSecBufferFinalize(&secret);
             return(-1);
         }
         ret = xmlSecGnuTLSKeyAgreementGenerateSecret(ctx, transform->operation, kamKeyData, &secret);


### PR DESCRIPTION
Noticed `xmlSecGnuTLSKeyAgreementExecute` finalizes the `secret` buffer on every path except the `kamKeyData == NULL` early return, which bails out right after `xmlSecBufferInitialize` and leaks it. The NSS backend already calls `xmlSecBufferFinalize` on that path.