### PR TITLE
return error from xmlSecTransformPump on incompatible data formats

### DIFF
--- a/src/openssl/x509.c
+++ b/src/openssl/x509.c
@@ -1454,7 +1454,7 @@ xmlSecOpenSSLX509Asn1TimeToTime(const ASN1_TIME * t, time_t * res) {
 
 #define g2(p) (((p)[0]-'0')*10+(p)[1]-'0')
     if(t->type == V_ASN1_UTCTIME) {
-        xmlSecAssert2(t->length > 12, 0);
+        xmlSecAssert2(t->length > 12, -1);
 
         /* this code is copied from OpenSSL asn1/a_utctm.c file */
         tm.tm_year = g2(t->data);
@@ -1469,7 +1469,7 @@ xmlSecOpenSSLX509Asn1TimeToTime(const ASN1_TIME * t, time_t * res) {
         if(t->data[12] == 'Z') {
             offset = 0;
         } else {
-            xmlSecAssert2(t->length > 16, 0);
+            xmlSecAssert2(t->length > 16, -1);
 
             offset = g2(t->data + 13) * 60 + g2(t->data + 15);
             if(t->data[12] == '-') {
@@ -1478,7 +1478,7 @@ xmlSecOpenSSLX509Asn1TimeToTime(const ASN1_TIME * t, time_t * res) {
         }
         tm.tm_isdst = -1;
     } else {
-        xmlSecAssert2(t->length > 14, 0);
+        xmlSecAssert2(t->length > 14, -1);
 
         tm.tm_year = g2(t->data) * 100 + g2(t->data + 2);
         tm.tm_mon  = g2(t->data + 4) - 1;
@@ -1489,7 +1489,7 @@ xmlSecOpenSSLX509Asn1TimeToTime(const ASN1_TIME * t, time_t * res) {
         if(t->data[14] == 'Z') {
             offset = 0;
         } else {
-            xmlSecAssert2(t->length > 18, 0);
+            xmlSecAssert2(t->length > 18, -1);
 
             offset = g2(t->data + 15) * 60 + g2(t->data + 17);
             if(t->data[14] == '-') {

--- a/src/transforms.c
+++ b/src/transforms.c
@@ -1587,6 +1587,7 @@ xmlSecTransformPump(xmlSecTransformPtr left, xmlSecTransformPtr right, xmlSecTra
         xmlSecInvalidTransfromError2(left,
                     "transforms input/output data formats do not match, right transform=\"%s\"",
                     xmlSecErrorsSafeString(xmlSecTransformGetName(right)));
+        return(-1);
     }
     return(0);
 }


### PR DESCRIPTION
When the left transform's pop data type and the right transform's push data type are neither both XML nor both binary, xmlSecTransformPump logs an invalid-transform error via xmlSecInvalidTransfromError2 but then falls through to return(0). Every other branch in the function returns -1 on failure, and the caller in xmlSecTransformInputURIExecute only tests ret < 0, so it treats the no-op pump as success and keeps processing the chain. Return -1 in that branch so the logged error actually propagates.