### PR TITLE
free node set when xmlSecNodeSetCreate fails in xmlSecNodeSetGetChildren

### DIFF
--- a/src/nodeset.c
+++ b/src/nodeset.c
@@ -477,6 +477,7 @@ xmlSecNodeSetWalkRecursive(xmlSecNodeSetPtr nset, xmlNodePtr startNode, xmlSecNo
  */
 xmlSecNodeSetPtr
 xmlSecNodeSetGetChildren(xmlDocPtr doc, const xmlNodePtr parent, int withComments, int invert) {
+    xmlSecNodeSetPtr nset;
     xmlNodeSetPtr nodes;
     xmlSecNodeSetType type;
 
@@ -508,7 +509,13 @@ xmlSecNodeSetGetChildren(xmlDocPtr doc, const xmlNodePtr parent, int withComment
         type = xmlSecNodeSetTreeWithoutComments;
     }
 
-    return(xmlSecNodeSetCreate(doc, nodes, type));
+    nset = xmlSecNodeSetCreate(doc, nodes, type);
+    if(nset == NULL) {
+        xmlSecInternalError("xmlSecNodeSetCreate", NULL);
+        xmlXPathFreeNodeSet(nodes);
+        return(NULL);
+    }
+    return(nset);
 }
 
 static int


### PR DESCRIPTION
xmlSecNodeSetGetChildren allocates a node set with xmlXPathNodeSetCreate and passes it to xmlSecNodeSetCreate, which only takes ownership on success and returns NULL without touching the list when its own allocation fails, leaking the set. The other caller in xpath.c already frees the set it passes on that failure path before returning NULL; this one returned the NULL straight through. Free it here to match.