### PR TITLE
free node on xmlSetProp failure in xmlSecTmplX509DataAddDigest

### DIFF
--- a/src/templates.c
+++ b/src/templates.c
@@ -1358,6 +1358,8 @@ xmlSecTmplX509DataAddDigest(xmlNodePtr x509DataNode, const xmlChar* digestAlgori
 
     if(xmlSetProp(cur, xmlSecAttrAlgorithm, digestAlgorithm) == NULL) {
         xmlSecXmlError2("xmlSetProp", NULL, "name=%s", xmlSecErrorsSafeString(xmlSecAttrAlgorithm));
+        xmlUnlinkNode(cur);
+        xmlFreeNode(cur);
         return(NULL);
     }
 


### PR DESCRIPTION
When xmlSetProp fails, xmlSecTmplX509DataAddDigest returns NULL but leaves the just-added X509Digest node in the caller's tree; xmlSecTmplTransformAddRsaDigest and xmlSecTmplTransformAddRsaMgf already xmlUnlinkNode/xmlFreeNode it on the same path.