### PR TITLE
compare aes key wrap magic block in constant time in xmlSecKWRfc3394Decode

### DIFF
--- a/src/kw_helpers.c
+++ b/src/kw_helpers.c
@@ -897,10 +897,20 @@ xmlSecKWRfc3394Decode(xmlSecKWRfc3394Id kwRfc3394Id, xmlSecTransformPtr transfor
     /* do not keep data in memory */
     memset(block, 0, sizeof(block));
 
-    /* check the output */
-    if(memcmp(xmlSecKWRfc3394MagicBlock, out, XMLSEC_KW_RFC3394_MAGIC_BLOCK_SIZE) != 0) {
-        xmlSecInvalidDataError("bad magic block", NULL);
-        return(-1);
+    /* check the output in constant time: the first block is derived from the
+     * unwrapped key, so the number of matching leading bytes must not leak
+     * through timing */
+    {
+        xmlSecByte diff = 0;
+        xmlSecSize ii;
+
+        for(ii = 0; ii < XMLSEC_KW_RFC3394_MAGIC_BLOCK_SIZE; ++ii) {
+            diff |= (xmlSecByte)(xmlSecKWRfc3394MagicBlock[ii] ^ out[ii]);
+        }
+        if(diff != 0) {
+            xmlSecInvalidDataError("bad magic block", NULL);
+            return(-1);
+        }
     }
 
     /* get rid of magic block */


### PR DESCRIPTION
xmlSecKWRfc3394Decode in src/kw_helpers.c is the shared AES-KW unwrap helper that all crypto backends route through when decrypting an attacker-supplied kw-aes128/192/256 EncryptedKey. The first 8 bytes of the unwrap output are then compared against the public magic block 0xA6A6A6A6A6A6A6A6 with memcmp, and the data-dependent verdict timing leaks the matching-prefix length of bytes derived from the KEK applied to the attacker's ciphertext. Same shape as #1179 for des3; switch to a constant-time XOR/OR accumulator.