### PR TITLE
fix friendly name buffer leak in xmlSecMSCngX509GetFriendlyNameUnicode

### DIFF
--- a/src/mscng/x509vfy.c
+++ b/src/mscng/x509vfy.c
@@ -1503,6 +1503,7 @@ xmlSecMSCngX509GetFriendlyNameUnicode(PCCERT_CONTEXT cert) {
         &dwPropSize);
     if ((ret != TRUE) || (dwPropSize <= 0)) {
         xmlSecMSCngLastError("CertGetCertificateContextProperty", NULL);
+        xmlFree(pbFriendlyName);
         return(NULL);
     }
 


### PR DESCRIPTION
Noticed this comparing the mscng and mscrypto friendly-name readers. xmlSecMSCngX509GetFriendlyNameUnicode allocates pbFriendlyName, then on a failed second CertGetCertificateContextProperty call returns without freeing it. Reachable when loading a cert/key from a PKCS12 file via xmlSecMSCngAppPkcs12Load. The mscrypto reader in keysstore.c frees the buffer on the same branch.