### PR TITLE
fix double-free in mscng dh key adoption on SetDhQ failure

### DIFF
--- a/src/mscng/certkeys.c
+++ b/src/mscng/certkeys.c
@@ -2332,12 +2332,13 @@ xmlSecMSCngAppKeyReadPubKeyFromDer(const xmlSecByte* derData, DWORD derDataLen) 
             xmlSecInternalError("xmlSecMSCngKeyDataAdoptKey(DH pub)", NULL);
             goto done;
         }
+        hPubKey = NULL; /* owned by data */
+
         ret = xmlSecMSCngKeyDataSetDhQ(data, pQ, pQLen);
         if(ret < 0) {
             xmlSecInternalError("xmlSecMSCngKeyDataSetDhQ", NULL);
             goto done;
         }
-        hPubKey = NULL; /* owned by data */
         res = data;
         data = NULL;
         goto done;

--- a/src/mscng/certkeys_dh.c
+++ b/src/mscng/certkeys_dh.c
@@ -355,6 +355,8 @@ xmlSecMSCngKeyDataDhRead(xmlSecKeyDataId id, xmlSecKeyValueDhPtr dhValue) {
         xmlSecInternalError("xmlSecMSCngKeyDataAdoptKey", xmlSecKeyDataGetName(data));
         goto done;
     }
+    hKey = 0; /* now owned by data */
+
     if(xmlSecBufferGetSize(&(dhValue->q)) > 0) {
         XMLSEC_SAFE_CAST_SIZE_TO_UINT(xmlSecBufferGetSize(&(dhValue->q)), dwBlobSize, goto done, NULL);
         ret = xmlSecMSCngKeyDataSetDhQ(data, xmlSecBufferGetData(&(dhValue->q)), dwBlobSize);
@@ -363,7 +365,6 @@ xmlSecMSCngKeyDataDhRead(xmlSecKeyDataId id, xmlSecKeyValueDhPtr dhValue) {
             goto done;
         }
     }
-    hKey = 0; /* now owned by data */
 
     /* success */
     res = data;
@@ -722,12 +723,13 @@ xmlSecMSCngKeyDataDhReadFromPkcs8Der(const xmlSecByte* derData, DWORD derDataLen
         xmlSecInternalError("xmlSecMSCngKeyDataAdoptBCryptPrivKey", NULL);
         goto done;
     }
+    hPrivKey = NULL; /* owned by data */
+
     ret = xmlSecMSCngKeyDataSetDhQ(data, pQ, pQLen);
     if(ret < 0) {
         xmlSecInternalError("xmlSecMSCngKeyDataSetDhQ", NULL);
         goto done;
     }
-    hPrivKey = NULL; /* owned by data */
 
     res = data;
     data = NULL;


### PR DESCRIPTION
Noticed that xmlSecMSCngKeyDataDhRead in src/mscng/certkeys_dh.c sets `hKey = 0` only after the trailing xmlSecMSCngKeyDataSetDhQ call. AdoptKey already transferred ownership to data->ctx->pubkey; if SetDhQ then fails the done: block destroys data (which BCryptDestroyKey's ctx->pubkey) and also calls BCryptDestroyKey(hKey) on the same handle.

The same pattern appears in xmlSecMSCngKeyDataDhReadFromPkcs8Der (hPrivKey adopted by xmlSecMSCngKeyDataAdoptBCryptPrivKey before SetDhQ) and in the DH branch of xmlSecMSCngAppKeyReadPubKeyFromDer in src/mscng/certkeys.c. RSA/DSA/EC readers and certkeys_xdh.c already clear the handle immediately after Adopt; moving the assignment up matches that convention.