### PR TITLE
reject HMACOutputLength larger than the HMAC digest size

### DIFF
--- a/src/gnutls/hmac.c
+++ b/src/gnutls/hmac.c
@@ -362,6 +362,17 @@ xmlSecGnuTLSHmacExecute(xmlSecTransformPtr transform, int last, xmlSecTransformC
         /* get hash */
         gnutls_hmac_output(ctx->hmac, ctx->hmacOutput);
 
+        /* HMACOutputLength can only truncate the digest, not extend it past the bytes we have */
+        {
+            xmlSecSize dgstSize = (xmlSecSize)gnutls_hmac_get_len(ctx->hmacAlgo);
+            if(XMLSEC_TRANSFORM_HMAC_BITS_TO_BYTES(ctx->hmacSizeInBits) > dgstSize) {
+                xmlSecInvalidSizeMoreThanError("HMAC output length",
+                    XMLSEC_TRANSFORM_HMAC_BITS_TO_BYTES(ctx->hmacSizeInBits), dgstSize,
+                    xmlSecTransformGetName(transform));
+                return(-1);
+            }
+        }
+
         /* write results if needed */
         if(transform->operation == xmlSecTransformOperationSign) {
             ret = xmlSecTransformHmacWriteOutput(ctx->hmacOutput, ctx->hmacSizeInBits, XMLSEC_TRANSFORM_HMAC_MAX_OUTPUT_SIZE, out);

--- a/src/nss/hmac.c
+++ b/src/nss/hmac.c
@@ -424,6 +424,14 @@ xmlSecNssHmacExecute(xmlSecTransformPtr transform, int last, xmlSecTransformCtxP
                 ctx->dgstSizeInBits = dgstSize * 8; /* no dgst size specified, use all we have */
             }
 
+            /* HMACOutputLength can only truncate the digest, not extend it past the bytes we have */
+            if(XMLSEC_TRANSFORM_HMAC_BITS_TO_BYTES(ctx->dgstSizeInBits) > dgstSize) {
+                xmlSecInvalidSizeMoreThanError("HMAC output length",
+                    XMLSEC_TRANSFORM_HMAC_BITS_TO_BYTES(ctx->dgstSizeInBits), dgstSize,
+                    xmlSecTransformGetName(transform));
+                return(-1);
+            }
+
             /* write results if needed */
             if(transform->operation == xmlSecTransformOperationSign) {
                 ret = xmlSecTransformHmacWriteOutput(ctx->dgst, ctx->dgstSizeInBits, dgstSize, out);

--- a/src/openssl/hmac.c
+++ b/src/openssl/hmac.c
@@ -558,6 +558,14 @@ xmlSecOpenSSLHmacExecute(xmlSecTransformPtr transform, int last, xmlSecTransform
                 ctx->dgstSizeInBits = dgstSize * 8; /* no dgst size specified, use all we have */
             }
 
+            /* HMACOutputLength can only truncate the digest, not extend it past the bytes we have */
+            if(XMLSEC_TRANSFORM_HMAC_BITS_TO_BYTES(ctx->dgstSizeInBits) > dgstSize) {
+                xmlSecInvalidSizeMoreThanError("HMAC output length",
+                    XMLSEC_TRANSFORM_HMAC_BITS_TO_BYTES(ctx->dgstSizeInBits), dgstSize,
+                    xmlSecTransformGetName(transform));
+                return(-1);
+            }
+
             /* write results if needed */
             if(transform->operation == xmlSecTransformOperationSign) {
                 ret = xmlSecTransformHmacWriteOutput(ctx->dgst, ctx->dgstSizeInBits, dgstSize, out);


### PR DESCRIPTION
HMACOutputLength is only bounded below, so a value larger than the digest makes hmac verify read past the computed MAC; mscng/mscrypto already reject it.