### PR TITLE
(xmlsec-core) Fixed various trivial issues (failures after OOM, integer overflows in buffer size math, spelling, comments, etc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ docs/html/html.stamp
 build-*/*
 scripts/__pycache__
 .github/copilot-instructions.md
-
+.opencode/

--- a/apps/xmlsec.c
+++ b/apps/xmlsec.c
@@ -204,7 +204,8 @@ static xmlSecAppCmdLineParam base64LineSizeParam = {
     "--base64-line-size",
     NULL,
     "--base64-line-size <size>"
-    "\n\tsets the max line size for base64 encodings to <size>",
+    "\n\tsets the max line size for base64 encodings to <size>; use 0 to disable"
+    "\n\tline breaks, otherwise <size> must be greater than 1",
     xmlSecAppCmdLineParamTypeNumber,
     xmlSecAppCmdLineParamFlagNone,
     NULL
@@ -1554,8 +1555,8 @@ xmlSecAppExecute(xmlSecAppCommand command, const char** utf8_argv, int argc) {
     /* base64 line size */
     if(xmlSecAppCmdLineParamIsSet(&base64LineSizeParam)) {
         int lineSize = xmlSecAppCmdLineParamGetInt(&base64LineSizeParam, 0);
-        if(lineSize <= 0) {
-            fprintf(stderr, "Error: base64 line size should be greater than zero\n");
+        if((lineSize != 0) && (lineSize <= 1)) {
+            fprintf(stderr, "Error: base64 line size should be 0 or greater than 1\n");
             xmlSecAppPrintUsage();
             goto done;
         }

--- a/include/xmlsec/app.h
+++ b/include/xmlsec/app.h
@@ -230,7 +230,7 @@ XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformConcatKdfGetKlass
 #define xmlSecTransformDes3CbcId                xmlSecTransformDes3CbcGetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformDes3CbcGetKlass(void);
 /**
- * @brief The DES3 CBC cipher transform klass.
+ * @brief The Triple DES key wrap transform klass.
  */
 #define xmlSecTransformKWDes3Id                 xmlSecTransformKWDes3GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformKWDes3GetKlass(void);
@@ -286,7 +286,7 @@ XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformEcdsaSha224GetKla
 #define xmlSecTransformEcdsaSha256Id            xmlSecTransformEcdsaSha256GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformEcdsaSha256GetKlass(void);
 /**
- * @brief The ECDS-SHA2-384 signature transform klass.
+ * @brief The ECDSA-SHA2-384 signature transform klass.
  */
 #define xmlSecTransformEcdsaSha384Id            xmlSecTransformEcdsaSha384GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformEcdsaSha384GetKlass(void);
@@ -307,7 +307,7 @@ XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformEcdsaSha3_224GetK
 #define xmlSecTransformEcdsaSha3_256Id          xmlSecTransformEcdsaSha3_256GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformEcdsaSha3_256GetKlass(void);
 /**
- * @brief The ECDS-SHA3-384 signature transform klass.
+ * @brief The ECDSA-SHA3-384 signature transform klass.
  */
 #define xmlSecTransformEcdsaSha3_384Id          xmlSecTransformEcdsaSha3_384GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformEcdsaSha3_384GetKlass(void);
@@ -512,12 +512,12 @@ XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformRsaPssSha3_512Get
 #define xmlSecTransformRsaPkcs1Id               xmlSecTransformRsaPkcs1GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformRsaPkcs1GetKlass(void);
 /**
- * @brief The RSA PKCS1 key transport transform klass (XMLEnc 1.0).
+ * @brief The RSA-OAEP key transport transform klass (XMLEnc 1.0).
  */
 #define xmlSecTransformRsaOaepId                xmlSecTransformRsaOaepGetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformRsaOaepGetKlass(void);
 /**
- * @brief The RSA PKCS1 key transport transform klass (XMLEnc 1.1).
+ * @brief The RSA-OAEP key transport transform klass (XMLEnc 1.1).
  */
 #define xmlSecTransformRsaOaepEnc11Id           xmlSecTransformRsaOaepEnc11GetKlass()
 XMLSEC_EXPORT xmlSecTransformId                 xmlSecTransformRsaOaepEnc11GetKlass(void);

--- a/include/xmlsec/errors.h
+++ b/include/xmlsec/errors.h
@@ -302,7 +302,13 @@ extern "C" {
 /**
  * @brief Impossible to cast from one type to another.
  */
-#define XMLSEC_ERROR_R_CAST_IMPOSSIBLE                  101
+#define XMLSEC_ERRORS_R_CAST_IMPOSSIBLE                 101
+
+/**
+ * @brief Impossible to cast from one type to another.
+ * DEPRECATED. Use #XMLSEC_ERRORS_R_CAST_IMPOSSIBLE instead.
+ */
+#define XMLSEC_ERROR_R_CAST_IMPOSSIBLE                  XMLSEC_ERRORS_R_CAST_IMPOSSIBLE
 
 /**
  * @brief The maximum xmlsec errors number.
@@ -318,6 +324,7 @@ extern "C" {
   *****************************************************************************/
 /**
  * @brief The errors reporting callback function.
+ * @param file the error location file name (__FILE__ macro).
  * @param line the error location line number (__LINE__ macro).
  * @param func the error location function name (__func__ macro).
  * @param errorObject the error specific error object (e.g. transform, key data, etc).

--- a/include/xmlsec/keyinfo.h
+++ b/include/xmlsec/keyinfo.h
@@ -179,7 +179,7 @@ struct _xmlSecKeyInfoCtx {
 
 #ifndef XMLSEC_NO_XMLENC
     /* EncryptedKey or DerivedKey */
-    xmlSecEncCtxPtr                     encCtx;  /**< the encryption context for <dsig:EncryptedKey /> element processing. */
+    xmlSecEncCtxPtr                     encCtx;  /**< the encryption context for <enc:EncryptedKey /> element processing. */
     int                                 maxEncryptedKeyLevel;  /**< the max recursion level when processing &lt;enc:EncryptedKey/&gt; element; default level is 1 (see #curEncryptedKeyLevel). */
 #endif /* XMLSEC_NO_XMLENC */
 

--- a/include/xmlsec/keyinfo.h
+++ b/include/xmlsec/keyinfo.h
@@ -162,7 +162,7 @@ typedef enum {
  */
 struct _xmlSecKeyInfoCtx {
     void*                               userData;  /**< the pointer to user data (xmlsec and xmlsec-crypto never touch this). */
-    unsigned int                        flags;  /**< the bit mask for flags that control processin. */
+    unsigned int                        flags;  /**< the bit mask for flags that control processing. */
     unsigned int                        flags2;  /**< reserved for future. */
     xmlSecKeysMngrPtr                   keysMngr;  /**< the pointer to current keys manager. */
     xmlSecKeyInfoMode                   mode;  /**< do we read or write <dsig:KeyInfo /> element. */
@@ -174,7 +174,7 @@ struct _xmlSecKeyInfoCtx {
     int                                 maxRetrievalMethodLevel;  /**< the max recursion level when processing &lt;dsig:RetrievalMethod/&gt; element; default level is 1 (see also #curRetrievalMethodLevel). */
 
     /* KeyInfoReference */
-    xmlSecTransformCtx                  keyInfoReferenceCtx;  /**< the transforms context for&lt;dsig11:KeyInfoReference/&gt; element processing. */
+    xmlSecTransformCtx                  keyInfoReferenceCtx;  /**< the transforms context for &lt;dsig11:KeyInfoReference/&gt; element processing. */
     int                                 maxKeyInfoReferenceLevel;  /**< the max recursion level when processing &lt;dsig11:KeyInfoReference/&gt; element; default level is 1 (see also #curKeyInfoReferenceLevel). */
 
 #ifndef XMLSEC_NO_XMLENC
@@ -193,9 +193,9 @@ struct _xmlSecKeyInfoCtx {
     void*                               deprecated0;  /**< DEPRECATED: reserved for PGP. */
 
     /* internal data */
-    int                                 curRetrievalMethodLevel;  /**< the current&lt;dsig:RetrievalMethod/&gt; element processing level (see #maxRetrievalMethodLevel). */
-    int                                 curKeyInfoReferenceLevel;  /**< the current&lt;dsig11:KeyInfoReference/&gt; element processing level (see #maxKeyInfoReferenceLevel). */
-    int                                 curEncryptedKeyLevel;  /**< the current&lt;enc:EncryptedKey/&gt; or&lt;enc11:DerivedKey/&gt; element processing level (see #maxEncryptedKeyLevel). */
+    int                                 curRetrievalMethodLevel;  /**< the current &lt;dsig:RetrievalMethod/&gt; element processing level (see #maxRetrievalMethodLevel). */
+    int                                 curKeyInfoReferenceLevel;  /**< the current &lt;dsig11:KeyInfoReference/&gt; element processing level (see #maxKeyInfoReferenceLevel). */
+    int                                 curEncryptedKeyLevel;  /**< the current &lt;enc:EncryptedKey/&gt; or &lt;enc11:DerivedKey/&gt; element processing level (see #maxEncryptedKeyLevel). */
     xmlSecTransformOperation            operation;  /**< the transform operation for this key info. */
     xmlSecKeyReq                        keyReq;  /**< the current key requirements. */
 

--- a/include/xmlsec/keys.h
+++ b/include/xmlsec/keys.h
@@ -112,7 +112,7 @@ struct _xmlSecKeyUseWith {
 };
 
 /**
- * @brief The keys list klass.
+ * @brief The key use-with list klass.
  */
 #define xmlSecKeyUseWithPtrListId       xmlSecKeyUseWithPtrListGetKlass()
 XMLSEC_EXPORT xmlSecPtrListId   xmlSecKeyUseWithPtrListGetKlass (void);
@@ -221,8 +221,8 @@ XMLSEC_EXPORT xmlSecKeyPtr      xmlSecKeyReadMemory     (xmlSecKeyDataId dataId,
 
 /**
  * @brief Macro. Returns 1 if @p key is valid.
- * @details Macro. Returns 1 if @p key is not NULL and @p key->id is not NULL
- * or 0 otherwise.
+ * @details Macro. Returns 1 if @p key is not NULL, @p key->value is not NULL
+ * and @p key->value->id is not NULL, or 0 otherwise.
  * @param key the pointer to key.
  */
 #define xmlSecKeyIsValid(key) \

--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -227,7 +227,7 @@ typedef enum {
     xmlSecKeyDataFormatDer,  /**< the DER key data (cert or public/private key). */
     xmlSecKeyDataFormatPkcs8Pem,  /**< the PKCS8 PEM private key. */
     xmlSecKeyDataFormatPkcs8Der,  /**< the PKCS8 DER private key. */
-    xmlSecKeyDataFormatPkcs12,  /**< the PKCS12 format (bag of keys and certs) */
+    xmlSecKeyDataFormatPkcs12,  /**< the PKCS12 format (bag of keys and certs). */
     xmlSecKeyDataFormatCertPem,  /**< the PEM cert. */
     xmlSecKeyDataFormatCertDer,  /**< the DER cert. */
     xmlSecKeyDataFormatEngine,  /**< the crypto engine (e.g. OpenSSL ENGINE). */
@@ -494,7 +494,7 @@ struct _xmlSecKeyDataKlass {
     /* get info */
     xmlSecKeyDataGetTypeMethod          getType;  /**< the method to access data's type information. */
     xmlSecKeyDataGetSizeMethod          getSize;  /**< the method to access data's size. */
-    void*                               deprecated0;  /**< DEPRECAED: the method to access data's string identifier. */
+    void*                               deprecated0;  /**< DEPRECATED: the method to access data's string identifier. */
 
     /* read/write */
     xmlSecKeyDataXmlReadMethod          xmlRead;  /**< the method for reading data from XML node. */

--- a/include/xmlsec/keysdata.h
+++ b/include/xmlsec/keysdata.h
@@ -423,7 +423,7 @@ typedef int                     (*xmlSecKeyDataBinReadMethod)   (xmlSecKeyDataId
                                                                  xmlSecKeyInfoCtxPtr keyInfoCtx);
 /**
  * @brief Key data specific method to write a binary buffer.
- * @details Key data specific method for reading binary buffer.
+ * @details Key data specific method for writing binary buffer.
  * @param id the data id.
  * @param key the key.
  * @param buf the output buffer.
@@ -620,7 +620,7 @@ XMLSEC_EXPORT void              xmlSecKeyDataStoreDestroy       (xmlSecKeyDataSt
 
 /**
  * @brief Macro. Returns 1 if @p store's object has at least @p size bytes.
- * @details Macro. Returns 1 if @p data is valid and @p stores's object has at least @p size bytes.
+ * @details Macro. Returns 1 if @p store is valid and @p store 's object has at least @p size bytes.
  * @param store the pointer to store.
  * @param size the expected size.
  */

--- a/include/xmlsec/keysmngr.h
+++ b/include/xmlsec/keysmngr.h
@@ -217,7 +217,7 @@ struct _xmlSecKeyStoreKlass {
     xmlSecKeyStoreInitializeMethod              initialize;  /**< the store's initialization method. */
     xmlSecKeyStoreFinalizeMethod                finalize;  /**< the store's finalization (destroy) method. */
 
-    /* key loopkup */
+    /* key lookup */
     xmlSecKeyStoreFindKeyMethod                 findKey;  /**< the store's method to find key by key name. */
     xmlSecKeyStoreFindKeyFromX509DataMethod     findKeyFromX509Data;  /**< the store's method to find key based on x509 data. */
 

--- a/include/xmlsec/keysmngr.h
+++ b/include/xmlsec/keysmngr.h
@@ -144,13 +144,13 @@ XMLSEC_EXPORT xmlSecKeyPtr      xmlSecKeyStoreFindKeyFromX509Data(xmlSecKeyStore
 
 /**
  * @brief Macro. Returns 1 if store is valid and object size meets minimum.
- * @details Macro. Returns 1 if @p store is valid and @p stores's object has at least @p size bytes.
+ * @details Macro. Returns 1 if @p store is valid and @p store 's object has at least @p size bytes.
  * @param store the pointer to store.
  * @param size the expected size.
  */
 #define xmlSecKeyStoreCheckSize(store, size) \
         (xmlSecKeyStoreIsValid(( store )) && \
-         (( store )->id->objSize >= size))
+          (( store )->id->objSize >= ( size )))
 
 
 /******************************************************************************
@@ -161,7 +161,7 @@ XMLSEC_EXPORT xmlSecKeyPtr      xmlSecKeyStoreFindKeyFromX509Data(xmlSecKeyStore
 /**
  * @brief The "unknown" id.
  */
-#define xmlSecKeyStoreIdUnknown                         ((xmlSecKeyDataStoreId)NULL)
+#define xmlSecKeyStoreIdUnknown                         ((xmlSecKeyStoreId)NULL)
 
 /**
  * @brief Keys store specific initialization method.

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -119,6 +119,9 @@ XMLSEC_EXPORT void              xmlSecPtrListDebugXmlDump       (xmlSecPtrListPt
 
 /**
  * @brief Duplicates item @p ptr.
+ * @details If this method is not NULL then the list klass must also provide
+ * #xmlSecPtrDestroyItemMethod to release items duplicated by this method,
+ * including partial copies rolled back after an error.
  * @param ptr the poinetr to list item.
  * @return pointer to new item copy or NULL if an error occurs.
  */
@@ -143,8 +146,8 @@ typedef void                    (*xmlSecPtrDebugDumpItemMethod) (xmlSecPtr ptr,
  */
 struct _xmlSecPtrListKlass {
     const xmlChar*                      name;  /**< the list klass name. */
-    xmlSecPtrDuplicateItemMethod        duplicateItem;  /**< the duplicate item method. */
-    xmlSecPtrDestroyItemMethod          destroyItem;  /**< the destroy item method. */
+    xmlSecPtrDuplicateItemMethod        duplicateItem;  /**< the duplicate item method; requires destroyItem when not NULL. */
+    xmlSecPtrDestroyItemMethod          destroyItem;  /**< the destroy item method for list-owned items, including duplicated items. */
     xmlSecPtrDebugDumpItemMethod        debugDumpItem;  /**< the debug dump item method. */
     xmlSecPtrDebugDumpItemMethod        debugXmlDumpItem;  /**< the debug dump item in xml format method. */
 };

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -83,7 +83,7 @@ XMLSEC_EXPORT void              xmlSecPtrListDebugXmlDump       (xmlSecPtrListPt
                                                                  FILE* output);
 
 /**
- * @brief Macro. Returns lists's name.
+ * @brief Macro. Returns list's name.
  * @param list the pointer to list.
  */
 #define xmlSecPtrListGetName(list) \

--- a/include/xmlsec/list.h
+++ b/include/xmlsec/list.h
@@ -84,7 +84,7 @@ XMLSEC_EXPORT void              xmlSecPtrListDebugXmlDump       (xmlSecPtrListPt
 
 /**
  * @brief Macro. Returns lists's name.
- * @param list the ponter to list.
+ * @param list the pointer to list.
  */
 #define xmlSecPtrListGetName(list) \
         (((list) != NULL) ? xmlSecPtrListKlassGetName((list)->id) : NULL)
@@ -122,20 +122,20 @@ XMLSEC_EXPORT void              xmlSecPtrListDebugXmlDump       (xmlSecPtrListPt
  * @details If this method is not NULL then the list klass must also provide
  * #xmlSecPtrDestroyItemMethod to release items duplicated by this method,
  * including partial copies rolled back after an error.
- * @param ptr the poinetr to list item.
+ * @param ptr the pointer to list item.
  * @return pointer to new item copy or NULL if an error occurs.
  */
 typedef xmlSecPtr               (*xmlSecPtrDuplicateItemMethod) (xmlSecPtr ptr);
 
 /**
  * @brief Destroys list item @p ptr.
- * @param ptr the poinetr to list item.
+ * @param ptr the pointer to list item.
  */
 typedef void                    (*xmlSecPtrDestroyItemMethod)   (xmlSecPtr ptr);
 
 /**
- * @brief Prints debug information about @p item to @p output.
- * @param ptr the poinetr to list item.
+ * @brief Prints debug information about @p ptr to @p output.
+ * @param ptr the pointer to list item.
  * @param output the output FILE.
  */
 typedef void                    (*xmlSecPtrDebugDumpItemMethod) (xmlSecPtr ptr,

--- a/include/xmlsec/nodeset.h
+++ b/include/xmlsec/nodeset.h
@@ -33,10 +33,10 @@ typedef struct _xmlSecNodeSet   xmlSecNodeSet, *xmlSecNodeSetPtr;
 typedef enum {
     xmlSecNodeSetNormal = 0,  /**< nodes set = nodes in the list. */
     xmlSecNodeSetInvert,  /**< nodes set = all document nodes minus nodes in the list. */
-    xmlSecNodeSetTree,  /**< nodes set = nodes in the list and all their subtress. */
-    xmlSecNodeSetTreeWithoutComments,  /**< nodes set = nodes in the list and all their subtress but no comment nodes. */
-    xmlSecNodeSetTreeInvert,  /**< nodes set = all document nodes minus nodes in the list and all their subtress. */
-    xmlSecNodeSetTreeWithoutCommentsInvert,  /**< nodes set = all document nodes minus (nodes in the list and all their subtress plus all comment nodes). */
+    xmlSecNodeSetTree,  /**< nodes set = nodes in the list and all their subtrees. */
+    xmlSecNodeSetTreeWithoutComments,  /**< nodes set = nodes in the list and all their subtrees but no comment nodes. */
+    xmlSecNodeSetTreeInvert,  /**< nodes set = all document nodes minus nodes in the list and all their subtrees. */
+    xmlSecNodeSetTreeWithoutCommentsInvert,  /**< nodes set = all document nodes minus (nodes in the list and all their subtrees plus all comment nodes). */
     xmlSecNodeSetList  /**< DEPRECATED: nodes set = all nodes in the children list of nodes sets. */
 } xmlSecNodeSetType;
 
@@ -71,7 +71,7 @@ struct _xmlSecNodeSet {
  * @param parent the pointer to the @p cur parent node.
  * @param data the pointer to application specific data.
  * @return 0 on success or a negative value if an error occurs
- * an walk procedure should be interrupted.
+ * a walk procedure should be interrupted.
  */
 typedef int (*xmlSecNodeSetWalkCallback)                (xmlSecNodeSetPtr nset,
                                                          xmlNodePtr cur,

--- a/include/xmlsec/private.h
+++ b/include/xmlsec/private.h
@@ -685,7 +685,7 @@ struct _xmlSecCryptoDLFunctions {
 
 
 /**
-* @brief Shift bits if node present but and not empty.
+* @brief Shift bits if node present and not empty.
 */
 #define XMLSEC_X509DATA_SHIFT_IF_NOT_EMPTY                      16
 

--- a/include/xmlsec/private.h
+++ b/include/xmlsec/private.h
@@ -193,7 +193,7 @@ typedef int                     (*xmlSecCryptoAppDefaultKeysMngrSaveMethod)
 /**
  * @brief Reads a cert from a file and adds it to the keys manager.
  * @details Reads cert from @p filename and adds to the list of trusted or known
- * untrusted certs in @p store.
+ * untrusted certs in @p mngr.
  * @param mngr the keys manager.
  * @param filename the certificate file.
  * @param format the certificate file format.
@@ -208,7 +208,7 @@ typedef int                     (*xmlSecCryptoAppKeysMngrCertLoadMethod)(xmlSecK
 /**
  * @brief Reads a cert from memory and adds it to the keys manager.
  * @details Reads cert from @p data and adds to the list of trusted or known
- * untrusted certs in @p store.
+ * untrusted certs in @p mngr.
  * @param mngr the keys manager.
  * @param data the certificate data.
  * @param dataSize the certificate data size.
@@ -224,7 +224,7 @@ typedef int                     (*xmlSecCryptoAppKeysMngrCertLoadMemoryMethod)(x
                                                                          xmlSecKeyDataType type);
 /**
  * @brief Reads CRLs from a file and adds to the keys manager.
- * @details Reads crls from @p filename and adds to the list of crls in @p store.
+ * @details Reads crls from @p filename and adds to the list of crls in @p mngr.
  * @param mngr the keys manager.
  * @param filename the CRL file.
  * @param format the CRL file format.
@@ -235,7 +235,7 @@ typedef int                     (*xmlSecCryptoAppKeysMngrCrlLoadMethod)(xmlSecKe
                                                                          xmlSecKeyDataFormat format);
 /**
  * @brief Reads CRLs from memory and adds to the keys manager.
- * @details Reads crls from @p data and adds to the list of crls in @p store.
+ * @details Reads crls from @p data and adds to the list of crls in @p mngr.
  * @param mngr the keys manager.
  * @param data the CRL data.
  * @param dataSize the CRL data size.
@@ -345,7 +345,7 @@ typedef xmlSecKeyPtr            (*xmlSecCryptoAppPkcs12LoadMemoryMethod)(const x
                                                                          void* pwdCallbackCtx);
 /**
  * @brief Reads a cert from a file and adds it to the key.
- * @details Reads the certificate from $@p filename and adds it to key.
+ * @details Reads the certificate from @p filename and adds it to key.
  * @param key the pointer to key.
  * @param filename the certificate filename.
  * @param format the certificate file format.
@@ -401,7 +401,7 @@ struct _xmlSecCryptoDLFunctions {
     xmlSecCryptoKeyDataGetKlassMethod            keyDataXdhGetKlass;  /**< the method to get pointer to XDH key data klass. */
     xmlSecCryptoKeyDataGetKlassMethod            keyDataX509GetKlass;  /**< the method to get pointer to X509 key data klass. */
     xmlSecCryptoKeyDataGetKlassMethod            keyDataRawX509CertGetKlass;  /**< the method to get pointer to raw X509 cert key data klass. */
-    xmlSecCryptoKeyDataGetKlassMethod            keyDataDEREncodedKeyValueGetKlass;  /**< the method to get pointer to X509 key data klass. */
+    xmlSecCryptoKeyDataGetKlassMethod            keyDataDEREncodedKeyValueGetKlass;  /**< the method to get pointer to DER encoded key value key data klass. */
 
     /* Key data store ids */
     xmlSecCryptoKeyDataStoreGetKlassMethod       x509StoreGetKlass;  /**< the method to get pointer to X509 key data store. */
@@ -429,7 +429,7 @@ struct _xmlSecCryptoDLFunctions {
     xmlSecCryptoTransformGetKlassMethod          transformChaCha20GetKlass;  /**< the method to get pointer to ChaCha20 stream cipher encryption transform. */
     xmlSecCryptoTransformGetKlassMethod          transformChaCha20Poly1305GetKlass;  /**< the method to get pointer to ChaCha20-Poly1305 AEAD encryption transform. */
 
-    xmlSecCryptoTransformGetKlassMethod          transformConcatKdfGetKlass;  /**< the method to get pointer to PBKDF2 KDF transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformConcatKdfGetKlass;  /**< the method to get pointer to ConcatKDF KDF transform. */
 
     xmlSecCryptoTransformGetKlassMethod          transformDes3CbcGetKlass;  /**< the method to get pointer to Triple DES encryption transform. */
     xmlSecCryptoTransformGetKlassMethod          transformKWDes3GetKlass;  /**< the method to get pointer to Triple DES key wrapper transform. */
@@ -494,17 +494,17 @@ struct _xmlSecCryptoDLFunctions {
     xmlSecCryptoTransformGetKlassMethod          transformRsaSha384GetKlass;  /**< the method to get pointer to RSA-SHA2-384 signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformRsaSha512GetKlass;  /**< the method to get pointer to RSA-SHA2-512 signature transform. */
 
-    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha1GetKlass;  /**< the method to get pointer to RSA-PSS-HA1 signature transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha1GetKlass;  /**< the method to get pointer to RSA-PSS-SHA1 signature transform. */
 
     xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha224GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-224 signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha256GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-256 signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha384GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-384 signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha512GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-512 signature transform. */
 
-    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_224GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-224 signature transform. */
-    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_256GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-256 signature transform. */
-    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_384GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-384 signature transform. */
-    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_512GetKlass;  /**< the method to get pointer to RSA-PSS-SHA2-512 signature transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_224GetKlass;  /**< the method to get pointer to RSA-PSS-SHA3-224 signature transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_256GetKlass;  /**< the method to get pointer to RSA-PSS-SHA3-256 signature transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_384GetKlass;  /**< the method to get pointer to RSA-PSS-SHA3-384 signature transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformRsaPssSha3_512GetKlass;  /**< the method to get pointer to RSA-PSS-SHA3-512 signature transform. */
 
     xmlSecCryptoTransformGetKlassMethod          transformRsaPkcs1GetKlass;  /**< the method to get pointer to RSA-PKCS1_5 key transport transform. */
     xmlSecCryptoTransformGetKlassMethod          transformRsaOaepGetKlass;  /**< the method to get pointer to RSA-OAEP key transport transform (XMLEnc 1.0). */
@@ -513,7 +513,7 @@ struct _xmlSecCryptoDLFunctions {
     xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_128fGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-128f signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_128sGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-128s signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_192fGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-192f signature transform. */
-    xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_192sGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-192f signature transform. */
+    xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_192sGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-192s signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_256fGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-256f signature transform. */
     xmlSecCryptoTransformGetKlassMethod          transformSLHDSA_SHA2_256sGetKlass;  /**< the method to get pointer to SLH-DSA-SHA2-256s signature transform. */
 
@@ -540,7 +540,7 @@ struct _xmlSecCryptoDLFunctions {
     xmlSecCryptoAppShutdownMethod                cryptoAppShutdown;  /**< the default crypto engine shutdown method. */
     xmlSecCryptoAppDefaultKeysMngrInitMethod     cryptoAppDefaultKeysMngrInit;  /**< the default keys manager init method. */
     xmlSecCryptoAppDefaultKeysMngrAdoptKeyMethod cryptoAppDefaultKeysMngrAdoptKey;  /**< the default keys manager adopt key method. */
-    xmlSecCryptoAppDefaultKeysMngVerifyKeyMethod cryptoAppDefaultKeysMngrVerifyKey;  /**< the defualt keys manager verify key method. */
+    xmlSecCryptoAppDefaultKeysMngVerifyKeyMethod cryptoAppDefaultKeysMngrVerifyKey;  /**< the default keys manager verify key method. */
     xmlSecCryptoAppDefaultKeysMngrLoadMethod     cryptoAppDefaultKeysMngrLoad;  /**< the default keys manager load method. */
     xmlSecCryptoAppDefaultKeysMngrSaveMethod     cryptoAppDefaultKeysMngrSave;  /**< the default keys manager save method. */
     xmlSecCryptoAppKeysMngrCertLoadMethod        cryptoAppKeysMngrCertLoad;  /**< the default keys manager file cert load method. */
@@ -550,7 +550,7 @@ struct _xmlSecCryptoDLFunctions {
     xmlSecCryptoAppKeysMngrCrlLoadMemoryMethod   cryptoAppKeysMngrCrlLoadMemory;  /**< the default keys manager memory crl load method. */
     xmlSecCryptoAppKeyLoadMethod                 cryptoAppKeyLoad;  /**< the key file load method. */
     xmlSecCryptoAppKeyLoadExMethod               cryptoAppKeyLoadEx;  /**< the key file load method. */
-    xmlSecCryptoAppKeyLoadMemoryMethod           cryptoAppKeyLoadMemory;  /**< the meory key load method. */
+    xmlSecCryptoAppKeyLoadMemoryMethod           cryptoAppKeyLoadMemory;  /**< the memory key load method. */
     xmlSecCryptoAppPkcs12LoadMethod              cryptoAppPkcs12Load;  /**< the pkcs12 file load method. */
     xmlSecCryptoAppPkcs12LoadMemoryMethod        cryptoAppPkcs12LoadMemory;  /**< the memory pkcs12 load method. */
     xmlSecCryptoAppKeyCertLoadMethod             cryptoAppKeyCertLoad;  /**< the cert file load method. */

--- a/include/xmlsec/strings.h
+++ b/include/xmlsec/strings.h
@@ -354,7 +354,7 @@ XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefXDHKeyValue[];
 
 /******************************************************************************
  *
- * ECDSA sigantures strings
+ * ECDSA signatures strings
  *
   *****************************************************************************/
 XMLSEC_EXPORT_VAR const xmlChar xmlSecNameEcdsaRipemd160[];
@@ -428,7 +428,7 @@ XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefMLDSAKeyValue[];
 
 /******************************************************************************
  *
- * ML-DSA signature trasnsform strings
+ * ML-DSA signature transform strings
  *
   *****************************************************************************/
 XMLSEC_EXPORT_VAR const xmlChar xmlSecMLDSANs[];
@@ -475,7 +475,7 @@ XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefSLHDSAKeyValue[];
 
 /******************************************************************************
  *
- * SLH-DSA signature trasnsform strings
+ * SLH-DSA signature transform strings
  *
   *****************************************************************************/
 XMLSEC_EXPORT_VAR const xmlChar xmlSecSLHDSANs[];
@@ -762,7 +762,7 @@ XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefMgf1Sha384[];
 XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefMgf1Sha512[];
 
 
-/* RSS PSS https://www.rfc-editor.org/rfc/rfc9231.txt */
+/* RSA PSS https://www.rfc-editor.org/rfc/rfc9231.txt */
 XMLSEC_EXPORT_VAR const xmlChar xmlSecNameRsaPssSha1[];
 XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefRsaPssSha1[];
 
@@ -877,7 +877,7 @@ XMLSEC_EXPORT_VAR const xmlChar xmlSecNameX509Store[];
 
 /******************************************************************************
  *
- * DEPRECATD PGP strings
+ * DEPRECATED PGP strings
  *
   *****************************************************************************/
 XMLSEC_EXPORT_VAR const xmlChar xmlSecNamePGPData[];

--- a/include/xmlsec/strings.h
+++ b/include/xmlsec/strings.h
@@ -939,7 +939,8 @@ XMLSEC_EXPORT_VAR const xmlChar xmlSecHrefXslt[];
  *
   *****************************************************************************/
 XMLSEC_EXPORT_VAR const xmlChar xmlSecStringEmpty[];
-XMLSEC_EXPORT_VAR const xmlChar xmlSecStringCR[];
+XMLSEC_EXPORT_VAR const xmlChar xmlSecStringCR[]; /* DEPRECATED */
+XMLSEC_EXPORT_VAR const xmlChar xmlSecStringLF[];
 
 #ifdef __cplusplus
 }

--- a/include/xmlsec/transforms.h
+++ b/include/xmlsec/transforms.h
@@ -145,7 +145,7 @@ typedef xmlSecByte                              xmlSecTransformDataType;
 
 /**
  * @brief The transform data type is unknown.
- * @details The transform data type is unknown or nor data expected.
+ * @details The transform data type is unknown or no data expected.
  */
 #define xmlSecTransformDataTypeUnknown          0x0000
 
@@ -269,7 +269,7 @@ struct _xmlSecTransformCtx {
     /* user settings */
     void*                                       userData;  /**< the pointer to user data (xmlsec and xmlsec-crypto never touch this). */
     unsigned int                                flags;  /**< the bit mask flags to control transforms execution. */
-    unsigned int                                maxDepth;  /**< the maximum depth for transforms (eg Relationshi Transform) execution (if 0 then depth check is disabled). */
+    unsigned int                                maxDepth;  /**< the maximum depth for transforms (eg Relationship Transform) execution (if 0 then depth check is disabled). */
     xmlSecSize                                  binaryChunkSize;  /**< the chunk of size for binary transforms processing. */
     xmlSecTransformUriType                      enabledUris;  /**< the allowed transform data source uri types. */
     xmlSecPtrList                               enabledTransforms;  /**< the list of enabled transforms; if list is empty (default) then all registered transforms are enabled. */
@@ -383,7 +383,7 @@ struct _xmlSecTransform {
     /* used for some transform (e.g. KDF) to determine the desired output size */
     xmlSecSize                          expectedOutputSize;  /**< the expected transform output size (used for key wraps). */
 
-    /* transform flags (use uintptr_t to insure struct size stays the same) )*/
+    /* transform flags (use uintptr_t to ensure struct size stays the same) */
     uintptr_t                           flags;  /**< the transform flags (eg user specified vs inserted by XMLSec). */
 
     /* reserved for the future */
@@ -666,7 +666,7 @@ typedef int             (*xmlSecTransformPushXmlMethod)         (xmlSecTransform
  * @details The transform specific method to pop data from previous transform in the chain,
  * process the data and return result in @p nodes.
  * @param transform the pointer to transform object.
- * @param nodes the pointer to store popinter to result nodes.
+ * @param nodes the pointer to store pointer to result nodes.
  * @param transformCtx the pointer to transform context object.
  * @return 0 on success or a negative value otherwise.
  */
@@ -709,9 +709,9 @@ struct _xmlSecTransformKlass {
     xmlSecTransformGetDataTypeMethod    getDataType;  /**< the input/output data type query method. */
 
     xmlSecTransformPushBinMethod        pushBin;  /**< the binary data "push thru chain" processing method. */
-    xmlSecTransformPopBinMethod         popBin;  /**< the binary data "pop from chain" procesing method. */
+    xmlSecTransformPopBinMethod         popBin;  /**< the binary data "pop from chain" processing method. */
     xmlSecTransformPushXmlMethod        pushXml;  /**< the XML data "push thru chain" processing method. */
-    xmlSecTransformPopXmlMethod         popXml;  /**< the XML data "pop from chain" procesing method. */
+    xmlSecTransformPopXmlMethod         popXml;  /**< the XML data "pop from chain" processing method. */
 
     /* low level method */
     xmlSecTransformExecuteMethod        execute;  /**< the low level data processing method used  by default implementations of #pushBin, #popBin, #pushXml and #popXml. */

--- a/include/xmlsec/x509.h
+++ b/include/xmlsec/x509.h
@@ -20,12 +20,12 @@ struct _xmlSecKeyX509DataValue {
 
     xmlSecBuffer ski;  /**< the ski from &lt;dsig:X509SKI/&gt; node. */
 
-    xmlChar* subject;  /**< the subject name from <dsig:X509SubjectName /> node. */
+    xmlChar* subject;  /**< the subject name from &lt;dsig:X509SubjectName/&gt; node. */
 
-    xmlChar* issuerName;  /**< the ski from &lt;dsig:X509IssuerSerial/&gt; node. */
-    xmlChar* issuerSerial;  /**< the ski from &lt;dsig:X509IssuerSerial/&gt; node. */
+    xmlChar* issuerName;  /**< the issuer name from &lt;dsig:X509IssuerName/&gt; node. */
+    xmlChar* issuerSerial;  /**< the serial number from &lt;dsig:X509SerialNumber/&gt; node. */
 
-    xmlChar* digestAlgorithm;  /**< the #digest algorithm from &lt;dsig11:X509Digest/&gt; node. */
+    xmlChar* digestAlgorithm;  /**< the digest algorithm URI from the Algorithm attribute of &lt;dsig11:X509Digest/&gt; node. */
     xmlSecBuffer digest;  /**< the digest from &lt;dsig11:X509Digest/&gt; node. */
 };
 

--- a/include/xmlsec/xmldsig.h
+++ b/include/xmlsec/xmldsig.h
@@ -73,7 +73,7 @@ typedef enum {
 /**
  * @brief If set, pre-digest buffer for SignedInfo References is stored in xmlSecDSigCtx.
  * @details If this flag is set then pre-digest buffer for &lt;dsig:Reference/&gt; child
- * of &lt;dsig:KeyInfo/&gt; element will be stored in xmlSecDSigCtx.
+ * of &lt;dsig:SignedInfo/&gt; element will be stored in xmlSecDSigCtx.
  */
 #define XMLSEC_DSIG_FLAGS_STORE_SIGNEDINFO_REFERENCES           0x00000002
 
@@ -114,7 +114,7 @@ struct _xmlSecDSigCtx {
     /* these data user can set before performing the operation */
     void*                       userData;  /**< the pointer to user data (xmlsec and xmlsec-crypto libraries never touches this). */
     unsigned int                flags;  /**< the XML Digital Signature processing flags. */
-    unsigned int                flags2;  /**< the XML Digital Signature processing flags. */
+    unsigned int                flags2;  /**< reserved for future. */
     xmlSecKeyInfoCtx            keyInfoReadCtx;  /**< the reading key context. */
     xmlSecKeyInfoCtx            keyInfoWriteCtx;  /**< the writing key context (not used for signature verification). */
     xmlSecTransformCtx          transformCtx;  /**< the &lt;dsig:SignedInfo/&gt; node processing context. */
@@ -126,7 +126,7 @@ struct _xmlSecDSigCtx {
     xmlSecTransformId           defDigestMethodId;  /**< the default digest method klass. */
 
     /* these data are returned */
-    xmlSecKeyPtr                signKey;  /**< the signature key; application may set #signKey before calling #xmlSecDSigCtxSign or #xmlSecDSigCtxVerify functions. */
+    xmlSecKeyPtr                signKey;  /**< the signature key; application may set #signKey before calling #xmlSecDSigCtxSign or #xmlSecDSigCtxVerify functions. The library takes ownership of the key and destroys it when the context is finalized/destroyed (see #xmlSecDSigCtxFinalize and #xmlSecDSigCtxDestroy). */
     xmlSecTransformOperation    operation;  /**< the operation: sign or verify. */
     xmlSecBufferPtr             result;  /**< the pointer to signature (not valid for signature verification). */
     xmlSecDSigStatus            status;  /**< the &lt;dsig:Signature/&gt; processing status. */
@@ -196,7 +196,7 @@ struct _xmlSecDSigReferenceCtx {
 
     xmlSecBufferPtr             result;  /**< the pointer to digest result. */
     xmlSecDSigStatus            status;  /**< the reference processing status. */
-    xmlSecTransformPtr          preDigestMemBufMethod;  /**< the pointer to binary buffer right before digest (valid only if either #XMLSEC_DSIG_FLAGS_STORE_SIGNEDINFO_REFERENCES or #XMLSEC_DSIG_FLAGS_STORE_MANIFEST_REFERENCES flags are set). */
+    xmlSecTransformPtr          preDigestMemBufMethod;  /**< the pointer to binary buffer right before digest (valid only if the #XMLSEC_DSIG_FLAGS_STORE_SIGNEDINFO_REFERENCES flag is set for SignedInfo References or the #XMLSEC_DSIG_FLAGS_STORE_MANIFEST_REFERENCES flag is set for Manifest References). */
     xmlChar*                    id;  /**< the &lt;dsig:Reference/&gt; node ID attribute. */
     xmlChar*                    uri;  /**< the &lt;dsig:Reference/&gt; node URI attribute. */
     xmlChar*                    type;  /**< the &lt;dsig:Reference/&gt; node Type attribute. */

--- a/include/xmlsec/xmlenc.h
+++ b/include/xmlsec/xmlenc.h
@@ -74,9 +74,9 @@ struct _xmlSecEncCtx {
     xmlSecTransformId           defEncMethodId;  /**< the default encryption method (used if &lt;enc:EncryptionMethod/&gt; node is not present). */
 
     /* these data are returned */
-    xmlSecKeyPtr                encKey;  /**< the signature key; application may set #encKey before calling encryption/decryption functions. */
+    xmlSecKeyPtr                encKey;  /**< the encryption key; application may set #encKey before calling encryption/decryption functions. */
     xmlSecTransformOperation    operation;  /**< the operation: encrypt or decrypt. */
-    xmlSecBufferPtr             result;  /**< the pointer to signature (not valid for signature verification). */
+    xmlSecBufferPtr             result;  /**< the pointer to the encrypted/decrypted data buffer (valid after a successful encrypt/decrypt operation). */
     int                         resultBase64Encoded;  /**< the flag: if set then result in #result is base64 encoded. */
     int                         resultReplaced;  /**< the flag: if set then resulted &lt;enc:EncryptedData/&gt; or &lt;enc:EncryptedKey/&gt; node is added to the document. */
     xmlSecTransformPtr          encMethod;  /**< the pointer to encryption transform. */
@@ -96,7 +96,7 @@ struct _xmlSecEncCtx {
     xmlNodePtr                  keyInfoNode;  /**< the pointer to &lt;enc:KeyInfo/&gt; node. */
     xmlNodePtr                  cipherValueNode;  /**< the pointer to &lt;enc:CipherValue/&gt; node. */
 
-    xmlNodePtr                  replacedNodeList;  /**< the first node of the list of replaced nodes depending on the nodeReplacementMode */
+    xmlNodePtr                  replacedNodeList;  /**< the first node of the list of replaced nodes (populated when the #XMLSEC_ENC_RETURN_REPLACED_NODE flag is set) */
     void*                       reserved1;  /**< reserved for the future. */
 };
 

--- a/include/xmlsec/xmlenc.h
+++ b/include/xmlsec/xmlenc.h
@@ -38,7 +38,7 @@ extern "C" {
  * @brief The xmlSecEncCtx mode.
  */
 typedef enum {
-    xmlEncCtxModeEncryptedData = 0,  /**< the &lt;enc:EncryptedData/&gt; element procesing. */
+    xmlEncCtxModeEncryptedData = 0,  /**< the &lt;enc:EncryptedData/&gt; element processing. */
     xmlEncCtxModeEncryptedKey  /**< the &lt;enc:EncryptedKey/&gt; element processing. */
 } xmlEncCtxMode;
 
@@ -86,8 +86,8 @@ struct _xmlSecEncCtx {
     xmlChar*                    id;  /**< the ID attribute of &lt;enc:EncryptedData/&gt; or &lt;enc:EncryptedKey/&gt; node. */
     xmlChar*                    type;  /**< the Type attribute of &lt;enc:EncryptedData/&gt; or &lt;enc:EncryptedKey/&gt; node. */
     xmlChar*                    mimeType;  /**< the MimeType attribute of &lt;enc:EncryptedData/&gt; or &lt;enc:EncryptedKey/&gt; node. */
-    xmlChar*                    encoding;  /**< the Encoding attributeof &lt;enc:EncryptedData/&gt; or &lt;enc:EncryptedKey/&gt; node. */
-    xmlChar*                    recipient;  /**< the Recipient attribute of &lt;enc:EncryptedKey/&gt; node.. */
+    xmlChar*                    encoding;  /**< the Encoding attribute of &lt;enc:EncryptedData/&gt; or &lt;enc:EncryptedKey/&gt; node. */
+    xmlChar*                    recipient;  /**< the Recipient attribute of &lt;enc:EncryptedKey/&gt; node. */
     xmlChar*                    carriedKeyName;  /**< the CarriedKeyName attribute of &lt;enc:EncryptedKey/&gt; node. */
 
     /* these are internal data, nobody should change that except us */

--- a/include/xmlsec/xmlsec.h
+++ b/include/xmlsec/xmlsec.h
@@ -15,6 +15,7 @@
 
 #include <libxml/tree.h>
 #include <libxml/parser.h>
+#include <stdint.h>
 
 #include <xmlsec/version.h>
 #include <xmlsec/exports.h>
@@ -135,8 +136,7 @@ XMLSEC_EXPORT xmlSecSize                        xmlSecStrlen            (const x
 /**
  * @brief Checks if loaded library version exactly matches.
  * @details Macro. Returns 1 if the loaded xmlsec library version exactly matches
- * the one used to compile the caller, 0 if it does not or a negative
- * value if an error occurs.
+ * the one used to compile the caller, 0 if it does not.
  */
 #define xmlSecCheckVersionExact()       \
     xmlSecCheckVersionExt(XMLSEC_VERSION_MAJOR, XMLSEC_VERSION_MINOR, XMLSEC_VERSION_SUBMINOR, xmlSecCheckVersionExactMatch)
@@ -144,8 +144,7 @@ XMLSEC_EXPORT xmlSecSize                        xmlSecStrlen            (const x
 /**
  * @brief Checks if loaded library version is ABI compatible.
  * @details Macro. Returns 1 if the loaded xmlsec library version ABI compatible with
- * the one used to compile the caller, 0 if it does not or a negative
- * value if an error occurs.
+ * the one used to compile the caller, 0 if it does not.
  */
 #define xmlSecCheckVersion()    \
     xmlSecCheckVersionExt(XMLSEC_VERSION_MAJOR, XMLSEC_VERSION_MINOR, XMLSEC_VERSION_SUBMINOR, xmlSecCheckVersionABICompatible)

--- a/include/xmlsec/xmltree.h
+++ b/include/xmlsec/xmltree.h
@@ -135,7 +135,7 @@ XMLSEC_EXPORT int               xmlSecPrintXmlString    (FILE * fd,
 
 /**
  * @brief Returns 1 if the character is a hex digit.
- * @details Macro. Returns 1 if @c is a hex digit or 0 other wise.
+ * @details Macro. Returns 1 if @c is a hex digit or 0 otherwise.
  * @param c the character.
  */
 #define xmlSecIsHex(c) \

--- a/include/xmlsec/xmltree.h
+++ b/include/xmlsec/xmltree.h
@@ -282,9 +282,9 @@ XMLSEC_EXPORT xmlSecQName2BitMaskInfoConstPtr xmlSecQName2BitMaskGetInfo
                                                                 (xmlSecQName2BitMaskInfoConstPtr info,
                                                                  xmlSecBitMask mask);
 XMLSEC_EXPORT int               xmlSecQName2BitMaskGetBitMask   (xmlSecQName2BitMaskInfoConstPtr info,
-                                                                 const xmlChar* qnameLocalPart,
-                                                                 const xmlChar* qnameHref,
-                                                                 xmlSecBitMask* mask);
+                                                                  const xmlChar* qnameHref,
+                                                                  const xmlChar* qnameLocalPart,
+                                                                  xmlSecBitMask* mask);
 XMLSEC_EXPORT int               xmlSecQName2BitMaskNodesRead    (xmlSecQName2BitMaskInfoConstPtr info,
                                                                  xmlNodePtr* node,
                                                                  const xmlChar* nodeName,

--- a/src/app.c
+++ b/src/app.c
@@ -139,7 +139,7 @@ xmlSecKeyDataConcatKdfGetKlass(void) {
 xmlSecKeyDataId
 xmlSecKeyDataDesGetKlass(void) {
     if((xmlSecCryptoDLGetFunctions() == NULL) || (xmlSecCryptoDLGetFunctions()->keyDataDesGetKlass == NULL)) {
-        xmlSecNotImplementedError2(missingMethodError, "keyDataDesId");
+        xmlSecNotImplementedError2(missingMethodError, "keyDataDesGetKlass");
         return(xmlSecKeyDataIdUnknown);
     }
 
@@ -445,7 +445,7 @@ xmlSecKeyDataStoreId
 xmlSecX509StoreGetKlass(void) {
     if((xmlSecCryptoDLGetFunctions() == NULL) || (xmlSecCryptoDLGetFunctions()->x509StoreGetKlass == NULL)) {
         xmlSecNotImplementedError2(missingMethodError, "x509StoreGetKlass");
-        return(xmlSecKeyStoreIdUnknown);
+        return(xmlSecKeyDataStoreIdUnknown);
     }
 
     return(xmlSecCryptoDLGetFunctions()->x509StoreGetKlass());
@@ -2305,7 +2305,7 @@ xmlSecCryptoAppKeyCertLoadMemory(xmlSecKeyPtr key, const xmlSecByte* data, xmlSe
  */
 void*
 xmlSecCryptoAppGetDefaultPwdCallback(void) {
-    if(xmlSecCryptoDLGetFunctions() == NULL) {
+    if((xmlSecCryptoDLGetFunctions() == NULL) || (xmlSecCryptoDLGetFunctions()->cryptoAppDefaultPwdCallback == NULL)) {
         xmlSecNotImplementedError2(missingMethodError, "cryptoAppDefaultPwdCallback");
         return(NULL);
     }

--- a/src/app.c
+++ b/src/app.c
@@ -117,7 +117,7 @@ xmlSecKeyDataAesGetKlass(void) {
 /**
  * @brief The ConcatKDF key data klass.
  * @return ConcatKDF key data klass or NULL if an error occurs
- * (xmlsec-crypto library is not loaded or the HMAC key data
+ * (xmlsec-crypto library is not loaded or the ConcatKDF key data
  * klass is not implemented).
  */
 xmlSecKeyDataId
@@ -277,7 +277,7 @@ xmlSecKeyDataHkdfGetKlass(void) {
 /**
  * @brief The PBKDF2 key data klass.
  * @return PBKDF2 key data klass or NULL if an error occurs
- * (xmlsec-crypto library is not loaded or the HMAC key data
+ * (xmlsec-crypto library is not loaded or the PBKDF2 key data
  * klass is not implemented).
  */
 xmlSecKeyDataId
@@ -417,7 +417,7 @@ xmlSecKeyDataRawX509CertGetKlass(void) {
 
 /**
  * @brief The DEREncodedKeyValue key data klass.
- * @return X5DEREncodedKeyValue09 key data klass or NULL if an error occurs
+ * @return DEREncodedKeyValue key data klass or NULL if an error occurs
  * (xmlsec-crypto library is not loaded or the DEREncodedKeyValue key data
  * klass is not implemented).
  */
@@ -556,8 +556,8 @@ xmlSecTransformAes256GcmGetKlass(void)
 }
 
 /**
- * @brief ConcatKDF key derivaton transform klass.
- * @return pointer to ConcatKDF key derivaton transform or NULL if an error
+ * @brief ConcatKDF key derivation transform klass.
+ * @return pointer to ConcatKDF key derivation transform or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
  */
@@ -574,7 +574,7 @@ xmlSecTransformConcatKdfGetKlass(void)
 
 /**
  * @brief The AES-128 key wrapper transform klass.
- * @return AES-128 kew wrapper transform klass or NULL if an error
+ * @return AES-128 key wrapper transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
  */
@@ -590,7 +590,7 @@ xmlSecTransformKWAes128GetKlass(void) {
 
 /**
  * @brief The AES-192 key wrapper transform klass.
- * @return AES-192 kew wrapper transform klass or NULL if an error
+ * @return AES-192 key wrapper transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
  */
@@ -606,7 +606,7 @@ xmlSecTransformKWAes192GetKlass(void) {
 
 /**
  * @brief The AES-256 key wrapper transform klass.
- * @return AES-256 kew wrapper transform klass or NULL if an error
+ * @return AES-256 key wrapper transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
  */
@@ -1255,8 +1255,8 @@ xmlSecTransformMLKEM1024GetKlass(void) {
     return(xmlSecCryptoDLGetFunctions()->transformMLKEM1024GetKlass());
 }
 /**
- * @brief PBKDF2 key derivaton transform klass.
- * @return pointer to PBKDF2 key derivaton transform or NULL if an error
+ * @brief PBKDF2 key derivation transform klass.
+ * @return pointer to PBKDF2 key derivation transform or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
  */
@@ -1483,7 +1483,7 @@ xmlSecTransformRsaPssSha512GetKlass(void) {
 
 
 /**
- * @brief The RSA-PSS-SHA2-224 signature transform klass.
+ * @brief The RSA-PSS-SHA3-224 signature transform klass.
  * @return RSA-PSS-SHA3-224 signature transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
@@ -1499,7 +1499,7 @@ xmlSecTransformRsaPssSha3_224GetKlass(void) {
 }
 
 /**
- * @brief The RSA-PSS-SHA2-256 signature transform klass.
+ * @brief The RSA-PSS-SHA3-256 signature transform klass.
  * @return RSA-PSS-SHA3-256 signature transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
@@ -1515,7 +1515,7 @@ xmlSecTransformRsaPssSha3_256GetKlass(void) {
 }
 
 /**
- * @brief The RSA-PSS-SHA2-384 signature transform klass.
+ * @brief The RSA-PSS-SHA3-384 signature transform klass.
  * @return RSA-PSS-SHA3-384 signature transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
@@ -1531,7 +1531,7 @@ xmlSecTransformRsaPssSha3_384GetKlass(void) {
 }
 
 /**
- * @brief The RSA-PSS-SHA2-512 signature transform klass.
+ * @brief The RSA-PSS-SHA3-512 signature transform klass.
  * @return RSA-PSS-SHA3-512 signature transform klass or NULL if an error
  * occurs (the xmlsec-crypto library is not loaded or this transform is not
  * implemented).
@@ -2263,7 +2263,7 @@ xmlSecCryptoAppPkcs12LoadMemory(const xmlSecByte* data, xmlSecSize dataSize,
 
 /**
  * @brief Loads a certificate and adds it to a key.
- * @details Reads the certificate from $@p filename and adds it to key.
+ * @details Reads the certificate from @p filename and adds it to key.
  * @param key the pointer to key.
  * @param filename the certificate filename.
  * @param format the certificate file format.

--- a/src/base64.c
+++ b/src/base64.c
@@ -69,6 +69,11 @@ static const xmlSecByte base64[] =
   *****************************************************************************/
 static int g_xmlsec_base64_default_line_size = XMLSEC_BASE64_LINESIZE;
 
+static int
+xmlSecBase64IsValidColumns(int columns) {
+    return((columns == 0) || (columns > 1));
+}
+
 /**
  * @brief Gets the current default line size.
  * @return The current default line size.
@@ -81,11 +86,13 @@ xmlSecBase64GetDefaultLineSize(void)
 
 /**
  * @brief Sets the current default line size.
- * @param columns number of columns
+ * @param columns number of columns; use 0 for no line breaks or a value greater than 1.
  */
 void
 xmlSecBase64SetDefaultLineSize(int columns)
 {
+    xmlSecAssert(xmlSecBase64IsValidColumns(columns));
+
     g_xmlsec_base64_default_line_size = columns;
 }
 
@@ -146,7 +153,7 @@ static int                      xmlSecBase64CtxDecodeIsFinished (xmlSecBase64Ctx
  * @brief Allocates and initializes new base64 context.
  *
  * @param encode the encode/decode flag (1 - encode, 0 - decode).
- * @param columns the max line length.
+ * @param columns the max line length; use 0 for no line breaks or a value greater than 1.
  *
  * @return a pointer to newly created xmlSecBase64Ctx structure
  * or NULL if an error occurs.
@@ -190,12 +197,13 @@ xmlSecBase64CtxDestroy(xmlSecBase64CtxPtr ctx) {
  * @brief Initializes new base64 context.
  * @param ctx the pointer to xmlSecBase64Ctx structure,
  * @param encode the encode/decode flag (1 - encode, 0 - decode)
- * @param columns the max line length.
+ * @param columns the max line length; use 0 for no line breaks or a value greater than 1.
  * @return 0 on success and a negative value otherwise.
  */
 int
 xmlSecBase64CtxInitialize(xmlSecBase64CtxPtr ctx, int encode, int columns) {
     xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(xmlSecBase64IsValidColumns(columns), -1);
 
     memset(ctx, 0, sizeof(xmlSecBase64Ctx));
 
@@ -568,10 +576,23 @@ xmlSecBase64CtxDecodeIsFinished(xmlSecBase64CtxPtr ctx) {
 static xmlSecSize
 xmlSecBase64GetEncodeSize(xmlSecSize columnsSize, xmlSecSize inSize) {
     xmlSecSize size;
+    xmlSecSize blocks;
 
-    size = (4 * inSize) / 3 + 4;
-    if(columnsSize > 0) {
+    blocks = inSize / 3;
+    if((inSize % 3) != 0) {
+        ++blocks;
+    }
+    if(blocks > (XMLSEC_SIZE_MAX / 4)) {
+        return(0);
+    }
+    size = blocks * 4;
+
+    if(columnsSize > 1) {
+        /* columnsSize is at least 2, so this is safe */
         size += (size / columnsSize) + 4;
+    }
+    if(size > XMLSEC_SIZE_MAX - 1) {
+        return(0);
     }
     return(size + 1);
 }
@@ -579,7 +600,18 @@ xmlSecBase64GetEncodeSize(xmlSecSize columnsSize, xmlSecSize inSize) {
 
 static xmlSecSize
 xmlSecBase64GetDecodeSize(xmlSecSize inSize) {
-    return(3 * inSize / 4 + 8);
+    xmlSecSize blocks;
+
+    blocks = inSize / 4;
+    if((inSize % 4) != 0) {
+        /* this only happens if we have line breaks, etc. so just to be safe */
+        ++blocks;
+    }
+
+    if(blocks > ((XMLSEC_SIZE_MAX - 8)/ 3)) {
+        return(0);
+    }
+    return(3 * blocks + 8);
 }
 
 /**
@@ -589,8 +621,7 @@ xmlSecBase64GetDecodeSize(xmlSecSize inSize) {
  * xmlFree() function.
  * @param in the input buffer.
  * @param inSize the input buffer size.
- * @param columns the output max line length (if 0 then no line breaks
- *                      would be inserted)
+ * @param columns the output max line length; use 0 for no line breaks or a value greater than 1.
  * @return newly allocated string with base64 encoded data
  * or NULL if an error occurs.
  */
@@ -781,7 +812,7 @@ xmlSecTransformBase64GetKlass(void) {
 /**
  * @brief Sets the max line size to @p lineSize.
  * @param transform the pointer to BASE64 encode transform.
- * @param lineSize the new max line size.
+ * @param lineSize the new max line size; use 0 for no line breaks or a value greater than 1.
  */
 void
 xmlSecTransformBase64SetLineSize(xmlSecTransformPtr transform, xmlSecSize lineSize) {

--- a/src/bn.c
+++ b/src/bn.c
@@ -279,7 +279,7 @@ xmlSecBnFromString(xmlSecBnPtr bn, const xmlChar* str, xmlSecSize base) {
  * freeing returned string with xmlFree.
  * @param bn the pointer to BN.
  * @param base the base for returned string.
- * @return the string represenataion if BN or a NULL if an error occurs.
+ * @return the string representation of BN or a NULL if an error occurs.
  */
 xmlChar*
 xmlSecBnToString(xmlSecBnPtr bn, xmlSecSize base) {
@@ -366,7 +366,7 @@ xmlSecBnToString(xmlSecBnPtr bn, xmlSecSize base) {
         res[ii++] = '0';
     }
 
-    /* we might have '0' at the beggining, remove it but keep one zero */
+    /* we might have '0' at the beginning, remove it but keep one zero */
     for(len = ii; (len > 1) && (res[len - 1] == '0'); len--) {
     }
     res[len] = '\0';
@@ -404,7 +404,7 @@ xmlSecBnFromHexString(xmlSecBnPtr bn, const xmlChar* str) {
  * @details Writes @p bn to hex string. Caller is responsible for
  * freeing returned string with xmlFree.
  * @param bn the pointer to BN.
- * @return the string represenataion if BN or a NULL if an error occurs.
+ * @return the string representation of BN or a NULL if an error occurs.
  */
 xmlChar*
 xmlSecBnToHexString(xmlSecBnPtr bn) {
@@ -427,7 +427,7 @@ xmlSecBnFromDecString(xmlSecBnPtr bn, const xmlChar* str) {
  * @details Writes @p bn to decimal string. Caller is responsible for
  * freeing returned string with xmlFree.
  * @param bn the pointer to BN.
- * @return the string represenataion if BN or a NULL if an error occurs.
+ * @return the string representation of BN or a NULL if an error occurs.
  */
 xmlChar*
 xmlSecBnToDecString(xmlSecBnPtr bn) {
@@ -619,7 +619,7 @@ xmlSecBnCompare(xmlSecBnPtr bn, const xmlSecByte* data, xmlSecSize dataSize) {
     bnData = xmlSecBnGetData(bn);
     bnSize = xmlSecBnGetSize(bn);
 
-    /* skip zeros in the beggining */
+    /* skip zeros in the beginning */
     while((dataSize > 0) && (data != 0) && (data[0] == 0)) {
         ++data;
         --dataSize;
@@ -667,7 +667,7 @@ xmlSecBnCompareReverse(xmlSecBnPtr bn, const xmlSecByte* data, xmlSecSize dataSi
     bnData = xmlSecBnGetData(bn);
     bnSize = xmlSecBnGetSize(bn);
 
-    /* skip zeros in the beggining */
+    /* skip zeros in the beginning */
     while((dataSize > 0) && (data != 0) && (data[dataSize - 1] == 0)) {
         --dataSize;
     }

--- a/src/bn.c
+++ b/src/bn.c
@@ -808,7 +808,6 @@ xmlSecBnSetNodeValue(xmlSecBnPtr bn, xmlNodePtr cur, xmlSecBnFormat format, int 
         content = xmlSecBnToHexString(bn);
         if(content == NULL) {
             xmlSecInternalError("xmlSecBnToHexString", NULL);
-            xmlFree(content);
             return(-1);
         }
         xmlNodeSetContent(cur, content);
@@ -818,7 +817,6 @@ xmlSecBnSetNodeValue(xmlSecBnPtr bn, xmlNodePtr cur, xmlSecBnFormat format, int 
         content = xmlSecBnToDecString(bn);
         if(content == NULL) {
             xmlSecInternalError("xmlSecBnToDecString", NULL);
-            xmlFree(content);
             return(-1);
         }
         xmlNodeSetContent(cur, content);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -720,6 +720,8 @@ static int      xmlSecBufferIOClose                             (xmlSecBufferPtr
  */
 xmlOutputBufferPtr
 xmlSecBufferCreateOutputBuffer(xmlSecBufferPtr buf) {
+    xmlSecAssert2(buf != NULL, NULL);
+
     return(xmlOutputBufferCreateIO((xmlOutputWriteCallback)xmlSecBufferIOWrite,
                                      (xmlOutputCloseCallback)xmlSecBufferIOClose,
                                      buf,

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -35,9 +35,9 @@ static xmlSecSize gInitialSize = 1024;
 
 /**
  * @brief Sets the default buffer allocation mode.
- * @details Sets new global default allocation mode and minimal intial size.
+ * @details Sets new global default allocation mode and minimal initial size.
  * @param defAllocMode the new default buffer allocation mode.
- * @param defInitialSize the new default buffer minimal intial size.
+ * @param defInitialSize the new default buffer minimal initial size.
  */
 void
 xmlSecBufferSetDefaultAllocMode(xmlSecAllocMode defAllocMode, xmlSecSize defInitialSize) {
@@ -52,7 +52,7 @@ xmlSecBufferSetDefaultAllocMode(xmlSecAllocMode defAllocMode, xmlSecSize defInit
  * @details Allocates and initializes new memory buffer with given size.
  * Caller is responsible for calling #xmlSecBufferDestroy function
  * to free the buffer.
- * @param size the intial size.
+ * @param size the initial size.
  * @return pointer to newly allocated buffer or NULL if an error occurs.
  */
 xmlSecBufferPtr
@@ -671,7 +671,7 @@ xmlSecBufferHexRead(xmlSecBufferPtr buf, const xmlChar* hexStr) {
         (*data) = xmlSecFromHex2(ch1, ch2);
     }
 
-    /* sucess */
+    /* success */
     return(0);
 }
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -267,11 +267,23 @@ xmlSecBufferSetMaxSize(xmlSecBufferPtr buf, xmlSecSize size) {
 
     switch(buf->allocMode) {
         case xmlSecAllocModeExact:
+            if(size > XMLSEC_SIZE_MAX - 8) {
+                xmlSecInvalidSizeError("size", size, (XMLSEC_SIZE_MAX - 8), NULL);
+                return(-1);
+            }
             newSize = size + 8;
             break;
         case xmlSecAllocModeDouble:
+            if(size > ((XMLSEC_SIZE_MAX - 32) / 2)) {
+                xmlSecInvalidSizeError("size", size, ((XMLSEC_SIZE_MAX - 32) / 2), NULL);
+                return(-1);
+            }
             newSize = 2 * size + 32;
             break;
+        default:
+            xmlSecInvalidIntegerDataError("allocMode", (int)(buf->allocMode),
+                "xmlSecAllocModeExact or xmlSecAllocModeDouble", NULL);
+            return(-1);
     }
 
     if(newSize < gInitialSize) {
@@ -334,6 +346,10 @@ xmlSecBufferAppend(xmlSecBufferPtr buf, const xmlSecByte* data, xmlSecSize size)
 
     if(size > 0) {
         xmlSecAssert2(data != NULL, -1);
+        if(buf->size > XMLSEC_SIZE_MAX - size) {
+            xmlSecInvalidSizeError("size", size, (XMLSEC_SIZE_MAX - buf->size), NULL);
+            return(-1);
+        }
 
         ret = xmlSecBufferSetMaxSize(buf, buf->size + size);
         if(ret < 0) {
@@ -365,6 +381,10 @@ xmlSecBufferPrepend(xmlSecBufferPtr buf, const xmlSecByte* data, xmlSecSize size
 
     if(size > 0) {
         xmlSecAssert2(data != NULL, -1);
+        if(buf->size > XMLSEC_SIZE_MAX - size) {
+            xmlSecInvalidSizeError("size", size, (XMLSEC_SIZE_MAX - buf->size), NULL);
+            return(-1);
+        }
 
         ret = xmlSecBufferSetMaxSize(buf, buf->size + size);
         if(ret < 0) {

--- a/src/c14n.c
+++ b/src/c14n.c
@@ -397,7 +397,7 @@ xmlSecTransformC14NExecute(xmlSecTransformId id, xmlSecNodeSetPtr nodes, xmlSecP
     } else if(id == xmlSecTransformRemoveXmlTagsC14NId) {
         ret = xmlSecNodeSetDumpTextNodes(nodes, buf);
     } else {
-        /* shoudn't be possible to come here, actually */
+        /* shouldn't be possible to come here, actually */
         xmlSecOtherError(XMLSEC_ERRORS_R_INVALID_TRANSFORM,
                          xmlSecTransformKlassGetName(id), NULL);
         return(-1);
@@ -625,7 +625,7 @@ static xmlSecTransformKlass xmlSecTransformExclC14NKlass = {
 
 /**
  * @brief Gets the exclusive C14N transform klass.
- * @details Exclusive canoncicalization that omits comments transform klass
+ * @details Exclusive canonicalization that omits comments transform klass
  * (http://www.w3.org/TR/xml-exc-c14n/).
  * @return exclusive c14n transform id.
  */
@@ -669,7 +669,7 @@ static xmlSecTransformKlass xmlSecTransformExclC14NWithCommentsKlass = {
 
 /**
  * @brief Gets the exclusive C14N with comments transform klass.
- * @details Exclusive canoncicalization that includes comments transform klass
+ * @details Exclusive canonicalization that includes comments transform klass
  * (http://www.w3.org/TR/xml-exc-c14n/).
  * @return exclusive c14n with comments transform id.
  */

--- a/src/c14n.c
+++ b/src/c14n.c
@@ -73,6 +73,10 @@ static int              xmlSecTransformC14NExecute      (xmlSecTransformId id,
                                                          xmlSecNodeSetPtr nodes,
                                                          xmlSecPtrListPtr nsList,
                                                          xmlOutputBufferPtr buf);
+
+#define XMLSEC_IS_XML_SPACE(ch) \
+    (((ch) == ' ') || ((ch) == '\t') || ((ch) == '\n') || ((ch) == '\r'))
+
 static int
 xmlSecTransformC14NInitialize(xmlSecTransformPtr transform) {
     xmlSecPtrListPtr nsList;
@@ -138,10 +142,20 @@ xmlSecTransformC14NNodeRead(xmlSecTransformPtr transform, xmlNodePtr node, xmlSe
             return(-1);
         }
 
-        /* the list of namespaces is space separated */
-        for(p = n = list; ((p != NULL) && ((*p) != '\0')); p = n) {
-            n = (xmlChar*)xmlStrchr(p, ' ');
-            if(n != NULL) {
+        /* the list of namespaces is XML whitespace separated */
+        for(p = list; ((p != NULL) && ((*p) != '\0')); p = n) {
+            while((*p != '\0') && XMLSEC_IS_XML_SPACE(*p)) {
+                ++p;
+            }
+            if(*p == '\0') {
+                break;
+            }
+
+            n = p;
+            while((*n != '\0') && !XMLSEC_IS_XML_SPACE(*n)) {
+                ++n;
+            }
+            if(*n != '\0') {
                 *(n++) = '\0';
             }
 

--- a/src/dl.c
+++ b/src/dl.c
@@ -380,6 +380,7 @@ xmlSecCryptoDLShutdown(void) {
     int ret;
 
     xmlSecPtrListFinalize(&gXmlSecCryptoDLLibraries);
+    gXmlSecCryptoDLFunctions = NULL;
 
 #ifdef XMLSEC_DL_LIBLTDL
     ret = lt_dlexit ();

--- a/src/dl.c
+++ b/src/dl.c
@@ -603,7 +603,6 @@ xmlSecCryptoDLFunctionsRegisterKeyDataAndTransforms(struct _xmlSecCryptoDLFuncti
       *****************************************************************************/
     XMLSEC_REGISTER_TRANSFORM(Aes128Cbc);                           // transformAes128CbcGetKlass
     XMLSEC_REGISTER_TRANSFORM(Aes192Cbc);                           // transformAes192CbcGetKlass
-    XMLSEC_REGISTER_TRANSFORM(Aes192Cbc);                           // transformAes192CbcGetKlass
     XMLSEC_REGISTER_TRANSFORM(Aes256Cbc);                           // transformAes256CbcGetKlass
 
     XMLSEC_REGISTER_TRANSFORM(Aes128Gcm);                           // transformAes128GcmGetKlass

--- a/src/errors.c
+++ b/src/errors.c
@@ -62,7 +62,7 @@ static const xmlSecErrorDescription xmlSecErrorsTable[XMLSEC_ERRORS_MAX_NUMBER +
   { XMLSEC_ERRORS_R_MISSING_NODE_ATTRIBUTE,     "missing node attribute" },
   { XMLSEC_ERRORS_R_NODE_ALREADY_PRESENT,       "node already present" },
   { XMLSEC_ERRORS_R_UNEXPECTED_NODE,            "unexpected node" },
-  { XMLSEC_ERRORS_R_NODE_NOT_FOUND,             "node node found" },
+  { XMLSEC_ERRORS_R_NODE_NOT_FOUND,             "node not found" },
   { XMLSEC_ERRORS_R_INVALID_TRANSFORM,          "invalid transform" },
   { XMLSEC_ERRORS_R_INVALID_TRANSFORM_KEY,      "invalid transform key" },
   { XMLSEC_ERRORS_R_INVALID_URI_TYPE,           "invalid URI type" },
@@ -93,7 +93,7 @@ static const xmlSecErrorDescription xmlSecErrorsTable[XMLSEC_ERRORS_MAX_NUMBER +
   { 0,                                          NULL}
 };
 
-/* We have sytstem callback that can be set by the xmlsec-crypto library and user callback
+/* We have system callback that can be set by the xmlsec-crypto library and user callback
  * that user can set. We always prioritize user callback if set. Note that if user sets
  * NULL callback then we disable errors reporting */
 static xmlSecErrorsCallback xmlSecErrorsSystemClbk = xmlSecErrorsDefaultCallback;
@@ -155,7 +155,7 @@ xmlSecErrorsSetSystemCallback(xmlSecErrorsCallback callback) {
  * @param func the error location function name (__FUNCTION__ macro).
  * @param errorObject the error specific error object
  * @param errorSubject the error specific error subject.
- * @param reason the error code.S
+ * @param reason the error code.
  * @param msg the additional error message.
  */
 void

--- a/src/io.c
+++ b/src/io.c
@@ -113,8 +113,8 @@ static xmlSecIOCallbackPtr              xmlSecIOCallbackPtrListFind     (xmlSecP
                                                                          const char* uri);
 
 /**
- * @brief The keys list klass.
- * @return keys list id.
+ * @brief The IO callback list klass.
+ * @return IO callback list id.
  */
 static xmlSecPtrListId
 xmlSecIOCallbackPtrListGetKlass(void) {
@@ -254,10 +254,10 @@ xmlSecIOFileExtractFilename(char const* filename, char** out) {
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
         escaped = &filename[7];
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://", 7)) {
-        /* lots of generators seems to lazy to read RFC 1738 */
+        /* lots of generators seems too lazy to read RFC 1738 */
         escaped = &filename[6];
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:/", 6)) {
-        /* lots of generators seems to lazy to read RFC 1738 */
+        /* lots of generators seems too lazy to read RFC 1738 */
         escaped = &filename[5];
     } else {
         (*out) = NULL;

--- a/src/io.c
+++ b/src/io.c
@@ -522,7 +522,11 @@ xmlSecTransformInputURIOpen(xmlSecTransformPtr transform, const xmlChar *uri) {
         if (unescaped != NULL) {
             ctx->clbks = xmlSecIOCallbackPtrListFind(&xmlSecAllIOCallbacks, unescaped);
             if(ctx->clbks != NULL) {
-                ctx->clbksCtx = ctx->clbks->opencallback(unescaped);
+                if(ctx->clbks->opencallback != NULL) {
+                    ctx->clbksCtx = ctx->clbks->opencallback(unescaped);
+                } else {
+                    ctx->clbksCtx = NULL;
+                }
             }
             xmlFree(unescaped);
         }
@@ -535,7 +539,11 @@ xmlSecTransformInputURIOpen(xmlSecTransformPtr transform, const xmlChar *uri) {
     if (ctx->clbks == NULL) {
         ctx->clbks = xmlSecIOCallbackPtrListFind(&xmlSecAllIOCallbacks, (char*)uri);
         if(ctx->clbks != NULL) {
-            ctx->clbksCtx = ctx->clbks->opencallback((char*)uri);
+            if(ctx->clbks->opencallback != NULL) {
+                ctx->clbksCtx = ctx->clbks->opencallback((char*)uri);
+            } else {
+                ctx->clbksCtx = NULL;
+            }
         }
     }
 

--- a/src/keyinfo.c
+++ b/src/keyinfo.c
@@ -159,7 +159,7 @@ xmlSecKeyInfoNodeWrite(xmlNodePtr keyInfoNode, xmlSecKeyPtr key, xmlSecKeyInfoCt
         nodeName = cur->name;
         nodeNs = xmlSecGetNodeNsHref(cur);
 
-        /* use global eanbled list only if we don't have a local one */
+        /* use global enabled list only if we don't have a local one */
         if(xmlSecPtrListGetSize(&(keyInfoCtx->enabledKeyData)) > 0) {
                 dataId = xmlSecKeyDataIdListFindByNode(&(keyInfoCtx->enabledKeyData),
                             nodeName, nodeNs,
@@ -346,7 +346,7 @@ xmlSecKeyInfoCtxReset(xmlSecKeyInfoCtxPtr keyInfoCtx) {
 
 /**
  * @brief Creates an encryption context for KeyInfo processing.
- * @details Creates encryption context form processing &lt;enc:EncryptedKey/&gt; child
+ * @details Creates encryption context for processing &lt;enc:EncryptedKey/&gt; child
  * of &lt;dsig:KeyInfo/&gt; element.
  * @param keyInfoCtx the pointer to &lt;dsig:KeyInfo/&gt; element processing context.
  *
@@ -669,7 +669,7 @@ xmlSecKeyDataNameXmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key, xmlNodePtr node, 
             xmlSecKeyEmpty(key);
 
             /* TODO: since we will destroy tmpKey anyway, we can easily
-             * just re-assign key data values. It'll save use some memory
+             * just re-assign key data values. It'll save us some memory
              * malloc/free
              */
 
@@ -1238,7 +1238,7 @@ xmlSecKeyDataRetrievalMethodReadXmlResult(xmlSecKeyDataId typeId, xmlSecKeyPtr k
 
 /******************************************************************************
  *
- *&lt;dsig11:KeyInfoReference/&gt; element  processing
+ *&lt;dsig11:KeyInfoReference/&gt; element processing
  *
   *****************************************************************************/
 static int                      xmlSecKeyDataKeyInfoReferenceXmlRead(xmlSecKeyDataId id,
@@ -1834,7 +1834,7 @@ xmlSecKeyDataDerivedKeyXmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key, xmlNodePtr 
      * (https://github.com/lsh123/xmlsec/issues/515)
      */
     if(xmlSecKeyReqMatchKey(&(keyInfoCtx->keyReq), generatedKey) != 1) {
-        /* we are not allowed to use  this key, ignore and continue */
+        /* we are not allowed to use this key, ignore and continue */
         xmlSecKeyDestroy(generatedKey);
         return(0);
     }
@@ -1860,7 +1860,7 @@ xmlSecKeyDataDerivedKeyXmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key, xmlNodePtr
     xmlSecAssert2(keyInfoCtx != NULL, -1);
     xmlSecAssert2(keyInfoCtx->mode == xmlSecKeyInfoModeWrite, -1);
 
-    /* do nothing, the template should already have all the necesary data to generate the key correctly */
+    /* do nothing, the template should already have all the necessary data to generate the key correctly */
     return(0);
 }
 
@@ -1998,7 +1998,7 @@ xmlSecKeyDataAgreementMethodXmlRead(xmlSecKeyDataId id, xmlSecKeyPtr key, xmlNod
     }
 
     if(xmlSecKeyReqMatchKey(&(keyInfoCtx->keyReq), generatedKey) != 1) {
-        /* we are not allowed to use  this key, ignore and continue */
+        /* we are not allowed to use this key, ignore and continue */
         xmlSecKeyDestroy(generatedKey);
         return(0);
     }
@@ -2046,7 +2046,7 @@ xmlSecKeyDataAgreementMethodXmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key, xmlNo
     xmlSecAssert2(keyInfoCtx != NULL, -1);
     xmlSecAssert2(keyInfoCtx->mode == xmlSecKeyInfoModeWrite, -1);
 
-    /* there might be several nodes that can re-use encCtx, we need to re-read the node before writing it  */
+    /* there might be several nodes that can re-use encCtx, we need to re-read the node before writing it */
 
     /* check the enc level */
     if(keyInfoCtx->curEncryptedKeyLevel >= keyInfoCtx->maxEncryptedKeyLevel) {

--- a/src/keyinfo.c
+++ b/src/keyinfo.c
@@ -544,11 +544,11 @@ xmlSecKeyInfoCtxDebugXmlDump(xmlSecKeyInfoCtxPtr keyInfoCtx, FILE* output) {
     }
 
     fprintf(output, "<RetrievalMethodLevel cur=\"%d\" max=\"%d\" />\n",
-        keyInfoCtx->curEncryptedKeyLevel, keyInfoCtx->maxEncryptedKeyLevel);
+        keyInfoCtx->curRetrievalMethodLevel, keyInfoCtx->maxRetrievalMethodLevel);
     xmlSecTransformCtxDebugXmlDump(&(keyInfoCtx->retrievalMethodCtx), output);
 
     fprintf(output, "<KeyInfoReferenceLevel cur=\"%d\" max=\"%d\" />\n",
-        keyInfoCtx->curEncryptedKeyLevel, keyInfoCtx->maxEncryptedKeyLevel);
+        keyInfoCtx->curKeyInfoReferenceLevel, keyInfoCtx->maxKeyInfoReferenceLevel);
     xmlSecTransformCtxDebugXmlDump(&(keyInfoCtx->keyInfoReferenceCtx), output);
 
 #ifndef XMLSEC_NO_XMLENC
@@ -736,7 +736,7 @@ xmlSecKeyDataNameXmlWrite(xmlSecKeyDataId id, xmlSecKeyPtr key, xmlNodePtr node,
 
     name = xmlSecKeyGetName(key);
     if(name == NULL) {
-        return(8);
+        return(0);
     }
 
     if(!xmlSecIsEmptyNode(node)) {

--- a/src/keys.c
+++ b/src/keys.c
@@ -350,6 +350,12 @@ xmlSecKeyReqCopy(xmlSecKeyReqPtr dst, xmlSecKeyReqPtr src) {
     xmlSecAssert2(dst != NULL, -1);
     xmlSecAssert2(src != NULL, -1);
 
+    if(dst == src) {
+        return(0);
+    }
+
+    xmlSecPtrListEmpty(&dst->keyUseWithList);
+
     dst->keyId          = src->keyId;
     dst->keyType        = src->keyType;
     dst->keyUsage       = src->keyUsage;

--- a/src/keys.c
+++ b/src/keys.c
@@ -71,7 +71,7 @@ xmlSecKeyUseWithReset(xmlSecKeyUseWithPtr keyUseWith) {
 }
 
 /**
- * @brief Copies information from @p dst to @p src.
+ * @brief Copies information from @p src to @p dst.
  * @param dst the pointer to destination object.
  * @param src the pointer to source object.
  *
@@ -583,7 +583,7 @@ xmlSecKeyCopy(xmlSecKeyPtr keyDst, xmlSecKeyPtr keySrc) {
     }
 
 /**
- * @brief Swaps key data for @p key1 and#key2
+ * @brief Swaps key data for @p key1 and @p key2
  * @param key1 the first key.
  * @param key2 the second key.
  *

--- a/src/keysdata.c
+++ b/src/keysdata.c
@@ -23,7 +23,6 @@
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/transforms.h>
 #include <xmlsec/base64.h>
-#include <xmlsec/keyinfo.h>
 #include <xmlsec/errors.h>
 #include <xmlsec/private.h>
 #include <xmlsec/x509.h>
@@ -170,12 +169,12 @@ xmlSecKeyDataIdsRegisterDefault(void) {
     }
 
     if(xmlSecKeyDataIdsRegister(xmlSecKeyDataRetrievalMethodId) < 0) {
-        xmlSecInternalError("xmlSecKeyDataIdsRegister(xmlSecKeyDataRetrievalMethodId", NULL);
+        xmlSecInternalError("xmlSecKeyDataIdsRegister(xmlSecKeyDataRetrievalMethodId)", NULL);
         return(-1);
     }
 
     if(xmlSecKeyDataIdsRegister(xmlSecKeyDataKeyInfoReferenceId) < 0) {
-        xmlSecInternalError("xmlSecKeyDataIdsRegister(xmlSecKeyDataKeyInfoReferenceId", NULL);
+        xmlSecInternalError("xmlSecKeyDataIdsRegister(xmlSecKeyDataKeyInfoReferenceId)", NULL);
         return(-1);
     }
 
@@ -586,7 +585,8 @@ xmlSecKeyDataIdListFindByNode(xmlSecPtrListPtr list, const xmlChar* nodeName,
 
         if(((usage & dataId->usage) != 0) &&
            xmlStrEqual(nodeName, dataId->dataNodeName) &&
-           xmlStrEqual(nodeNs, dataId->dataNodeNs)) {
+           ((nodeNs == NULL && dataId->dataNodeNs == NULL) ||
+            xmlStrEqual(nodeNs, dataId->dataNodeNs))) {
 
            return(dataId);
         }
@@ -735,6 +735,7 @@ xmlSecKeyDataStoreCreate(xmlSecKeyDataStoreId id)  {
     int ret;
 
     xmlSecAssert2(id != NULL, NULL);
+    xmlSecAssert2(id->klassSize >= sizeof(xmlSecKeyDataStoreKlass), NULL);
     xmlSecAssert2(id->objSize > 0, NULL);
 
     /* Allocate a new xmlSecKeyDataStore and fill the fields. */

--- a/src/keysdata.c
+++ b/src/keysdata.c
@@ -133,7 +133,7 @@ xmlSecKeyDataIdsRegister(xmlSecKeyDataId id) {
 
 /**
  * @brief Registers a key data klass in the global list (disabled).
- * @details Registers @p id in the global list of key data klasses and but DO NOT enable this key data.
+ * @details Registers @p id in the global list of key data klasses but DO NOT enable this key data.
  * @param id the key data klass.
  *
  * @return 0 on success or a negative value if an error occurs.
@@ -765,7 +765,7 @@ xmlSecKeyDataStoreCreate(xmlSecKeyDataStoreId id)  {
  * @brief Destroys a key data store.
  * @details Destroys the key data store created with #xmlSecKeyDataStoreCreate
  * function.
- * @param store the pointer to the key data store..
+ * @param store the pointer to the key data store.
  */
 void
 xmlSecKeyDataStoreDestroy(xmlSecKeyDataStorePtr store) {

--- a/src/keysdata_helpers.c
+++ b/src/keysdata_helpers.c
@@ -657,7 +657,7 @@ done:
  * @param base64LineSize the base64 max line size.
  * @param addLineBreaks the flag indicating if we need to add line breaks around base64 output.
  * @param writeFunc the pointer to the function that converts
- *                      xmlSecKeyData to  xmlSecKeyValueEc.
+ *                      xmlSecKeyData to xmlSecKeyValueEc.
  *
  * @return 0 on success or a negative value if an error occurs.
  */
@@ -790,7 +790,7 @@ xmlSecKeyDataEcPublicKeySplitComponents (xmlSecKeyValueEcPtr ecValue) {
     data = xmlSecBufferGetData(&(ecValue->pubkey));
     size = xmlSecBufferGetSize(&(ecValue->pubkey));
     if((data == NULL) || (size <= 1) || ((size % 2) != 1)) {
-        xmlSecInvalidSizeDataError("PublicKey", size, "ECPoint data should have an odd size > 1 ", NULL);
+        xmlSecInvalidSizeDataError("PublicKey", size, "ECPoint data should have an odd size > 1", NULL);
         return(-1);
     }
     if(data[0] != XMLSEC_ECKEYVALYU_ECPOINT_MAGIC_BYTE) {
@@ -1003,7 +1003,7 @@ xmlSecKeyValueEcXmlWrite(xmlSecKeyValueEcPtr data, xmlNodePtr node,  int base64L
 
     ret = xmlSecBufferBase64NodeContentWrite(&(data->pubkey), cur, base64LineSize);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(q)", NULL);
+        xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(pubkey)", NULL);
         return(-1);
     }
     if(addLineBreaks) {
@@ -1026,7 +1026,7 @@ xmlSecKeyValueEcXmlWrite(xmlSecKeyValueEcPtr data, xmlNodePtr node,  int base64L
  *          <sequence minOccurs="0">
  *              <element name="P" type="ds:CryptoBinary"/>
  *              <element name="Q" type="ds:CryptoBinary"/>
- *              <element name="Generator"type="ds:CryptoBinary"/>
+ *              <element name="Generator" type="ds:CryptoBinary"/>
  *          </sequence>
  *          <element name="Public" type="ds:CryptoBinary"/>
  *          <sequence minOccurs="0">
@@ -1136,7 +1136,7 @@ done:
  * @param base64LineSize the base64 max line size.
  * @param addLineBreaks the flag indicating if we need to add line breaks around base64 output.
  * @param writeFunc the pointer to the function that converts
- *                      xmlSecKeyData to  xmlSecKeyValueDh.
+ *                      xmlSecKeyData to xmlSecKeyValueDh.
  *
  * @return 0 on success or a negative value if an error occurs.
  */
@@ -1593,7 +1593,7 @@ done:
  * @param base64LineSize the base64 max line size.
  * @param addLineBreaks the flag indicating if we need to add line breaks around base64 output.
  * @param writeFunc the pointer to the function that converts
- *                      xmlSecKeyData to  xmlSecKeyValueDsa.
+ *                      xmlSecKeyData to xmlSecKeyValueDsa.
  *
  * @return 0 on success or a negative value if an error occurs.
  */
@@ -1805,7 +1805,7 @@ xmlSecKeyValueDsaXmlRead(xmlSecKeyValueDsaPtr data, xmlNodePtr node) {
     }
 
     if((cur != NULL) && (xmlSecCheckNodeName(cur, xmlSecNodeDSAPgenCounter, xmlSecDSigNs))) {
-        xmlSecNotImplementedError("DSA key value pgencounter parameter is not supported");
+        xmlSecNotImplementedError("DSA key value PgenCounter parameter is not supported");
         cur = xmlSecGetNextElementNode(cur->next);
     }
 
@@ -2039,7 +2039,7 @@ done:
  * @param base64LineSize the base64 max line size.
  * @param addLineBreaks the flag indicating if we need to add line breaks around base64 output.
  * @param writeFunc the pointer to the function that converts
- *                      xmlSecKeyData to  xmlSecKeyValueRsa.
+ *                      xmlSecKeyData to xmlSecKeyValueRsa.
  *
  * @return 0 on success or a negative value if an error occurs.
  */
@@ -2159,14 +2159,14 @@ xmlSecKeyValueRsaXmlRead(xmlSecKeyValueRsaPtr data, xmlNodePtr node) {
 
     cur = xmlSecGetNextElementNode(node->children);
 
-    /* first is REQUIRED  Modulus node. */
+    /* first is REQUIRED Modulus node. */
     if((cur == NULL) || (!xmlSecCheckNodeName(cur,  xmlSecNodeRSAModulus, xmlSecDSigNs))) {
         xmlSecInvalidNodeError(cur, xmlSecNodeRSAModulus, NULL);
         return(-1);
     }
     ret = xmlSecBufferBase64NodeContentRead(&(data->modulus), cur);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecBufferBase64NodeContentRead(p)", NULL);
+        xmlSecInternalError("xmlSecBufferBase64NodeContentRead(modulus)", NULL);
         return(-1);
     }
     cur = xmlSecGetNextElementNode(cur->next);
@@ -2178,7 +2178,7 @@ xmlSecKeyValueRsaXmlRead(xmlSecKeyValueRsaPtr data, xmlNodePtr node) {
     }
     ret = xmlSecBufferBase64NodeContentRead(&(data->publicExponent), cur);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecBufferBase64NodeContentRead(q)", NULL);
+        xmlSecInternalError("xmlSecBufferBase64NodeContentRead(exponent)", NULL);
         return(-1);
     }
     cur = xmlSecGetNextElementNode(cur->next);
@@ -2188,7 +2188,7 @@ xmlSecKeyValueRsaXmlRead(xmlSecKeyValueRsaPtr data, xmlNodePtr node) {
     if((cur != NULL) && (xmlSecCheckNodeName(cur, xmlSecNodeRSAPrivateExponent, xmlSecNs))) {
         ret = xmlSecBufferBase64NodeContentRead(&(data->privateExponent), cur);
         if(ret < 0) {
-            xmlSecInternalError("xmlSecBufferBase64NodeContentRead(x)", NULL);
+            xmlSecInternalError("xmlSecBufferBase64NodeContentRead(privateExponent)", NULL);
             return(-1);
         }
         cur = xmlSecGetNextElementNode(cur->next);

--- a/src/keysdata_helpers.c
+++ b/src/keysdata_helpers.c
@@ -23,7 +23,6 @@
 #include <xmlsec/keys.h>
 #include <xmlsec/keyinfo.h>
 #include <xmlsec/base64.h>
-#include <xmlsec/keyinfo.h>
 #include <xmlsec/membuf.h>
 #include <xmlsec/strings.h>
 #include <xmlsec/errors.h>
@@ -801,7 +800,7 @@ xmlSecKeyDataEcPublicKeySplitComponents (xmlSecKeyValueEcPtr ecValue) {
     ++data;
     size = (size - 1) / 2;
 
-    /* set pub_y */
+    /* set pub_x */
     ret = xmlSecBufferSetData(&(ecValue->pub_x), data, size);
     if(ret < 0) {
         xmlSecInternalError2("xmlSecBufferSetData(pub_x)", NULL,
@@ -844,7 +843,7 @@ xmlSecKeyDataEcPublicKeyCombineComponents (xmlSecKeyValueEcPtr ecValue) {
     size = 1 + 2 * sizeKey; /* <magic byte> || x || y */
     ret = xmlSecBufferSetSize(&(ecValue->pubkey), size);
     if(ret < 0) {
-        xmlSecInternalError2("xmlSecBufferSetSize(pubkeyy)", NULL,
+        xmlSecInternalError2("xmlSecBufferSetSize(pubkey)", NULL,
             "size=" XMLSEC_SIZE_FMT, size);
         return(-1);
     }
@@ -1432,7 +1431,7 @@ xmlSecKeyValueDhXmlWrite(xmlSecKeyValueDhPtr data, xmlNodePtr node, int base64Li
     }
     ret = xmlSecBufferBase64NodeContentWrite(&(data->public), cur, base64LineSize);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(g)", NULL);
+        xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(xmlSecNodeDHPublic)", NULL);
         return(-1);
     }
     if(addLineBreaks) {
@@ -1453,7 +1452,7 @@ xmlSecKeyValueDhXmlWrite(xmlSecKeyValueDhPtr data, xmlNodePtr node, int base64Li
         }
         ret = xmlSecBufferBase64NodeContentWrite(&(data->seed), cur, base64LineSize);
         if(ret < 0) {
-            xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(g)", NULL);
+            xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(xmlSecNodeDHSeed)", NULL);
             return(-1);
         }
         if(addLineBreaks) {
@@ -1475,7 +1474,7 @@ xmlSecKeyValueDhXmlWrite(xmlSecKeyValueDhPtr data, xmlNodePtr node, int base64Li
         }
         ret = xmlSecBufferBase64NodeContentWrite(&(data->pgenCounter), cur, base64LineSize);
         if(ret < 0) {
-            xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(g)", NULL);
+            xmlSecInternalError("xmlSecBufferBase64NodeContentWrite(xmlSecNodeDHPgenCounter)", NULL);
             return(-1);
         }
         if(addLineBreaks) {
@@ -2127,13 +2126,13 @@ xmlSecKeyValueRsaInitialize(xmlSecKeyValueRsaPtr data) {
     }
     ret = xmlSecBufferInitialize(&(data->publicExponent), XMLSEC_KEY_DATA_RSA_INIT_BUF_SIZE);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecBufferInitialize(q)", NULL);
+        xmlSecInternalError("xmlSecBufferInitialize(publicExponent)", NULL);
         xmlSecKeyValueRsaFinalize(data);
         return(-1);
     }
     ret = xmlSecBufferInitialize(&(data->privateExponent), XMLSEC_KEY_DATA_RSA_INIT_BUF_SIZE);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecBufferInitialize(g)", NULL);
+        xmlSecInternalError("xmlSecBufferInitialize(privateExponent)", NULL);
         xmlSecKeyValueRsaFinalize(data);
         return(-1);
     }
@@ -2162,7 +2161,7 @@ xmlSecKeyValueRsaXmlRead(xmlSecKeyValueRsaPtr data, xmlNodePtr node) {
 
     /* first is REQUIRED  Modulus node. */
     if((cur == NULL) || (!xmlSecCheckNodeName(cur,  xmlSecNodeRSAModulus, xmlSecDSigNs))) {
-        xmlSecInvalidNodeError(cur, xmlSecNodeDSAP, NULL);
+        xmlSecInvalidNodeError(cur, xmlSecNodeRSAModulus, NULL);
         return(-1);
     }
     ret = xmlSecBufferBase64NodeContentRead(&(data->modulus), cur);
@@ -2174,7 +2173,7 @@ xmlSecKeyValueRsaXmlRead(xmlSecKeyValueRsaPtr data, xmlNodePtr node) {
 
     /* next is REQUIRED Exponent node. */
     if((cur == NULL) || (!xmlSecCheckNodeName(cur, xmlSecNodeRSAExponent, xmlSecDSigNs))) {
-        xmlSecInvalidNodeError(cur, xmlSecNodeDSAQ, NULL);
+        xmlSecInvalidNodeError(cur, xmlSecNodeRSAExponent, NULL);
         return(-1);
     }
     ret = xmlSecBufferBase64NodeContentRead(&(data->publicExponent), cur);

--- a/src/keysmngr.c
+++ b/src/keysmngr.c
@@ -60,6 +60,7 @@ xmlSecKeysMngrCreate(void) {
     ret = xmlSecPtrListInitialize(&(mngr->storesList), xmlSecKeyDataStorePtrListId);
     if(ret < 0) {
         xmlSecInternalError("xmlSecPtrListInitialize(xmlSecKeyDataStorePtrListId)", NULL);
+        xmlFree(mngr);
         return(NULL);
     }
 

--- a/src/kw_helpers.c
+++ b/src/kw_helpers.c
@@ -84,8 +84,12 @@ xmlSecTransformKWDes3Finalize(xmlSecTransformPtr transform, xmlSecTransformKWDes
 }
 
 int
-xmlSecTransformKWDes3SetKeyReq(xmlSecTransformPtr transform, xmlSecTransformKWDes3CtxPtr ctx,
-                        xmlSecKeyReqPtr keyReq) {
+xmlSecTransformKWDes3SetKeyReq(xmlSecTransformPtr transform, xmlSecTransformKWDes3CtxPtr ctx, xmlSecKeyReqPtr keyReq) {
+    xmlSecAssert2(transform != NULL, -1);
+    xmlSecAssert2(ctx != NULL, -1);
+    xmlSecAssert2(ctx->keyId != NULL, -1);
+    xmlSecAssert2(keyReq != NULL, -1);
+
     keyReq->keyId   = ctx->keyId;
     keyReq->keyType = xmlSecKeyDataTypeSymmetric;
     if(transform->operation == xmlSecTransformOperationEncrypt) {
@@ -546,7 +550,7 @@ xmlSecTransformKWRfc3394SetKeyReq(xmlSecTransformPtr transform, xmlSecTransformK
     xmlSecAssert2(ctx->keyId != NULL, -1);
     xmlSecAssert2(keyReq != NULL, -1);
 
-    keyReq->keyId   = ctx->keyId;;
+    keyReq->keyId   = ctx->keyId;
     keyReq->keyType = xmlSecKeyDataTypeSymmetric;
     if(transform->operation == xmlSecTransformOperationEncrypt) {
         keyReq->keyUsage = xmlSecKeyUsageEncrypt;

--- a/src/kw_helpers.c
+++ b/src/kw_helpers.c
@@ -255,7 +255,7 @@ xmlSecTransformKWDes3Execute(xmlSecTransformPtr transform, xmlSecTransformKWDes3
  * 4. Generate 8 random octets [RANDOM] and call this IV.
  * 5. Encrypt WKCKS in CBC mode using KEK as the key and IV as the
  *    initialization vector. Call the results TEMP1.
- * 6. Left TEMP2 = IV || TEMP1.
+ * 6. Let TEMP2 = IV || TEMP1.
  * 7. Reverse the order of the octets in TEMP2 and call the result TEMP3.
  * 8. Encrypt TEMP3 in CBC mode using the KEK and an initialization vector
  *    of 0x4adda22c79e82105. The resulting cipher text is the desired result.
@@ -727,10 +727,10 @@ xmlSecTransformKWRfc3394Execute(xmlSecTransformPtr transform, xmlSecTransformKWR
  *      If N>1, perform the following steps:
  *   2. Initialize variables:
  *          * Set A to 0xA6A6A6A6A6A6A6A6
- *          * Fori=1 to N,
+ *          * For i=1 to N,
  *            R(i)=P(i)
  *   3. Calculate intermediate values:
- *          * Forj=0 to 5,
+ *          * For j=0 to 5,
  *                o For i=1 to N,
  *                  t= i + j*N
  *                  B=AES(K)enc(A|R(i))

--- a/src/list.c
+++ b/src/list.c
@@ -260,6 +260,10 @@ xmlSecPtrListGetSize(xmlSecPtrListPtr list) {
 xmlSecPtr
 xmlSecPtrListGetItem(xmlSecPtrListPtr list, xmlSecSize pos) {
     xmlSecAssert2(xmlSecPtrListIsValid(list), NULL);
+
+    if(pos >= list->use) {
+        return(NULL);
+    }
     xmlSecAssert2(list->data != NULL, NULL);
     xmlSecAssert2(pos < list->use, NULL);
 
@@ -469,7 +473,7 @@ xmlSecPtrListEnsureSize(xmlSecPtrListPtr list, xmlSecSize size) {
 
     xmlSecAssert2(xmlSecPtrListIsValid(list), -1);
 
-    if(size < list->max) {
+    if(size <= list->max) {
         return(0);
     }
 

--- a/src/list.c
+++ b/src/list.c
@@ -151,20 +151,24 @@ xmlSecPtrListEmpty(xmlSecPtrListPtr list) {
 /**
  * @brief Copies items from one list to another.
  * @details Copies @p src list items to @p dst list using duplicateItem method
- * of the list klass. If duplicateItem method is NULL then
- * we jsut copy pointers to items.
+ * of the list klass. If duplicateItem is provided then the list klass must
+ * also provide destroyItem so partially copied items can be released on
+ * errors. If duplicateItem method is NULL then we jsut copy pointers to items.
  * @param dst the pointer to destination list.
  * @param src the pointer to source list.
  * @return 0 on success or a negative value if an error occurs.
  */
 int
 xmlSecPtrListCopy(xmlSecPtrListPtr dst, xmlSecPtrListPtr src) {
-    xmlSecSize i;
+    xmlSecSize ii;
+    xmlSecSize initialUse;
     int ret;
 
     xmlSecAssert2(xmlSecPtrListIsValid(dst), -1);
     xmlSecAssert2(xmlSecPtrListIsValid(src), -1);
     xmlSecAssert2(dst->id == src->id, -1);
+
+    initialUse = dst->use;
 
     /* allocate memory */
     ret = xmlSecPtrListEnsureSize(dst, dst->use + src->use);
@@ -175,18 +179,30 @@ xmlSecPtrListCopy(xmlSecPtrListPtr dst, xmlSecPtrListPtr src) {
     }
 
     /* copy one item after another */
-    for(i = 0; i < src->use; ++i, ++dst->use) {
+    for(ii = 0; ii < src->use; ++ii, ++dst->use) {
         xmlSecAssert2(src->data != NULL, -1);
         xmlSecAssert2(dst->data != NULL, -1);
 
-        if((dst->id->duplicateItem != NULL) && (src->data[i] != NULL)) {
-            dst->data[dst->use] = dst->id->duplicateItem(src->data[i]);
+        if((dst->id->duplicateItem != NULL) && (src->data[ii] != NULL)) {
+            dst->data[dst->use] = dst->id->duplicateItem(src->data[ii]);
             if(dst->data[dst->use] == NULL) {
+                xmlSecSize pos;
+
+                if(dst->id->destroyItem != NULL) {
+                    for(pos = initialUse; pos < dst->use; ++pos) {
+                        xmlSecAssert2(dst->data != NULL, -1);
+                        if(dst->data[pos] != NULL) {
+                            dst->id->destroyItem(dst->data[pos]);
+                            dst->data[pos] = NULL;
+                        }
+                    }
+                }
+                dst->use = initialUse;
                 xmlSecInternalError("duplicateItem", xmlSecPtrListGetName(src));
                 return(-1);
             }
         } else {
-            dst->data[dst->use] = src->data[i];
+            dst->data[dst->use] = src->data[ii];
         }
     }
 

--- a/src/list.c
+++ b/src/list.c
@@ -153,7 +153,7 @@ xmlSecPtrListEmpty(xmlSecPtrListPtr list) {
  * @details Copies @p src list items to @p dst list using duplicateItem method
  * of the list klass. If duplicateItem is provided then the list klass must
  * also provide destroyItem so partially copied items can be released on
- * errors. If duplicateItem method is NULL then we jsut copy pointers to items.
+ * errors. If duplicateItem method is NULL then we just copy pointers to items.
  * @param dst the pointer to destination list.
  * @param src the pointer to source list.
  * @return 0 on success or a negative value if an error occurs.

--- a/src/membuf.c
+++ b/src/membuf.c
@@ -20,7 +20,6 @@
 #include <xmlsec/buffer.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/transforms.h>
-#include <xmlsec/keys.h>
 #include <xmlsec/base64.h>
 #include <xmlsec/membuf.h>
 #include <xmlsec/errors.h>
@@ -125,7 +124,7 @@ xmlSecTransformMemBufFinalize(xmlSecTransformPtr transform) {
     buffer = xmlSecMemBufGetCtx(transform);
     xmlSecAssert(buffer != NULL);
 
-    xmlSecBufferFinalize(xmlSecMemBufGetCtx(transform));
+    xmlSecBufferFinalize(buffer);
 }
 
 static int

--- a/src/membuf.c
+++ b/src/membuf.c
@@ -51,7 +51,7 @@ static xmlSecTransformKlass xmlSecTransformMemBufKlass = {
     0,                                          /* xmlSecAlgorithmUsage usage; */
 
     xmlSecTransformMemBufInitialize,            /* xmlSecTransformInitializeMethod initialize; */
-    xmlSecTransformMemBufFinalize,              /* xmlSecTransformFianlizeMethod finalize; */
+    xmlSecTransformMemBufFinalize,              /* xmlSecTransformFinalizeMethod finalize; */
     NULL,                                       /* xmlSecTransformNodeReadMethod readNode; */
     NULL,                                       /* xmlSecTransformNodeWriteMethod writeNode; */
     NULL,                                       /* xmlSecTransformSetKeyReqMethod setKeyReq; */

--- a/src/nodeset.c
+++ b/src/nodeset.c
@@ -494,7 +494,14 @@ xmlSecNodeSetGetChildren(xmlDocPtr doc, const xmlNodePtr parent, int withComment
         xmlNodePtr cur;
         for(cur = doc->children; cur != NULL; cur = cur->next) {
             if(withComments || (cur->type != XML_COMMENT_NODE)) {
-                xmlXPathNodeSetAdd(nodes, cur);
+                int ret;
+
+                ret = xmlXPathNodeSetAdd(nodes, cur);
+                if(ret < 0) {
+                    xmlSecXmlError("xmlXPathNodeSetAdd", NULL);
+                    xmlXPathFreeNodeSet(nodes);
+                    return(NULL);
+                }
             }
         }
     }
@@ -530,6 +537,9 @@ xmlSecNodeSetDumpTextNodesWalkCallback(xmlSecNodeSetPtr nset, xmlNodePtr cur,
     UNREFERENCED_PARAMETER(parent);
 
     if(cur->type != XML_TEXT_NODE) {
+        return(0);
+    }
+    if(cur->content == NULL) {
         return(0);
     }
     ret = xmlOutputBufferWriteString((xmlOutputBufferPtr)data,
@@ -592,6 +602,9 @@ xmlSecNodeSetDebugDump(xmlSecNodeSetPtr nset, FILE *output) {
         xmlSecNotImplementedError("xmlSecNodeSetList is deprecated");
         fprintf(output, "(xmlSecNodeSetList)\n");
         break;
+    default:
+        xmlSecUnsupportedEnumValueError("node set type", nset->type, NULL);
+        break;
     }
 
     len = xmlXPathNodeSetGetLength(nset->nodes);
@@ -609,10 +622,11 @@ xmlSecNodeSetDebugDump(xmlSecNodeSetPtr nset, FILE *output) {
                 XMLSEC_ENUM_CAST(cur->type),
                 (ns->prefix) ? ns->prefix : BAD_CAST "null",
                 (ns->href) ? ns->href : BAD_CAST "null",
-                (((xmlNodePtr)ns->next)->ns &&
+                ((ns->next != NULL) &&
+                 ((xmlNodePtr)ns->next)->ns &&
                  ((xmlNodePtr)ns->next)->ns->prefix) ?
-                  ((xmlNodePtr)ns->next)->ns->prefix : BAD_CAST "null",
-                ((xmlNodePtr)ns->next)->name);
+                 ((xmlNodePtr)ns->next)->ns->prefix : BAD_CAST "null",
+                (ns->next != NULL) ? ((xmlNodePtr)ns->next)->name : BAD_CAST "null");
         }
     }
 }

--- a/src/nodeset.c
+++ b/src/nodeset.c
@@ -463,7 +463,7 @@ xmlSecNodeSetWalkRecursive(xmlSecNodeSetPtr nset, xmlNodePtr startNode, xmlSecNo
  *    all nodes in the @p parent subtree;
  *  - if @p withComments is 0 and @p invert is 0:
  *    all nodes in the @p parent subtree except comment nodes;
- *  - if @p withComments is not 0 and @p invert not is 0:
+ *  - if @p withComments is not 0 and @p invert is not 0:
  *    all nodes in the @p doc except nodes in the @p parent subtree;
  *  - if @p withComments is 0 and @p invert is 0:
  *    all nodes in the @p doc except nodes in the @p parent subtree

--- a/src/openssl/evp.c
+++ b/src/openssl/evp.c
@@ -1345,11 +1345,13 @@ xmlSecOpenSSLKeyDataDsaSetValue(xmlSecKeyDataPtr data, xmlSecOpenSSLKeyValueDsaP
             xmlSecKeyDataGetName(data));
         goto done;
     }
-    ret = OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_PRIV_KEY, dsaKeyValue->priv_key);
-    if(ret != 1) {
-        xmlSecOpenSSLError("OSSL_PARAM_BLD_push_BN(priv_key)",
-            xmlSecKeyDataGetName(data));
-        goto done;
+    if(dsaKeyValue->priv_key != NULL) {
+        ret = OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_PRIV_KEY, dsaKeyValue->priv_key);
+        if(ret != 1) {
+            xmlSecOpenSSLError("OSSL_PARAM_BLD_push_BN(priv_key)",
+                xmlSecKeyDataGetName(data));
+            goto done;
+        }
     }
 
     params = OSSL_PARAM_BLD_to_param(param_bld);
@@ -1371,7 +1373,11 @@ xmlSecOpenSSLKeyDataDsaSetValue(xmlSecKeyDataPtr data, xmlSecOpenSSLKeyValueDsaP
             xmlSecKeyDataGetName(data));
         goto done;
     }
-    ret = EVP_PKEY_fromdata(ctx, &pKey, EVP_PKEY_KEYPAIR, params);
+    /*
+     * If the private key is not present, import only the public key.
+     * Importing a keypair with an empty private key parameter fails.
+     */
+    ret = EVP_PKEY_fromdata(ctx, &pKey, (dsaKeyValue->priv_key != NULL) ? EVP_PKEY_KEYPAIR : EVP_PKEY_PUBLIC_KEY, params);
     if(ret <= 0) {
         xmlSecOpenSSLError("EVP_PKEY_fromdata",
             xmlSecKeyDataGetName(data));
@@ -2139,6 +2145,14 @@ xmlSecOpenSSLKeyDataDhSetValue(xmlSecKeyDataPtr data, xmlSecOpenSSLKeyValueDhPtr
             goto done;
         }
     }
+    if(dhKeyValue->private != NULL) {
+        ret = OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_PRIV_KEY, dhKeyValue->private);
+        if(ret != 1) {
+            xmlSecOpenSSLError("OSSL_PARAM_BLD_push_BN(private)",
+                xmlSecKeyDataGetName(data));
+            goto done;
+        }
+    }
 
     /* create params */
     params = OSSL_PARAM_BLD_to_param(param_bld);
@@ -2160,7 +2174,11 @@ xmlSecOpenSSLKeyDataDhSetValue(xmlSecKeyDataPtr data, xmlSecOpenSSLKeyValueDhPtr
             xmlSecKeyDataGetName(data));
         goto done;
     }
-    ret = EVP_PKEY_fromdata(ctx, &pKey, EVP_PKEY_KEYPAIR, params);
+    /*
+     * If the private key is not present, import only the public key.
+     * Importing a keypair with an empty private key parameter fails.
+     */
+    ret = EVP_PKEY_fromdata(ctx, &pKey, (dhKeyValue->private != NULL) ? EVP_PKEY_KEYPAIR : EVP_PKEY_PUBLIC_KEY, params);
     if(ret <= 0) {
         xmlSecOpenSSLError("EVP_PKEY_fromdata",
             xmlSecKeyDataGetName(data));
@@ -3628,11 +3646,13 @@ xmlSecOpenSSLKeyDataRsaSetValue(xmlSecKeyDataPtr data, xmlSecOpenSSLKeyValueRsaP
             xmlSecKeyDataGetName(data));
         goto done;
     }
-    ret = OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_RSA_D, rsaKeyValue->d);
-    if(ret != 1) {
-        xmlSecOpenSSLError("OSSL_PARAM_BLD_push_BN(d)",
-            xmlSecKeyDataGetName(data));
-        goto done;
+    if(rsaKeyValue->d != NULL) {
+        ret = OSSL_PARAM_BLD_push_BN(param_bld, OSSL_PKEY_PARAM_RSA_D, rsaKeyValue->d);
+        if(ret != 1) {
+            xmlSecOpenSSLError("OSSL_PARAM_BLD_push_BN(d)",
+                xmlSecKeyDataGetName(data));
+            goto done;
+        }
     }
 
     params = OSSL_PARAM_BLD_to_param(param_bld);
@@ -3654,7 +3674,11 @@ xmlSecOpenSSLKeyDataRsaSetValue(xmlSecKeyDataPtr data, xmlSecOpenSSLKeyValueRsaP
             xmlSecKeyDataGetName(data));
         goto done;
     }
-    ret = EVP_PKEY_fromdata(ctx, &pKey, EVP_PKEY_KEYPAIR, params);
+    /*
+     * If the private key is not present, import only the public key.
+     * Importing a keypair with an empty private key parameter fails.
+     */
+    ret = EVP_PKEY_fromdata(ctx, &pKey, (rsaKeyValue->d != NULL) ? EVP_PKEY_KEYPAIR : EVP_PKEY_PUBLIC_KEY, params);
     if(ret <= 0) {
         xmlSecOpenSSLError("EVP_PKEY_fromdata",
             xmlSecKeyDataGetName(data));

--- a/src/parser.c
+++ b/src/parser.c
@@ -295,7 +295,7 @@ xmlSecParserPopXml(xmlSecTransformPtr transform, xmlSecNodeSetPtr* nodes,
 
     /* finaly do the parsing */
     ret = xmlParseDocument(ctxt);
-    if(ret < 0) {
+    if((ret < 0) || (ctxt->myDoc == NULL)) {
         xmlSecXmlParserError("xmlParseDocument", ctxt, xmlSecTransformGetName(transform));
         if(ctxt->myDoc != NULL) {
             xmlFreeDoc(ctxt->myDoc);

--- a/src/parser.c
+++ b/src/parser.c
@@ -293,7 +293,7 @@ xmlSecParserPopXml(xmlSecTransformPtr transform, xmlSecNodeSetPtr* nodes,
         return(-1);
     }
 
-    /* finaly do the parsing */
+    /* finally do the parsing */
     ret = xmlParseDocument(ctxt);
     if((ret < 0) || (ctxt->myDoc == NULL)) {
         xmlSecXmlParserError("xmlParseDocument", ctxt, xmlSecTransformGetName(transform));
@@ -558,7 +558,7 @@ xmlSecParsePrepareCtxt(xmlParserCtxtPtr ctxt) {
 /*
  * To block network access and loading of external entities:
  * - XML_PARSE_NO_XXE: disable loading of external content (available >= 2.13.0),
- *   it disables XML_PARSE_DTDLOAD | XML_PARSE_DTDATTR ut we keep those in defaults
+ *   it disables XML_PARSE_DTDLOAD | XML_PARSE_DTDATTR but we keep those in defaults
  *   to make it work if XML_PARSE_NO_XXE is disabled (e.g. with --xxe option)
  * - XML_PARSE_NONET: forbid network access
  *

--- a/src/parser.c
+++ b/src/parser.c
@@ -274,7 +274,10 @@ xmlSecParserPopXml(xmlSecTransformPtr transform, xmlSecNodeSetPtr* nodes,
     if(input == NULL) {
         xmlSecXmlParserError("xmlNewIOInputStream", ctxt, xmlSecTransformGetName(transform));
         xmlFreeParserCtxt(ctxt);
+#if (LIBXML_VERSION < 21300)
+        /* libxml2 >= 2.13 frees the buffer itself on failure */
         xmlFreeParserInputBuffer(buf);
+#endif /* (LIBXML_VERSION < 21300) */
         return(-1);
     }
 

--- a/src/relationship.c
+++ b/src/relationship.c
@@ -30,7 +30,7 @@
 
 /******************************************************************************
  *
- * XML Relationshi transform
+ * XML Relationship transform
  *
  *  * [Relationship transform](http://standards.iso.org/ittf/PubliclyAvailableStandards/c061796_ISO_IEC_29500-2_2012.zip)
  *

--- a/src/strings.c
+++ b/src/strings.c
@@ -941,3 +941,4 @@ const xmlChar xmlSecHrefXslt[]                  = "http://www.w3.org/TR/1999/REC
   *****************************************************************************/
 const xmlChar xmlSecStringEmpty[]               = "";
 const xmlChar xmlSecStringCR[]                  = "\n";
+const xmlChar xmlSecStringLF[]                  = "\n";

--- a/src/strings.c
+++ b/src/strings.c
@@ -14,7 +14,7 @@
 
 #include <xmlsec/xmlsec.h>
 
-/** THIS IS FOR EXPERIEMENTAL FEATURES, DO NOT USE IN PRODUCTION */
+/** THIS IS FOR EXPERIMENTAL FEATURES, DO NOT USE IN PRODUCTION */
 #define XMLSEC_ALKESEY_EXPERIMENTAL_2025_12   "http://www.aleksey.com/xmlsec/2025/12/xmldsig-more#"
 
 /******************************************************************************
@@ -381,7 +381,7 @@ const xmlChar xmlSecHrefXDHKeyValue[]           = XMLSEC_ALKESEY_EXPERIMENTAL_20
 
 /******************************************************************************
  *
- * ECDSA sigantures strings
+ * ECDSA signatures strings
  *
  * https://www.ietf.org/rfc/rfc9231.html@p name-ecdsa-sha-ecdsa-ripemd160-e
  *
@@ -426,7 +426,7 @@ const xmlChar xmlSecHrefMLDSAKeyValue[]       = XMLSEC_ALKESEY_EXPERIMENTAL_2025
 
 /******************************************************************************
  *
- * ML-DSA signature trasnsform strings
+ * ML-DSA signature transform strings
  *
   *****************************************************************************/
 const xmlChar xmlSecMLDSANs[]                 = XMLSEC_ALKESEY_EXPERIMENTAL_2025_12;
@@ -475,7 +475,7 @@ const xmlChar xmlSecHrefSLHDSAKeyValue[]      = XMLSEC_ALKESEY_EXPERIMENTAL_2025
 
 /******************************************************************************
  *
- * SLH-DSA signature trasnsform strings
+ * SLH-DSA signature transform strings
  *
   *****************************************************************************/
 const xmlChar xmlSecSLHDSANs[]                = XMLSEC_ALKESEY_EXPERIMENTAL_2025_12;
@@ -761,7 +761,7 @@ const xmlChar xmlSecHrefMgf1Sha256[]            = "http://www.w3.org/2009/xmlenc
 const xmlChar xmlSecHrefMgf1Sha384[]            = "http://www.w3.org/2009/xmlenc11#mgf1sha384";
 const xmlChar xmlSecHrefMgf1Sha512[]            = "http://www.w3.org/2009/xmlenc11#mgf1sha512";
 
-/* RSS PSS https://www.rfc-editor.org/rfc/rfc9231.txt */
+/* RSA PSS https://www.rfc-editor.org/rfc/rfc9231.txt */
 const xmlChar xmlSecNameRsaPssSha1[]            = "rsa-pss-sha1";
 const xmlChar xmlSecHrefRsaPssSha1[]            = "http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1";
 

--- a/src/templates.c
+++ b/src/templates.c
@@ -605,7 +605,7 @@ xmlSecTmplPrepareEncData(xmlNodePtr parentNode, xmlSecTransformId encMethodId) {
  * @brief Ensures a &lt;dsig:KeyInfo/&gt; child in the &lt;enc:EncryptedData/&gt; node.
  * @details Adds &lt;dsig:KeyInfo/&gt; to the  &lt;enc:EncryptedData/&gt; node @p encNode.
  * @param encNode the pointer to &lt;enc:EncryptedData/&gt; node.
- * @param id the Id attrbibute (optional).
+ * @param id the Id attribute (optional).
  *
  * @return the pointer to newly created &lt;dsig:KeyInfo/&gt; node or
  * NULL if an error occurs.
@@ -733,7 +733,7 @@ xmlSecTmplEncDataEnsureCipherValue(xmlNodePtr encNode) {
         return(NULL);
     }
 
-    /* check that we don;t have CipherReference node */
+    /* check that we don't have CipherReference node */
     tmp = xmlSecFindChild(cipherDataNode, xmlSecNodeCipherReference, xmlSecEncNs);
     if(tmp != NULL) {
         xmlSecNodeAlreadyPresentError(cipherDataNode, xmlSecNodeCipherReference, NULL);
@@ -776,7 +776,7 @@ xmlSecTmplEncDataEnsureCipherReference(xmlNodePtr encNode, const xmlChar *uri) {
         return(NULL);
     }
 
-    /* check that we don;t have CipherValue node */
+    /* check that we don't have CipherValue node */
     tmp = xmlSecFindChild(cipherDataNode, xmlSecNodeCipherValue, xmlSecEncNs);
     if(tmp != NULL) {
         xmlSecNodeAlreadyPresentError(cipherDataNode, xmlSecNodeCipherValue, NULL);
@@ -801,7 +801,7 @@ xmlSecTmplEncDataEnsureCipherReference(xmlNodePtr encNode, const xmlChar *uri) {
 
 /**
  * @brief Gets pointer to &lt;enc:EncryptionMethod/&gt; node.
- * @param encNode the pointer to <enc:EcnryptedData /> node.
+ * @param encNode the pointer to <enc:EncryptedData /> node.
  *
  * @return pointer to <enc:EncryptionMethod /> node or NULL if an error occurs.
  */

--- a/src/transform_helpers.c
+++ b/src/transform_helpers.c
@@ -223,7 +223,7 @@ xmlSecTransformConcatKdfParamsRead(xmlSecTransformConcatKdfParamsPtr params, xml
     }
     ret = xmlSecTransformConcatKdfParamsReadsBitsAttr(&(params->bufSuppPrivInfo), node, xmlSecNodeConcatKDFAttrSuppPrivInfo);
     if(ret < 0) {
-        xmlSecInternalError("xmlSecTransformConcatKdfParamsReadsBitsAttr(ASuppPrivInfo)", NULL);
+        xmlSecInternalError("xmlSecTransformConcatKdfParamsReadsBitsAttr(SuppPrivInfo)", NULL);
         return(-1);
     }
 
@@ -344,7 +344,7 @@ xmlSecTransformReadKeyInfoNode(xmlSecKeyDataType keyType, xmlNodePtr node,
         goto done;
     }
     if(!xmlSecKeyMatch(key, NULL, &(keyInfoCtx.keyReq))) {
-        xmlSecOtherError(XMLSEC_ERRORS_R_KEY_NOT_FOUND, xmlSecNodeGetName(node), "key doesn't match requiremetns");
+        xmlSecOtherError(XMLSEC_ERRORS_R_KEY_NOT_FOUND, xmlSecNodeGetName(node), "key doesn't match requirements");
         goto done;
     }
 
@@ -549,7 +549,7 @@ xmlSecTransformKAMRead(xmlSecTransformKAMPtr params, xmlNodePtr node, xmlSecTran
     }
     cur = xmlSecGetNextElementNode(cur->next);
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         return(-1);
@@ -628,7 +628,7 @@ xmlSecTransformKAMWrite(xmlSecTransformKAMPtr params, xmlNodePtr node, xmlSecTra
     }
     cur = xmlSecGetNextElementNode(cur->next);
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         goto done;
@@ -1325,7 +1325,7 @@ xmlSecTransformPbkdf2ParamsReadSalt(xmlSecTransformPbkdf2ParamsPtr params, xmlNo
     xmlSecAssert2(params != NULL, -1);
     xmlSecAssert2(node != NULL, -1);
 
-    /* first and onluy node is required Salt / Specified (Salt / OtherSource is not supported)*/
+    /* first and only node is required Salt / Specified (Salt / OtherSource is not supported)*/
     cur  = xmlSecGetNextElementNode(node->children);
     if((cur == NULL) || (!xmlSecCheckNodeName(cur, xmlSecNodePbkdf2SaltSpecified, xmlSecEnc11Ns))) {
         xmlSecInvalidNodeError(cur, xmlSecNodePbkdf2SaltSpecified, NULL);

--- a/src/transforms.c
+++ b/src/transforms.c
@@ -117,7 +117,7 @@ xmlSecTransformIdsInit(void) {
 
 /**
  * @brief Shuts down the transform klasses.
- * @details Shuts down the keys data klasses. This function is called from the
+ * @details Shuts down the transform klasses. This function is called from the
  * #xmlSecShutdown function and the application should not call it directly.
  */
 void
@@ -644,7 +644,7 @@ xmlSecTransformCtxAppend(xmlSecTransformCtxPtr ctx, xmlSecTransformPtr transform
 
 /**
  * @brief Connects a transform to the beginning of the chain in @p ctx.
- * @details Connects the @p transform to the beggining of the chain of transforms in the @p ctx
+ * @details Connects the @p transform to the beginning of the chain of transforms in the @p ctx
  * (see #xmlSecTransformConnect function for details).
  * @param ctx the pointer to transforms chain processing context.
  * @param transform the pointer to new transform.
@@ -1797,7 +1797,7 @@ xmlSecTransformPushXml(xmlSecTransformPtr transform, xmlSecNodeSetPtr nodes,
  * @details Pops data from previous transform in the chain, processes the data and
  * returns result in @p nodes.
  * @param transform the pointer to transform object.
- * @param nodes the pointer to store popinter to result nodes.
+ * @param nodes the pointer to store pointer to result nodes.
  * @param transformCtx the pointer to transform context object.
  *
  * @return 0 on success or a negative value if an error occurs.
@@ -2176,7 +2176,7 @@ xmlSecTransformDefaultPopBin(xmlSecTransformPtr transform, xmlSecByte* data,
                         "size=" XMLSEC_SIZE_FMT, (inSize + chunkSize));
                     return(-1);
                 }
-                final = 0; /* the previous transform returned some data..*/
+                final = 0; /* the previous transform returned some data */
             } else {
                 final = 1; /* no data returned from previous transform, we are done */
             }
@@ -2268,7 +2268,7 @@ xmlSecTransformDefaultPushXml(xmlSecTransformPtr transform, xmlSecNodeSetPtr nod
  * @details Pops data from previous transform in the chain, processes the data
  * by calling transform's execute method and returns result in @p nodes.
  * @param transform the pointer to transform object.
- * @param nodes the pointer to store popinter to result nodes.
+ * @param nodes the pointer to store pointer to result nodes.
  * @param transformCtx the pointer to transform context object.
  *
  * @return 0 on success or a negative value if an error occurs.

--- a/src/x509_helpers.c
+++ b/src/x509_helpers.c
@@ -840,8 +840,8 @@ xmlSecKeyX509DataValueXmlWrite(xmlSecKeyX509DataValuePtr x509Value, xmlNodePtr n
 /**
  * @brief Reads X509 escaped string.
  * @details Reads X509 escaped string (see https://datatracker.ietf.org/doc/html/rfc4514#section-3).
- * The function parses the string in the @p in paramter until end of string or @p delim is encountered.
- * The @p in and @p inSize parameters are moved to the next character (e.g. delimeter if it was encountered
+ * The function parses the string in the @p in parameter until end of string or @p delim is encountered.
+ * The @p in and @p inSize parameters are moved to the next character (e.g. delimiter if it was encountered
  * during parsing).
  * @param in the in/out pointer to the parsed string.
  * @param inSize the in/out size of the parsed string.
@@ -881,7 +881,7 @@ xmlSecX509EscapedStringRead(const xmlChar **in, xmlSecSize *inSize,
                 /* stop */
                 state = XMLSEC_X509_NAME_READ_STATE_DELIMETER;
             } else if (inCh == '\\') {
-                /* do not update output, move to next chat */
+                  /* do not update output, move to next char */
                 state = XMLSEC_X509_NAME_READ_STATE_AFTER_SLASH1;
                 ++ii;
             } else {
@@ -964,8 +964,8 @@ xmlSecX509EscapedStringRead(const xmlChar **in, xmlSecSize *inSize,
  *   - string (eg 'abc')
  *   - quoted string (eg '"abc"')
  *   - hexstring (eg '@p A0B0')
- * The function parses the string in the @p in paramter until end of string or @p delim is encountered.
- * The @p in and @p inSize parameters are moved to the next character (e.g. delimeter if it was encountered
+ * The function parses the string in the @p in parameter until end of string or @p delim is encountered.
+ * The @p in and @p inSize parameters are moved to the next character (e.g. delimiter if it was encountered
  * during parsing).
  * @param in the in/out pointer to the parsed string.
  * @param inSize the in/out size of the parsed string.
@@ -1031,7 +1031,7 @@ xmlSecX509AttrValueStringRead(
             }
         }
     } else if((**in) == '#') {
-        /* read octect value:
+        /* read octet value:
                 hexstring = SHARP 1*hexpair
                 hexpair = HEX HEX
         */

--- a/src/xmldsig.c
+++ b/src/xmldsig.c
@@ -687,8 +687,7 @@ xmlSecDSigCtxProcessSignedInfoNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node, xm
         /* the dsig spec does require SignatureMethod node
          * to be present but in some case it application might decide to
          * minimize traffic */
-        dsigCtx->signMethod = xmlSecTransformCtxCreateAndAppend(&(dsigCtx->transformCtx),
-                                                              dsigCtx->defSignMethodId);
+        dsigCtx->signMethod = xmlSecTransformCtxCreateAndAppend(&(dsigCtx->transformCtx), dsigCtx->defSignMethodId);
         if(dsigCtx->signMethod == NULL) {
             xmlSecInternalError("xmlSecTransformCtxCreateAndAppend", NULL);
             return(-1);
@@ -1388,12 +1387,11 @@ xmlSecDSigReferenceCtxProcessNode(xmlSecDSigReferenceCtxPtr dsigRefCtx, xmlNodeP
         }
 
         cur = xmlSecGetNextElementNode(cur->next);
-    } else if(dsigRefCtx->dsigCtx->defSignMethodId != xmlSecTransformIdUnknown) {
+    } else if(dsigRefCtx->dsigCtx->defDigestMethodId != xmlSecTransformIdUnknown) {
         /* the dsig spec does require DigestMethod node
          * to be present but in some case it application might decide to
          * minimize traffic */
-        dsigRefCtx->digestMethod = xmlSecTransformCtxCreateAndAppend(&(dsigRefCtx->transformCtx),
-                                                              dsigRefCtx->dsigCtx->defSignMethodId);
+        dsigRefCtx->digestMethod = xmlSecTransformCtxCreateAndAppend(&(dsigRefCtx->transformCtx), dsigRefCtx->dsigCtx->defDigestMethodId);
         if(dsigRefCtx->digestMethod == NULL) {
             xmlSecInternalError("xmlSecTransformCtxCreateAndAppend", NULL);
             return(-1);

--- a/src/xmldsig.c
+++ b/src/xmldsig.c
@@ -241,7 +241,7 @@ xmlSecDSigCtxEnableSignatureTransform(xmlSecDSigCtxPtr dsigCtx, xmlSecTransformI
 /**
  * @brief Gets the pre-signature buffer for the SignedInfo element.
  * @details Gets pointer to the buffer with serialized &lt;dsig:SignedInfo/&gt; element
- * just before signature claculation (valid if and only if
+ * just before signature calculation (valid if and only if
  * #XMLSEC_DSIG_FLAGS_STORE_SIGNATURE context flag is set.
  *
  * @param dsigCtx the pointer to &lt;dsig:Signature/&gt; processing context.
@@ -506,7 +506,7 @@ xmlSecDSigCtxProcessSignatureNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node) {
         cur = xmlSecGetNextElementNode(cur->next);
     }
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         return(-1);
@@ -644,7 +644,7 @@ xmlSecDSigCtxProcessSignedInfoNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node, xm
         }
     } else if(dsigCtx->defC14NMethodId != xmlSecTransformIdUnknown) {
         /* the dsig spec does require CanonicalizationMethod node
-         * to be present but in some case it application might decide to
+         * to be present but in some case the application might decide to
          * minimize traffic */
         dsigCtx->c14nMethod = xmlSecTransformCtxCreateAndAppend(&(dsigCtx->transformCtx),
                                                               dsigCtx->defC14NMethodId);
@@ -685,7 +685,7 @@ xmlSecDSigCtxProcessSignedInfoNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node, xm
         cur = xmlSecGetNextElementNode(cur->next);
     } else if(dsigCtx->defSignMethodId != xmlSecTransformIdUnknown) {
         /* the dsig spec does require SignatureMethod node
-         * to be present but in some case it application might decide to
+         * to be present but in some case the application might decide to
          * minimize traffic */
         dsigCtx->signMethod = xmlSecTransformCtxCreateAndAppend(&(dsigCtx->transformCtx), dsigCtx->defSignMethodId);
         if(dsigCtx->signMethod == NULL) {
@@ -719,7 +719,7 @@ xmlSecDSigCtxProcessSignedInfoNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node, xm
         return(-1);
     }
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         return(-1);
@@ -799,7 +799,7 @@ xmlSecDSigCtxProcessKeyInfoNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node) {
         return(-1);
     }
 
-    /* ignore <dsig:KeyInfo /> if there is the key is already set */
+    /* ignore <dsig:KeyInfo /> if the key is already set */
     /* todo: throw an error if key is set and node != NULL? */
     if((dsigCtx->signKey == NULL) && (dsigCtx->keyInfoReadCtx.keysMngr != NULL)
                         && (dsigCtx->keyInfoReadCtx.keysMngr->getKey != NULL)) {
@@ -950,7 +950,7 @@ xmlSecDSigCtxProcessManifestNode(xmlSecDSigCtxPtr dsigCtx, xmlNodePtr node) {
             return(-1);
         }
 
-        /* we don;t care if Reference processing failed because
+        /* we don't care if Reference processing failed because
          * it's Manifest node */
         cur = xmlSecGetNextElementNode(cur->next);
     }
@@ -1213,7 +1213,7 @@ xmlSecDSigReferenceCtxDestroy(xmlSecDSigReferenceCtxPtr dsigRefCtx) {
  * @param dsigRefCtx the pointer to &lt;dsig:Reference/&gt; element processing context.
  * @param dsigCtx the pointer to parent &lt;dsig:Signature/&gt; node processing context.
  * @param origin the reference origin (&lt;dsig:SignedInfo/&gt; or &lt;dsig:Manifest/&gt; node).
- * @return 0 on succes or aa negative value otherwise.
+ * @return 0 on success or a negative value otherwise.
  */
 int
 xmlSecDSigReferenceCtxInitialize(xmlSecDSigReferenceCtxPtr dsigRefCtx, xmlSecDSigCtxPtr dsigCtx,
@@ -1283,7 +1283,7 @@ xmlSecDSigReferenceCtxFinalize(xmlSecDSigReferenceCtxPtr dsigRefCtx) {
  * @brief Gets the pre-digest buffer for the Reference element.
  * @details Gets the results of &lt;dsig:Reference/&gt; node processing just before digesting
  * (valid only if #XMLSEC_DSIG_FLAGS_STORE_SIGNEDINFO_REFERENCES or
- * #XMLSEC_DSIG_FLAGS_STORE_MANIFEST_REFERENCES flas of signature context
+ * #XMLSEC_DSIG_FLAGS_STORE_MANIFEST_REFERENCES flags of signature context
  * is set).
  *
  * @param dsigRefCtx the pointer to &lt;dsig:Reference/&gt; element processing context.
@@ -1314,7 +1314,7 @@ xmlSecDSigReferenceCtxGetPreDigestBuffer(xmlSecDSigReferenceCtxPtr dsigRefCtx) {
  *
  * @param dsigRefCtx the pointer to &lt;dsig:Reference/&gt; element processing context.
  * @param node the pointer to &lt;dsig:Reference/&gt; node.
- * @return 0 on succes or aa negative value otherwise.
+ * @return 0 on success or a negative value otherwise.
  */
 int
 xmlSecDSigReferenceCtxProcessNode(xmlSecDSigReferenceCtxPtr dsigRefCtx, xmlNodePtr node) {
@@ -1389,7 +1389,7 @@ xmlSecDSigReferenceCtxProcessNode(xmlSecDSigReferenceCtxPtr dsigRefCtx, xmlNodeP
         cur = xmlSecGetNextElementNode(cur->next);
     } else if(dsigRefCtx->dsigCtx->defDigestMethodId != xmlSecTransformIdUnknown) {
         /* the dsig spec does require DigestMethod node
-         * to be present but in some case it application might decide to
+         * to be present but in some case the application might decide to
          * minimize traffic */
         dsigRefCtx->digestMethod = xmlSecTransformCtxCreateAndAppend(&(dsigRefCtx->transformCtx), dsigRefCtx->dsigCtx->defDigestMethodId);
         if(dsigRefCtx->digestMethod == NULL) {

--- a/src/xmlenc.c
+++ b/src/xmlenc.c
@@ -285,7 +285,7 @@ xmlSecEncCtxBinaryEncrypt(xmlSecEncCtxPtr encCtx, xmlNodePtr tmpl,
     xmlSecAssert2(tmpl != NULL, -1);
     xmlSecAssert2((data != NULL) || (dataSize == 0), -1);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = xmlSecTransformOperationEncrypt;
     xmlSecAddIDs(tmpl->doc, tmpl, xmlSecEncIds);
 
@@ -335,7 +335,7 @@ xmlSecEncCtxXmlEncrypt(xmlSecEncCtxPtr encCtx, xmlNodePtr tmpl, xmlNodePtr node)
     xmlSecAssert2(node != NULL, -1);
     xmlSecAssert2(node->doc != NULL, -1);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = xmlSecTransformOperationEncrypt;
     xmlSecAddIDs(tmpl->doc, tmpl, xmlSecEncIds);
 
@@ -459,7 +459,7 @@ xmlSecEncCtxUriEncrypt(xmlSecEncCtxPtr encCtx, xmlNodePtr tmpl, const xmlChar *u
     xmlSecAssert2(tmpl != NULL, -1);
     xmlSecAssert2(uri != NULL, -1);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = xmlSecTransformOperationEncrypt;
     xmlSecAddIDs(tmpl->doc, tmpl, xmlSecEncIds);
 
@@ -581,7 +581,7 @@ xmlSecEncCtxDecryptToBuffer(xmlSecEncCtxPtr encCtx, xmlNodePtr node) {
     xmlSecAssert2(encCtx->result == NULL, NULL);
     xmlSecAssert2(node != NULL, NULL);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = xmlSecTransformOperationDecrypt;
     xmlSecAddIDs(node->doc, node, xmlSecEncIds);
 
@@ -716,7 +716,7 @@ xmlSecEncCtxEncDataNodeRead(xmlSecEncCtxPtr encCtx, xmlNodePtr node) {
         }
     }
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         return(-1);
@@ -922,7 +922,7 @@ xmlSecEncCtxCipherReferenceNodeRead(xmlSecEncCtxPtr encCtx, xmlNodePtr node) {
         cur = xmlSecGetNextElementNode(cur->next);
     }
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         return(-1);
@@ -1227,7 +1227,7 @@ xmlSecEncCtxDerivedKeyGenerate(xmlSecEncCtxPtr encCtx, xmlSecKeyDataId keyId, xm
     xmlSecAssert2(node != NULL, NULL);
     xmlSecAssert2(keyInfoCtx != NULL, NULL);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = keyInfoCtx->operation;
     xmlSecAddIDs(node->doc, node, xmlSecEncIds);
 
@@ -1281,7 +1281,7 @@ xmlSecEncCtxDerivedKeyGenerate(xmlSecEncCtxPtr encCtx, xmlSecKeyDataId keyId, xm
         cur = xmlSecGetNextElementNode(cur->next);
     }
 
-    /* forth node is optional MasterKeyName */
+      /* fourth node is optional MasterKeyName */
     if((cur != NULL) && (xmlSecCheckNodeName(cur, xmlSecNodeMasterKeyName, xmlSecEnc11Ns))) {
         masterKeyName = xmlSecGetNodeContentAndTrim(cur);
         if(masterKeyName == NULL) {
@@ -1292,7 +1292,7 @@ xmlSecEncCtxDerivedKeyGenerate(xmlSecEncCtxPtr encCtx, xmlSecKeyDataId keyId, xm
         cur = xmlSecGetNextElementNode(cur->next);
     }
 
-    /* if there is something left than it's an error */
+    /* if there is something left, then it's an error */
     if(cur != NULL) {
         xmlSecUnexpectedNodeError(cur,  NULL);
         goto done;
@@ -1371,7 +1371,7 @@ xmlSecEncCtxAgreementMethodGenerate(xmlSecEncCtxPtr encCtx, xmlSecKeyDataId keyI
     xmlSecAssert2(node != NULL, NULL);
     xmlSecAssert2(keyInfoCtx != NULL, NULL);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = keyInfoCtx->operation;
     xmlSecAddIDs(node->doc, node, xmlSecEncIds);
 
@@ -1419,7 +1419,7 @@ xmlSecEncCtxAgreementMethodXmlWrite(xmlSecEncCtxPtr encCtx, xmlNodePtr node, xml
     xmlSecAssert2(node != NULL, -1);
     xmlSecAssert2(keyInfoCtx != NULL, -1);
 
-    /* initialize context and add ID atributes to the list of known ids */
+      /* initialize context and add ID attributes to the list of known ids */
     encCtx->operation = keyInfoCtx->operation;
     xmlSecAddIDs(node->doc, node, xmlSecEncIds);
 

--- a/src/xmlsec.c
+++ b/src/xmlsec.c
@@ -168,8 +168,8 @@ const xmlChar * xmlSecGetDefaultCrypto(void) {
  * @param subminor the subminor version number.
  * @param mode the version check mode.
  *
- * @return 1 if the loaded xmlsec library version is OK to use
- * 0 if it is not or a negative value if an error occurs.
+ * @return 1 if the loaded xmlsec library version is OK to use,
+ * 0 if it is not.
  */
 int
 xmlSecCheckVersionExt(int major, int minor, int subminor, xmlSecCheckVersionMode mode) {

--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -33,7 +33,7 @@
 #include "cast_helpers.h"
 
 
-static const xmlChar*    g_xmlsec_xmltree_default_linefeed = xmlSecStringCR;
+static const xmlChar*    g_xmlsec_xmltree_default_linefeed = xmlSecStringLF;
 
 /**
  * @brief Gets the current default linefeed.

--- a/src/xmltree.c
+++ b/src/xmltree.c
@@ -84,7 +84,7 @@ xmlSecGetNodeContentAndTrim(const xmlNodePtr cur) {
     while((bb <= ee) && isspace(*ee)) { --ee; }
     *(ee + 1) = '\0';
 
-    /* move string to the beggining */
+    /* move string to the beginning */
     if(content != bb) {
         memmove(content, bb, (size_t)xmlStrlen(bb) + 1);
     }
@@ -992,7 +992,7 @@ xmlSecIsEmptyString(const xmlChar* str) {
 }
 
 
-/* Helpers  for XML Tree traversal */
+/* Helpers for XML Tree traversal */
 #define xmlSecXmlNodePtrListId  (&xmlSecXmlNodePtrListKlass)
 static xmlSecPtrListKlass xmlSecXmlNodePtrListKlass = {
     BAD_CAST "xml-node-ptr-list",
@@ -1079,7 +1079,7 @@ xmlSecDepthFirstTreeWalk(xmlNodePtr node, xmlSecTreeWalkCallback callback, void*
  * @details Encodes the @p str (e.g. replaces '&' with '&amp;') and writes it to @p fd.
  * @param fd the file descriptor to write the XML string to
  * @param str the string
- * @return he number of bytes transmitted or a negative value if an error occurs.
+ * @return the number of bytes transmitted or a negative value if an error occurs.
  */
 int
 xmlSecPrintXmlString(FILE * fd, const xmlChar * str) {
@@ -1195,7 +1195,7 @@ xmlSecQName2IntegerGetInfo(xmlSecQName2IntegerInfoConstPtr info, int intValue) {
 
 /**
  * @brief Maps a QName to an integer value.
- * @details Maps qname qname to an integer and returns it in @p intValue.
+ * @details Maps a qname to an integer and returns it in @p intValue.
  * @param info the qname<->integer mapping information.
  * @param qnameHref the qname href value.
  * @param qnameLocalPart the qname local part value.
@@ -1411,7 +1411,7 @@ xmlSecQName2IntegerNodeWrite(xmlSecQName2IntegerInfoConstPtr info, xmlNodePtr no
 
 /**
  * @brief Reads an attribute's QName value and converts it to an integer.
- * @details Gets the value of @p attrName atrtibute from @p node and converts it to integer
+ * @details Gets the value of @p attrName attribute from @p node and converts it to integer
  * according to @p info.
  * @param info the qname<->integer mapping information.
  * @param node the element node.
@@ -1612,7 +1612,7 @@ xmlSecQName2BitMaskGetBitMask(xmlSecQName2BitMaskInfoConstPtr info,
  * @param info the qname<->integer mapping information.
  * @param node the pointer to node.
  * @param qname the qname string.
- * @param mask the pointer to result msk value.
+ * @param mask the pointer to result mask value.
  * @return 0 on success or a negative value if an error occurs,
  */
 int

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -33,7 +33,7 @@
  * @details The implementation of XPath "here()" function.
  * See xmlXPtrHereFunction() in xpointer.c. the only change is that
  * we return NodeSet instead of NodeInterval.
- * @param ctxt the ponter to XPath context.
+ * @param ctxt the pointer to XPath context.
  * @param nargs the arguments number.
  */
 static void
@@ -245,7 +245,7 @@ xmlSecXPathDataExecute(xmlSecXPathDataPtr data, xmlDocPtr doc, xmlNodePtr hereNo
         return(NULL);
     }
 
-    /* sometime LibXML2 returns an empty nodeset or just NULL, we want
+    /* sometimes LibXML2 returns an empty nodeset or just NULL, we want
     to reserve NULL for our own purposes so we simply create an empty
     node set here */
     if(xpathObj->nodesetval == NULL) {

--- a/src/xslt.c
+++ b/src/xslt.c
@@ -160,8 +160,8 @@ xmlSecTransformXsltSetDefaultSecurityPrefs(xsltSecurityPrefsPtr sec) {
  *
  * This transform requires an octet stream as input. If the actual input is an
  * XPath node-set, then the signature application should attempt to convert it
- * to octets (apply Canonical XML]) as described in the Reference Processing
- * Model (section 4.3.3.2).]
+ * to octets (apply Canonical XML) as described in the Reference Processing
+ * Model (section 4.3.3.2).
  *
  * The output of this transform is an octet stream. The processing rules for
  * the XSL style sheet or transform element are stated in the XSLT specification
@@ -525,7 +525,7 @@ xmlSecXsApplyStylesheet(xmlSecXsltCtxPtr ctx, xmlDocPtr doc) {
         goto done;
     }
 
-    /* set security prefs  */
+    /* set security prefs */
     ret = xsltSetCtxtSecurityPrefs(g_xslt_default_security_prefs, xsltCtx);
     if(ret < 0) {
         xmlSecXsltError("xsltSetCtxtSecurityPrefs", ctx->xslt, NULL);


### PR DESCRIPTION
Note that base64 encoder now enforces columns size (LF positions) to be greater than 1 (instead of > 0 before)