### PR TITLE
return error from xmlSecKeyDataBinaryValueBinRead on key req mismatch

### DIFF
--- a/src/keysdata_helpers.c
+++ b/src/keysdata_helpers.c
@@ -389,7 +389,7 @@ xmlSecKeyDataBinaryValueBinRead(xmlSecKeyDataId id, xmlSecKeyPtr key,
         xmlSecInternalError("xmlSecKeyReqMatchKeyValue",
             xmlSecKeyDataKlassGetName(id));
         xmlSecKeyDataDestroy(data);
-        return(0);
+        return(-1);
     }
 
     ret = xmlSecKeySetValue(key, data);


### PR DESCRIPTION
The binary key value reader accepts a value that fails xmlSecKeyReqMatchKeyValue and reports success, unlike the XML sibling xmlSecKeyDataBinaryValueXmlRead which returns an error. Triggered when an EncryptedKey decrypts to a key whose type doesn't match the request, leaving the caller to continue with no key set.