### PR TITLE
free algorithm names on digest/mgf1 mismatch in mscng rsa oaep

### DIFF
--- a/src/mscng/kt_rsa.c
+++ b/src/mscng/kt_rsa.c
@@ -547,6 +547,12 @@ xmlSecMSCngRsaOaepNodeRead(xmlSecTransformPtr transform, xmlNodePtr node,
             "for mscng, rsa/oaep mgf1 algorithm=\"%s\" must be the same as digest algorithm=\"%s\"",
             xmlSecErrorsSafeString(digestAlg),
             xmlSecErrorsSafeString(mgf1Alg));
+        if (digestAlg != NULL) {
+            xmlFree(digestAlg);
+        }
+        if (mgf1Alg != NULL) {
+            xmlFree(mgf1Alg);
+        }
         xmlSecTransformRsaOaepParamsFinalize(&oaepParams);
         return(-1);
     }


### PR DESCRIPTION
xmlSecMSCngRsaOaepNodeRead in src/mscng/kt_rsa.c allocates two utf8
strings via xmlSecWin32ConvertUnicodeToUtf8 for the mismatched
digest/mgf1 error message and returns -1 without freeing either. The
function's docs say the returned string must be freed with xmlFree.
Triggered when an attacker-supplied EncryptionMethod for rsa-oaep
specifies a DigestMethod whose hash differs from the MGF Algorithm.