### PR TITLE
avoid integer overflow in length check in xmlSecGnuTLSReadDerInteger

### DIFF
--- a/src/gnutls/signatures.c
+++ b/src/gnutls/signatures.c
@@ -812,8 +812,8 @@ xmlSecGnuTLSReadDerInteger(const xmlSecByte * data, xmlSecSize dataSize, xmlSecS
         return(-1);
     }
 
-    /* val */
-    if(dataSize < (*ii) + len) {
+    /* val: (*ii) <= dataSize here, so check len without overflowing (*ii) + len */
+    if(len > dataSize - (*ii)) {
         return(-1);
     }
     /* skip zeros if any */


### PR DESCRIPTION
Noticed the bounds check in xmlSecGnuTLSReadDerInteger reads `dataSize < (*ii) + len`, but `len` comes from the long-form DER length parser and can be as large as SIZE_MAX, so `(*ii) + len` wraps around and the check passes. The skip-leading-zeros loop right after then reads past the end of `data`. Since `(*ii) <= dataSize` at that point, checking `len > dataSize - (*ii)` keeps the same intent without the wraparound. A crafted long-form length (0x88 followed by eight 0xFF bytes) triggers a 1-byte heap over-read under ASAN with the old check and is rejected cleanly with the new one; valid integers and leading-zero stripping are unaffected.