### PR TITLE
return 0 on signature mismatch in nss/mscng/mscrypto verify

### DIFF
--- a/src/mscng/signatures.c
+++ b/src/mscng/signatures.c
@@ -813,6 +813,7 @@ xmlSecMSCngSignatureVerify(xmlSecTransformPtr transform,
                 xmlSecTransformGetName(transform),
                 "BCryptVerifySignature: the signature was not verified");
             transform->status = xmlSecTransformStatusFail;
+            res = 0;
             goto done;
         } else {
             xmlSecMSCngNtError("BCryptVerifySignature",

--- a/src/mscrypto/signatures.c
+++ b/src/mscrypto/signatures.c
@@ -409,6 +409,7 @@ static int xmlSecMSCryptoSignatureVerify(xmlSecTransformPtr transform,
             xmlSecOtherError(XMLSEC_ERRORS_R_DATA_NOT_MATCH, xmlSecTransformGetName(transform),
                 "CryptVerifySignature: signature verification failed");
             transform->status = xmlSecTransformStatusFail;
+            res = 0;
             goto done;
         } else {
             xmlSecMSCryptoError("CryptVerifySignature", xmlSecTransformGetName(transform));

--- a/src/nss/signatures.c
+++ b/src/nss/signatures.c
@@ -754,6 +754,7 @@ xmlSecNssSignatureVerify(xmlSecTransformPtr transform,
                              xmlSecTransformGetName(transform),
                              "signature verification failed");
             transform->status = xmlSecTransformStatusFail;
+            return(0);
         } else {
             xmlSecNssError((ctx->isEdDSA) ? "PK11_Verify" : "VFY_EndWithSignature",
                            xmlSecTransformGetName(transform));


### PR DESCRIPTION
xmlSecNssSignatureVerify, xmlSecMSCngSignatureVerify and xmlSecMSCryptoSignatureVerify set transform->status to Fail on a signature mismatch but then return -1, so a bad SignatureValue surfaces as a processing error instead of a clean invalid verdict. The openssl and gnutls verifiers, and every backend's digest verify, return 0 with status Fail there. Return 0 on the mismatch branch to match.