### PR TITLE
OSS-Fuzz: Add fuzzer targets keyinfo parsing

### DIFF
--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -182,4 +182,38 @@ xmlsec_dsig_verify_fuzzer_DEPENDENCIES = \
 	$(XMLSEC_LIBS) \
 	$(NULL)
 
+# xmlsec KeyInfo fuzzer (OSS-Fuzz harness — OpenSSL only)
+noinst_PROGRAMS += xmlsec_keyinfo_fuzzer
+
+xmlsec_keyinfo_fuzzer_SOURCES = \
+	oss-fuzz/xmlsec_keyinfo_target.c \
+	oss-fuzz/standalone_fuzz_runner.c \
+	$(NULL)
+
+xmlsec_keyinfo_fuzzer_CFLAGS = \
+	-DPACKAGE=\"@PACKAGE@\" \
+	-I../include \
+	-I$(top_srcdir)/include \
+	$(XMLSEC_DEFINES) \
+	$(XMLSEC_OPENSSL_CFLAGS) \
+	$(LIBXML_CFLAGS) \
+	$(NULL)
+
+xmlsec_keyinfo_fuzzer_LDFLAGS = \
+	@XMLSEC_STATIC_BINARIES@ \
+	@XMLSEC_EXTRA_LDFLAGS@ \
+	$(NULL)
+
+xmlsec_keyinfo_fuzzer_LDADD = \
+	$(LIBXML_LIBS) \
+	$(OPENSSL_LIBS) \
+	$(XMLSEC_OPENSSL_LIB) \
+	$(XMLSEC_LIBS) \
+	$(NULL)
+
+xmlsec_keyinfo_fuzzer_DEPENDENCIES = \
+	$(XMLSEC_OPENSSL_LIB) \
+	$(XMLSEC_LIBS) \
+	$(NULL)
+
 endif # !XMLSEC_NO_OPENSSL

--- a/apps/oss-fuzz/config/xmlsec_keyinfo_fuzzer.options
+++ b/apps/oss-fuzz/config/xmlsec_keyinfo_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+dict = xml.dict

--- a/apps/oss-fuzz/standalone_fuzz_runner.c
+++ b/apps/oss-fuzz/standalone_fuzz_runner.c
@@ -17,7 +17,8 @@
 #include <stdlib.h>
 #include <assert.h>
 
-/* Declared by the fuzzer harness (xmlsec_target.c / xmlsec_dsig_verify_target.c). */
+/* Declared by the fuzzer harness (xmlsec_target.c / xmlsec_dsig_verify_target.c /
+   xmlsec_keyinfo_target.c). */
 extern int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
 
 int main(int argc, char** argv) {

--- a/apps/oss-fuzz/xmlsec_keyinfo_target.c
+++ b/apps/oss-fuzz/xmlsec_keyinfo_target.c
@@ -1,0 +1,150 @@
+/*
+ * xmlsec <dsig:KeyInfo /> reader fuzz target.
+ *
+ * xmlsec_target.c only parses XML (xmlSecParseMemory), and the dsig target
+ * needs a whole well-formed signature before it reaches any key handling. This
+ * target calls xmlSecKeyInfoNodeRead() on a <KeyInfo> element directly, which
+ * is reachable from a very small document, so a mutator makes progress from the
+ * first input.
+ *
+ * The code it drives is the largest cold area in the library: keysdata_helpers.c
+ * (the KeyValue, X509Data and EncryptedKey structure readers), keyinfo.c,
+ * x509_helpers.c and the OpenSSL key-data implementations.
+ *
+ * The keys manager is NULL on purpose. A manager only adds trusted-key lookup,
+ * which needs key material this target does not supply, and it brings in
+ * application-level initialisation that this target does not need. Structure
+ * parsing, the part that reads attacker-supplied bytes, runs either way.
+ *
+ * External fetches are disabled, so the target stays offline.
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+#include <libxml/xmlerror.h>
+
+#include <xmlsec/xmlsec.h>
+#include <xmlsec/xmltree.h>
+#include <xmlsec/keys.h>
+#include <xmlsec/keyinfo.h>
+#include <xmlsec/keysdata.h>
+#include <xmlsec/transforms.h>
+#include <xmlsec/errors.h>
+#include <xmlsec/strings.h>
+
+#include <xmlsec/openssl/app.h>
+#include <xmlsec/openssl/crypto.h>
+
+static int g_initialized = 0;
+/* Set when do_init() fails, so a failed one-time init is not retried on
+ * every input. */
+static int g_init_failed = 0;
+
+static void ignore_error(void* ctx, const char* msg, ...) {
+    (void)ctx; (void)msg;
+}
+
+static void ignore_xmlsec_error(const char* file, int line, const char* func,
+                                const char* errorObject, const char* errorSubject,
+                                int reason, const char* msg) {
+    (void)file; (void)line; (void)func;
+    (void)errorObject; (void)errorSubject; (void)reason; (void)msg;
+}
+
+static int do_init(void) {
+    xmlInitParser();
+
+    if (xmlSecInit() < 0) {
+        return -1;
+    }
+    if (xmlSecCheckVersion() != 1) {
+        return -1;
+    }
+    if (xmlSecOpenSSLAppInit(NULL) < 0) {
+        return -1;
+    }
+    if (xmlSecOpenSSLInit() < 0) {
+        return -1;
+    }
+
+    xmlSetGenericErrorFunc(NULL, &ignore_error);
+    xmlSecErrorsSetCallback(&ignore_xmlsec_error);
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    xmlDocPtr doc = NULL;
+    xmlNodePtr root = NULL;
+    xmlNodePtr node = NULL;
+    xmlSecKeyPtr key = NULL;
+    xmlSecKeyInfoCtxPtr keyInfoCtx = NULL;
+
+    if (!g_initialized) {
+        g_init_failed = (do_init() < 0);
+        g_initialized = 1;
+    }
+    if (g_init_failed || size == 0) {
+        return 0;
+    }
+
+    /* NONET and NOENT stop external fetches and entity expansion. */
+    doc = xmlReadMemory((const char*)data, (int)size, "fuzz.xml", NULL,
+                        XML_PARSE_NONET | XML_PARSE_NOENT);
+    if (doc == NULL) {
+        return 0;
+    }
+    root = xmlDocGetRootElement(doc);
+    if (root == NULL) {
+        xmlFreeDoc(doc);
+        return 0;
+    }
+
+    /* Accept a bare <KeyInfo> document as well as one that contains it, so a
+     * seed does not have to carry a signature wrapper. */
+    if (xmlSecCheckNodeName(root, xmlSecNodeKeyInfo, xmlSecDSigNs)) {
+        node = root;
+    } else {
+        node = xmlSecFindNode(root, xmlSecNodeKeyInfo, xmlSecDSigNs);
+    }
+    if (node == NULL) {
+        xmlFreeDoc(doc);
+        return 0;
+    }
+
+    key = xmlSecKeyCreate();
+    if (key == NULL) {
+        xmlFreeDoc(doc);
+        return 0;
+    }
+
+    keyInfoCtx = xmlSecKeyInfoCtxCreate(NULL);
+    if (keyInfoCtx == NULL) {
+        xmlSecKeyDestroy(key);
+        xmlFreeDoc(doc);
+        return 0;
+    }
+
+    keyInfoCtx->mode = xmlSecKeyInfoModeRead;
+    /* Accept any key so no child element is skipped on a type mismatch. */
+    keyInfoCtx->keyReq.keyId = xmlSecKeyDataIdUnknown;
+    keyInfoCtx->keyReq.keyType = xmlSecKeyDataTypeAny;
+    keyInfoCtx->keyReq.keyUsage = xmlSecKeyUsageAny;
+    /* <RetrievalMethod> and <KeyInfoReference> must not fetch remote or local
+     * data. This is the no-network guard. */
+    keyInfoCtx->retrievalMethodCtx.enabledUris =
+        xmlSecTransformUriTypeEmpty | xmlSecTransformUriTypeSameDocument;
+    keyInfoCtx->keyInfoReferenceCtx.enabledUris =
+        xmlSecTransformUriTypeEmpty | xmlSecTransformUriTypeSameDocument;
+
+    /* The return value does not matter. The parsing paths are the target. */
+    (void)xmlSecKeyInfoNodeRead(node, key, keyInfoCtx);
+
+    xmlSecKeyInfoCtxDestroy(keyInfoCtx);
+    xmlSecKeyDestroy(key);
+    xmlFreeDoc(doc);
+    return 0;
+}


### PR DESCRIPTION
This PR creates a new fuzzer targeting keyinfo parsing of the xmlsec project, together with the corpus preparation on the OSS-Fuzz side.

Sorry I have left off the fuzzer creation for some time because I am quite busy. But I will continue to add more fuzzers for this project in the coming weeks.