### PR TITLE
insert key cert at front in xmlSecGnuTLSKeyDataX509AddCertInternal

### DIFF
--- a/src/gnutls/x509.c
+++ b/src/gnutls/x509.c
@@ -231,7 +231,7 @@ xmlSecGnuTLSKeyDataX509AddCertInternal(xmlSecGnuTLSX509DataCtxPtr ctx, gnutls_x5
     }
 
     /* ensure that key cert is the first one */
-    if(keyCert != 1) {
+    if(keyCert != 0) {
         ret = xmlSecPtrListInsert(&(ctx->certsList), cert, 0);
         if(ret < 0) {
             xmlSecInternalError("xmlSecPtrListInsert(0)", NULL);


### PR DESCRIPTION
xmlSecGnuTLSKeyDataX509AddCertInternal inserts at position 0 when keyCert != 1, so chain certs land at the front and the key cert is appended to the end, the opposite of the comment just above it. The OpenSSL and NSS backends both put the key cert at the head (keyCert != 0). Switching the gnutls test to != 0 makes the key cert first again, matching the other backends and the documented intent.